### PR TITLE
fix: correct .tagging_complete.json path to card_files/processed/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ _No unreleased changes yet_
 _No unreleased changes yet_
 
 ### Fixed
-_No unreleased changes yet_
+- **Setup readiness check always failing on fresh hosts**: The setup-complete flag path was still referencing the old `csv_files/.tagging_complete.json` location in `orchestrator.py`, `themes.py`, `builder.py`, and `headless_runner.py`, while the tagger writes it to `card_files/processed/.tagging_complete.json` (since the Parquet migration). Fixed all references to point to the correct path.
 
 ### Removed
 _No unreleased changes yet_

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -398,4 +398,4 @@ Use the `--compat-snapshot` or other script arguments as needed.
 - **Files missing on the host:** ensure the host directories exist before starting Compose; Windows will create empty folders if the path is invalid.
 - **Long first boot:** dataset downloads and tagging can take several minutes the first time. Watch progress at `/setup`.
 - **Random build hangs:** lower `RANDOM_MAX_ATTEMPTS` or raise `RANDOM_TIMEOUT_MS`, and confirm your theme overrides are valid slugs via `/themes/`.
-- **Commander catalog outdated:** rerun the refresh command above or delete `csv_files/.tagging_complete.json` to force a full rebuild on next start.
+- **Commander catalog outdated:** rerun the refresh command above or delete `card_files/processed/.tagging_complete.json` to force a full rebuild on next start.

--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ When adding features, favor the web UI first, keep public builder APIs stable, a
 
 ## Troubleshooting
 - **Blank page after start**: Visit `/healthz`, check `/logs`, ensure `SHOW_LOGS=1`, and inspect host `logs/` for stack traces.
-- **Stale data**: Run Initial Setup or delete `csv_files/.tagging_complete.json` to force reseeding.
+- **Stale data**: Run Initial Setup or delete `card_files/processed/.tagging_complete.json` to force reseeding.
 - **Owned-only build fails**: Confirm owned files were uploaded correctly and that `owned_cards/` is mounted.
 - **Random build stalls**: Lower `RANDOM_MAX_ATTEMPTS`, increase `RANDOM_TIMEOUT_MS`, and verify selected themes exist via `/themes/`.
 - **Commander list outdated**: Rerun the commander refresh script or Initial Setup.

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -8,7 +8,7 @@ _No unreleased changes yet_
 _No unreleased changes yet_
 
 ### Fixed
-_No unreleased changes yet_
+- Setup readiness check now correctly locates the tagging completion flag at `card_files/processed/.tagging_complete.json`, resolving a "Setup required" false-positive on fresh hosts after the Parquet migration.
 
 ### Removed
 _No unreleased changes yet_

--- a/code/deck_builder/builder.py
+++ b/code/deck_builder/builder.py
@@ -164,7 +164,7 @@ class DeckBuilder(
                 from code.path_util import get_processed_cards_path
                 
                 parquet_path = get_processed_cards_path()
-                flag_path = os.path.join(CSV_DIRECTORY, '.tagging_complete.json')
+                flag_path = os.path.join('card_files', 'processed', '.tagging_complete.json')
                 refresh_needed = False
                 
                 if not os.path.exists(parquet_path):
@@ -188,7 +188,7 @@ class DeckBuilder(
                     from tagging import tagger as _tagger
                     _tagger.run_tagging()
                     try:
-                        os.makedirs(CSV_DIRECTORY, exist_ok=True)
+                        os.makedirs(os.path.join('card_files', 'processed'), exist_ok=True)
                         with open(flag_path, 'w', encoding='utf-8') as _fh:
                             _json.dump({'tagged_at': _dt.now().isoformat(timespec='seconds')}, _fh)
                     except Exception:

--- a/code/headless_runner.py
+++ b/code/headless_runner.py
@@ -35,7 +35,7 @@ def _ensure_data_ready():
     from path_util import get_processed_cards_path
     
     parquet_path = get_processed_cards_path()
-    tagging_json = os.path.join("csv_files", ".tagging_complete.json")
+    tagging_json = os.path.join("card_files", "processed", ".tagging_complete.json")
     
     # If all_cards.parquet is missing, run full pipeline
     if not os.path.isfile(parquet_path):

--- a/code/web/routes/themes.py
+++ b/code/web/routes/themes.py
@@ -43,7 +43,7 @@ except Exception:  # Fallback (tests/minimal contexts)
 THEME_LIST_PATH = Path("config/themes/theme_list.json")
 CATALOG_DIR = Path("config/themes/catalog")
 STATUS_PATH = Path("csv_files/.setup_status.json")
-TAG_FLAG_PATH = Path("csv_files/.tagging_complete.json")
+TAG_FLAG_PATH = Path("card_files/processed/.tagging_complete.json")
 
 
 def _iso(ts: float | int | None) -> Optional[str]:

--- a/code/web/services/orchestrator.py
+++ b/code/web/services/orchestrator.py
@@ -1045,7 +1045,7 @@ def is_setup_ready() -> bool:
     try:
         from path_util import get_processed_cards_path
         parquet_path = get_processed_cards_path()
-        flag_path = os.path.join('csv_files', '.tagging_complete.json')
+        flag_path = os.path.join('card_files', 'processed', '.tagging_complete.json')
         return os.path.exists(parquet_path) and os.path.exists(flag_path)
     except Exception:
         return False
@@ -1088,7 +1088,7 @@ def is_setup_stale() -> bool:
 
         # If tagging completed recently, treat as fresh regardless of cards.csv mtime
         try:
-            tag_flag = os.path.join('csv_files', '.tagging_complete.json')
+            tag_flag = os.path.join('card_files', 'processed', '.tagging_complete.json')
             if os.path.exists(tag_flag):
                 with open(tag_flag, 'r', encoding='utf-8') as f:
                     tf = json.load(f) or {}
@@ -1329,7 +1329,7 @@ def _ensure_setup_ready(out, force: bool = False) -> None:
         # M4 (Parquet Migration): Check for processed Parquet file instead of CSV
         from path_util import get_processed_cards_path
         cards_path = get_processed_cards_path()
-        flag_path = os.path.join('csv_files', '.tagging_complete.json')
+        flag_path = os.path.join('card_files', 'processed', '.tagging_complete.json')
         auto_setup_enabled = _is_truthy_env('WEB_AUTO_SETUP', '1')
         # Allow tuning of time-based refresh; default 7 days
         try:
@@ -1593,7 +1593,7 @@ def _ensure_setup_ready(out, force: bool = False) -> None:
         # Only attempt if we did NOT just perform a refresh (refresh_needed False) and auto-setup enabled
         # We detect refresh_needed by checking presence of the status flag percent=100 and phase done.
         status_path = os.path.join('csv_files', '.setup_status.json')
-        tag_flag = os.path.join('csv_files', '.tagging_complete.json')
+        tag_flag = os.path.join('card_files', 'processed', '.tagging_complete.json')
         auto_setup_enabled = _is_truthy_env('WEB_AUTO_SETUP', '1')
         if not auto_setup_enabled:
             return


### PR DESCRIPTION
## Summary

Fixes a regression where fresh-host builds always showed the 'Setup required' modal even after running setup.

The tagger writes the completion flag to card_files/processed/.tagging_complete.json (since the Parquet migration in M4), but the readiness checks in multiple files were still looking for it at the old csv_files/.tagging_complete.json path. The flag was never found, so is_setup_ready() always returned False on a fresh host.

## Changes

- code/web/services/orchestrator.py: Fixed 4 stale path references (is_setup_ready, is_setup_stale, _ensure_setup_ready, theme artifact refresh)
- code/web/routes/themes.py: Updated TAG_FLAG_PATH constant
- code/deck_builder/builder.py: Updated flag path and makedirs target
- code/headless_runner.py: Updated 	agging_json path
- Docs updated: CHANGELOG.md, RELEASE_NOTES_TEMPLATE.md, README.md, DOCKER.md

See \CHANGELOG.md\ for full details.