### PR TITLE
Maintenance: UI polish for alternative suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,16 @@ This format follows Keep a Changelog principles and aims for Semantic Versioning
 
 ## [Unreleased]
 ### Summary
-- _No changes yet._
+- Alternative suggestions in the build wizard now surface the replacement card preview immediately and reload the list after a swap.
+
+### Added
+- Alternatives panel includes a "New pool" button so you can request a fresh batch of suggestions without rerunning the stage.
+
+### Changed
+- Alternative suggestion buttons expose role, mana, and rarity metadata to hover previews for better at-a-glance context.
+
+### Fixed
+- Previewing an alternative card now shows the replacement instead of the currently slotted card, and the list refreshes automatically after choosing an alternative.
 
 ## [2.5.0] - 2025-10-06
 ### Summary

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -1,13 +1,13 @@
 # MTG Python Deckbuilder ${VERSION}
 
-## Summary
-- _Add one-line highlights for the release._
+### Summary
+- Alternative suggestions in the build wizard now surface the replacement card preview immediately and reload the list after a swap.
 
-## Added
-- _Bullet list of new features._
+### Added
+- Alternatives panel includes a "New pool" button so you can request a fresh batch of suggestions without rerunning the stage.
 
-## Changed
-- _Bullet list of user-facing changes._
+### Changed
+- Alternative suggestion buttons expose role, mana, and rarity metadata to hover previews for better at-a-glance context.
 
-## Fixed
-- _Bullet list of bug fixes._
+### Fixed
+- Previewing an alternative card now shows the replacement instead of the currently slotted card, and the list refreshes automatically after choosing an alternative.

--- a/code/tests/test_alternatives_filters.py
+++ b/code/tests/test_alternatives_filters.py
@@ -66,3 +66,14 @@ def test_alternatives_filters_out_commander_in_deck_and_locked():
     assert 'alt commander' not in body
     assert 'alt in deck' not in body
     assert 'alt locked' not in body
+    assert '"owned_only":"0"' in r.text
+    assert 'New pool' in r.text
+
+
+def test_alternatives_refresh_query():
+    app_module = importlib.import_module('code.web.app')
+    client = TestClient(app_module.app)
+    _inject_fake_ctx(client, commander='Alt Commander', locks=['alt locked'])
+    r = client.get('/build/alternatives?name=Target%20Card&owned_only=0&refresh=1')
+    assert r.status_code == 200
+    assert 'New pool' in r.text

--- a/code/web/templates/base.html
+++ b/code/web/templates/base.html
@@ -1204,6 +1204,10 @@
         document.addEventListener('mousemove', move);
         function getCardFromEl(el){
           if(!el) return null;
+          if(el.closest){
+            var altBtn = el.closest('.alts button[data-card-name]');
+            if(altBtn){ return altBtn; }
+          }
           // If inside flip button
           var btn = el.closest && el.closest('.dfc-toggle');
           if(btn) return btn.closest('.card-sample, .commander-cell, .commander-thumb, .commander-card, .card-tile, .candidate-tile, .card-preview, .stack-card');

--- a/code/web/templates/build/_alternatives.html
+++ b/code/web/templates/build/_alternatives.html
@@ -4,12 +4,16 @@
   ]
 #}
 <div class="alts" style="margin-top:.35rem; padding:.5rem; border:1px solid var(--border); border-radius:8px; background:#0f1115;">
-  <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:.25rem;">
+  <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:.25rem; gap:.5rem; flex-wrap:wrap;">
     <strong>Alternatives</strong>
     {% set toggle_q = '0' if require_owned else '1' %}
     {% set toggle_label = 'Owned only: On' if require_owned else 'Owned only: Off' %}
-    <button class="btn" hx-get="/build/alternatives?name={{ name|urlencode }}&owned_only={{ toggle_q }}"
-            hx-target="closest .alts" hx-swap="outerHTML">{{ toggle_label }}</button>
+    <div style="display:flex; gap:.35rem; flex-wrap:wrap;">
+      <button class="btn" hx-get="/build/alternatives?name={{ name|urlencode }}&owned_only={{ toggle_q }}"
+              hx-target="closest .alts" hx-swap="outerHTML">{{ toggle_label }}</button>
+      <button class="btn" hx-get="/build/alternatives?name={{ name|urlencode }}&owned_only={{ 1 if require_owned else 0 }}&refresh=1"
+              hx-target="closest .alts" hx-swap="outerHTML" title="Request a fresh pool of alternatives">New pool</button>
+    </div>
   </div>
   {% if not items or items|length == 0 %}
     <div class="muted">No alternatives found{{ ' (owned only)' if require_owned else '' }}.</div>
@@ -21,9 +25,13 @@
         {% set tags = (it.tags or []) %}
         <li>
           <span class="owned-badge" title="{{ title }}">{{ badge }}</span>
-          <button class="btn" data-card-name="{{ it.name }}"
+          <button class="btn alt-option" data-card-name="{{ it.name }}"
+                  {% if it.role %}data-role="{{ it.role }}"{% endif %}
+                  {% if it.mana %}data-mana="{{ it.mana }}"{% endif %}
+                  {% if it.rarity %}data-rarity="{{ it.rarity }}"{% endif %}
+                  {% if it.hover_simple %}data-hover-simple="1"{% endif %}
                   data-tags="{{ tags|join(', ') }}" hx-post="/build/replace"
-                  hx-vals='{"old":"{{ name }}", "new":"{{ it.name }}"}'
+                  hx-vals='{"old":"{{ name }}", "new":"{{ it.name }}", "owned_only":"{{ 1 if require_owned else 0 }}"}'
                   hx-target="closest .alts" hx-swap="outerHTML" title="Lock this alternative and unlock the current pick">
             Replace with {{ it.name }}
           </button>


### PR DESCRIPTION
# MTG Python Deckbuilder ${VERSION}

### Summary
- Alternative suggestions in the build wizard now surface the replacement card preview immediately and reload the list after a swap.

### Added
- Alternatives panel includes a "New pool" button so you can request a fresh batch of suggestions without rerunning the stage.

### Changed
- Alternative suggestion buttons expose role, mana, and rarity metadata to hover previews for better at-a-glance context.

### Fixed
- Previewing an alternative card now shows the replacement instead of the currently slotted card, and the list refreshes automatically after choosing an alternative.