### PR TITLE
Fix/GitHub action module path

### DIFF
--- a/.github/workflows/build-similarity-cache.yml
+++ b/.github/workflows/build-similarity-cache.yml
@@ -145,12 +145,30 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           
-          # Switch to or create dedicated cache branch
-          git checkout -b similarity-cache-data || git checkout similarity-cache-data
+          # Fetch all branches
+          git fetch origin
           
-          # Add only the similarity cache files (not all_cards.parquet)
-          git add card_files/similarity_cache.parquet
-          git add card_files/similarity_cache_metadata.json
+          # Try to checkout existing branch, or create new orphan branch
+          if git ls-remote --heads origin similarity-cache-data | grep similarity-cache-data; then
+            echo "Checking out existing similarity-cache-data branch..."
+            git checkout similarity-cache-data
+          else
+            echo "Creating new orphan branch similarity-cache-data..."
+            git checkout --orphan similarity-cache-data
+            git rm -rf . || true
+            # Create minimal README for the branch
+            echo "# Similarity Cache Data" > README.md
+            echo "This branch contains pre-built similarity cache files for the MTG Deckbuilder." >> README.md
+            echo "Updated automatically by GitHub Actions." >> README.md
+          fi
+          
+          # Ensure card_files directory exists
+          mkdir -p card_files
+          
+          # Add only the similarity cache files (use -f to override .gitignore)
+          git add -f card_files/similarity_cache.parquet
+          git add -f card_files/similarity_cache_metadata.json
+          git add README.md 2>/dev/null || true
           
           # Check if there are changes to commit
           if git diff --staged --quiet; then

--- a/.github/workflows/dockerhub-publish.yml
+++ b/.github/workflows/dockerhub-publish.yml
@@ -7,15 +7,53 @@ on:
   workflow_dispatch:
 
 jobs:
+  check-cache-age:
+    name: Check similarity cache age
+    runs-on: ubuntu-latest
+    outputs:
+      needs_rebuild: ${{ steps.check.outputs.needs_rebuild }}
+    steps:
+      - name: Check cache age
+        id: check
+        run: |
+          # Check if cache is older than 7 days
+          CACHE_URL="https://raw.githubusercontent.com/${{ github.repository }}/similarity-cache-data/card_files/similarity_cache_metadata.json"
+          
+          if wget -q --spider "$CACHE_URL"; then
+            wget -q "$CACHE_URL" -O metadata.json
+            BUILD_DATE=$(jq -r '.build_date' metadata.json)
+            
+            # Calculate age in seconds
+            BUILD_EPOCH=$(date -d "$BUILD_DATE" +%s 2>/dev/null || echo 0)
+            NOW_EPOCH=$(date +%s)
+            AGE_DAYS=$(( ($NOW_EPOCH - $BUILD_EPOCH) / 86400 ))
+            
+            echo "Cache age: $AGE_DAYS days"
+            
+            if [ $AGE_DAYS -gt 7 ]; then
+              echo "needs_rebuild=true" >> $GITHUB_OUTPUT
+              echo "Cache is stale (>7 days), will rebuild"
+            else
+              echo "needs_rebuild=false" >> $GITHUB_OUTPUT
+              echo "Cache is fresh (<7 days), skipping rebuild"
+            fi
+          else
+            echo "needs_rebuild=true" >> $GITHUB_OUTPUT
+            echo "Cache not found, will build"
+          fi
+
   build-cache:
     name: Build similarity cache
+    needs: check-cache-age
+    if: needs.check-cache-age.outputs.needs_rebuild == 'true'
     uses: ./.github/workflows/build-similarity-cache.yml
     secrets: inherit
 
   prepare:
     name: Prepare metadata
     runs-on: ubuntu-latest
-    needs: build-cache
+    needs: [check-cache-age, build-cache]
+    if: always() && (needs.build-cache.result == 'success' || needs.build-cache.result == 'skipped')
     permissions:
       contents: read
     outputs:

--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,6 @@ csv_files/*
 !csv_files/testdata/
 !csv_files/testdata/**/*
 card_files/*
-!card_files/similarity_cache.parquet
-!card_files/similarity_cache_metadata.json
 
 deck_files/
 dist/


### PR DESCRIPTION
## Fix GitHub Actions Cache Workflow

Fixes critical module import error and optimizes cache distribution strategy.

### Changes

**1. Fixed Module Path Error**
- Corrected `all_cards.parquet` generation to use `code.file_setup.card_aggregator.CardAggregator`
- Was incorrectly trying to import non-existent `code.web.services.card_loader`
- Fixes `ModuleNotFoundError` that was blocking cache builds

**2. Optimized Cache Distribution**
- Create/use orphan branch `similarity-cache-data` for cache files
- Keeps main branch clean from large binary artifacts (~3.5-4MB cache files)
- Uses `git add -f` to force-add files, keeping `.gitignore` simple

**3. Smart Cache Rebuilding**
- Docker Hub builds now check cache age before rebuilding
- Only regenerates cache if >7 days old
- Weekly scheduled workflow (Sundays 2 AM UTC) keeps cache fresh automatically
- Avoids unnecessary ~5-10 min rebuilds on every Docker publish

### Impact

- Unblocks CI/CD pipeline for similarity cache
- Reduces Docker build times when cache is fresh
- Improves cache distribution strategy (orphan branch vs main)