### PR TITLE
feat: card detail page overhaul, rulings, and owned library UX improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,35 @@ This format follows Keep a Changelog principles and aims for Semantic Versioning
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- **Card Detail Page** (`/cards/{name}`): Fully redesigned with a 2-column grid layout
+  - Card image with "New" badge for recently released cards
+  - Stats table: card type, mana value, power/toughness, rarity, EDHREC rank, color identity pips
+  - Oracle text with inline mana symbol rendering
+  - Theme tag chips
+  - External links to Scryfall, Gatherer, and EDHREC
+  - Market price panel with live TCG + CK prices via `/api/price/`
+  - **Official rulings** panel: first 3 rulings shown, expandable "Show all / Show fewer" toggle; mana symbols rendered in ruling text
+  - Similar cards section
+- **Rulings service** (`code/web/services/rulings.py`): cache-first lookup (loads `rulings_cache.json` at startup); falls back to a rate-limited live Scryfall fetch (≤10 req/s) on cache miss
+- **Rulings cache builder** (`code/file_setup/rulings_cache.py`): downloads the Scryfall bulk rulings file (one request, ~25 MB), maps oracle_id → rulings, then writes `card_files/processed/rulings_cache.json` keyed by scryfallID; integrated into the setup pipeline
+- **Owned Library overhaul**: Full redesign matching the card browser layout and filter UX
+  - Server-side filtering: search, card type, color identity, themes (multi-select, AND logic), CMC/Power/Toughness range
+  - Sticky filter bar (same `position: sticky` behavior as card browser)
+  - Card name autocomplete via new `/owned/search-autocomplete` endpoint
+  - Theme multi-select with chip UI, reusing the `/cards/theme-autocomplete` endpoint
+  - CMC, Power, and Toughness range inputs; `owned_store.get_stats_map()` enriches values from stored meta, falling back to a batch parquet lookup
+  - Full-page scroll replacing the old fixed-height scroll box
+- **Card browser sticky filter bar**: `.card-browser-filters` is now `position: sticky` so filters remain visible while scrolling through results
+- **Collapsible filter panel**: Both the card browser and owned library have a "Filters ▼" toggle button; collapsed state persists per page via `localStorage`; active filter count shown in the button label while collapsed (e.g., "Filters (2 active)")
+- **Owned Library → Card Details link**: Each owned library card tile now has a "Card Details" button linking to `/cards/{name}?ref=owned`
+- **Smart back button on card detail page**: The "Back" button reads the `ref` query param; arriving from the owned library shows "Back to Owned Library" (→ `/owned`), all other sources show "Back to Card Browser" (→ `/cards`)
+- **Similar cards expanded**: Card detail page now shows up to 15 similar cards (was 5)
 
 ### Changed
-_No unreleased changes yet_
+- **Card browser filter bar**: `position: relative` inline style removed from template; stickiness now comes from the CSS class
 
 ### Fixed
-_No unreleased changes yet_
+- **Similar cards refresh button**: `/{card_name:path}/similar` HTMX endpoint now registered before the `/{card_name:path}` catch-all route; previously the greedy `:path` matcher captured `/similar` as part of the card name, returning a 404
 
 ### Removed
 _No unreleased changes yet_

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -2,13 +2,35 @@
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- **Card Detail Page** (`/cards/{name}`): Fully redesigned with a 2-column grid layout
+  - Card image with "New" badge for recently released cards
+  - Stats table: card type, mana value, power/toughness, rarity, EDHREC rank, color identity pips
+  - Oracle text with inline mana symbol rendering
+  - Theme tag chips
+  - External links to Scryfall, Gatherer, and EDHREC
+  - Market price panel with live TCG + CK prices via `/api/price/`
+  - **Official rulings** panel: first 3 rulings shown, expandable "Show all / Show fewer" toggle; mana symbols rendered in ruling text
+  - Similar cards section
+- **Rulings service** (`code/web/services/rulings.py`): cache-first lookup (loads `rulings_cache.json` at startup); falls back to a rate-limited live Scryfall fetch (≤10 req/s) on cache miss
+- **Rulings cache builder** (`code/file_setup/rulings_cache.py`): downloads the Scryfall bulk rulings file (one request, ~25 MB), maps oracle_id → rulings, then writes `card_files/processed/rulings_cache.json` keyed by scryfallID; integrated into the setup pipeline
+- **Owned Library overhaul**: Full redesign matching the card browser layout and filter UX
+  - Server-side filtering: search, card type, color identity, themes (multi-select, AND logic), CMC/Power/Toughness range
+  - Sticky filter bar (same `position: sticky` behavior as card browser)
+  - Card name autocomplete via new `/owned/search-autocomplete` endpoint
+  - Theme multi-select with chip UI, reusing the `/cards/theme-autocomplete` endpoint
+  - CMC, Power, and Toughness range inputs; `owned_store.get_stats_map()` enriches values from stored meta, falling back to a batch parquet lookup
+  - Full-page scroll replacing the old fixed-height scroll box
+- **Card browser sticky filter bar**: `.card-browser-filters` is now `position: sticky` so filters remain visible while scrolling through results
+- **Collapsible filter panel**: Both the card browser and owned library have a "Filters ▼" toggle button; collapsed state persists per page via `localStorage`; active filter count shown in the button label while collapsed (e.g., "Filters (2 active)")
+- **Owned Library → Card Details link**: Each owned library card tile now has a "Card Details" button linking to `/cards/{name}?ref=owned`
+- **Smart back button on card detail page**: The "Back" button reads the `ref` query param; arriving from the owned library shows "Back to Owned Library" (→ `/owned`), all other sources show "Back to Card Browser" (→ `/cards`)
+- **Similar cards expanded**: Card detail page now shows up to 15 similar cards (was 5)
 
 ### Changed
-_No unreleased changes yet_
+- **Card browser filter bar**: `position: relative` inline style removed from template; stickiness now comes from the CSS class
 
 ### Fixed
-_No unreleased changes yet_
+- **Similar cards refresh button**: `/{card_name:path}/similar` HTMX endpoint now registered before the `/{card_name:path}` catch-all route; previously the greedy `:path` matcher captured `/similar` as part of the card name, returning a 404
 
 ### Removed
 _No unreleased changes yet_

--- a/code/file_setup/rulings_cache.py
+++ b/code/file_setup/rulings_cache.py
@@ -1,0 +1,154 @@
+"""
+Rulings cache builder for card detail view.
+
+Downloads the Scryfall rulings bulk file (~25 MB, one request) and maps
+rulings to the cards in our dataset by oracle_id. This is far more efficient
+than making per-card API calls and stays within Scryfall's guidelines.
+
+Strategy:
+1. GET https://api.scryfall.com/bulk-data  →  find rulings download URL
+2. Download the rulings bulk JSON
+3. Build oracle_id → [rulings] from it
+4. Build scryfallID → oracle_id from card_files/raw/scryfall_bulk_data.json
+5. For each card in all_cards.parquet, write scryfallID → rulings to cache
+
+The live fallback in code/web/services/rulings.py handles individual cache
+misses (new cards not yet in a bulk snapshot).
+
+Usage (standalone):
+    python -c "from code.file_setup.rulings_cache import build_rulings_cache; build_rulings_cache()"
+"""
+
+import json
+import logging
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+SCRYFALL_BULK_DATA_API = "https://api.scryfall.com/bulk-data"
+RULINGS_CACHE_PATH = Path("card_files/processed/rulings_cache.json")
+PARQUET_PATH = Path("card_files/processed/all_cards.parquet")
+LOCAL_BULK_DATA_PATH = Path("card_files/raw/scryfall_bulk_data.json")
+
+_USER_AGENT = "MTGPythonDeckbuilder/1.0 (contact via GitHub)"
+
+
+def _get(url: str) -> bytes:
+    """Simple HTTP GET with project User-Agent."""
+    req = Request(url, headers={"User-Agent": _USER_AGENT, "Accept": "application/json"})
+    with urlopen(req, timeout=60) as r:
+        return r.read()
+
+
+def _fetch_rulings_bulk_url() -> str:
+    """Fetch the current rulings bulk-data download URL from Scryfall."""
+    data = json.loads(_get(SCRYFALL_BULK_DATA_API))
+    for item in data.get("data", []):
+        if item.get("type") == "rulings":
+            return item["download_uri"]
+    raise ValueError("Rulings bulk-data entry not found in Scryfall API response.")
+
+
+def _download_rulings_bulk(url: str, output_func=None) -> list[dict]:
+    """Download and parse the Scryfall rulings bulk JSON file."""
+    _log = output_func or (lambda msg: logger.info(msg))
+    _log(f"Downloading rulings bulk file from Scryfall…")
+    raw = _get(url)
+    _log(f"Downloaded {len(raw) / 1_048_576:.1f} MB — parsing…")
+    return json.loads(raw)
+
+
+def _build_oracle_id_map() -> dict[str, str]:
+    """
+    Return scryfallID -> oracle_id using the local scryfall_bulk_data.json.
+    Falls back to empty dict if the file is missing.
+    """
+    if not LOCAL_BULK_DATA_PATH.exists():
+        logger.warning(f"{LOCAL_BULK_DATA_PATH} not found; oracle_id mapping unavailable.")
+        return {}
+    with open(LOCAL_BULK_DATA_PATH, encoding="utf-8") as f:
+        cards = json.load(f)
+    return {
+        card["id"]: card["oracle_id"]
+        for card in cards
+        if "id" in card and "oracle_id" in card
+    }
+
+
+def build_rulings_cache(output_func=None) -> None:
+    """
+    Build card_files/processed/rulings_cache.json from the Scryfall rulings
+    bulk file.  Requires all_cards.parquet to exist (run initial_setup first).
+
+    One bulk download (~25 MB) replaces thousands of individual API calls.
+    This is an optional, standalone step — NOT part of the default pipeline.
+
+    Args:
+        output_func: Optional callable(str) for progress messages.
+    """
+    _log = output_func or (lambda msg: logger.info(msg))
+
+    if not PARQUET_PATH.exists():
+        _log(f"Parquet not found at {PARQUET_PATH}; run initial_setup() first.")
+        return
+
+    # Step 1: cards we care about
+    _log("Loading card data…")
+    df = pd.read_parquet(PARQUET_PATH, columns=["scryfallID"])
+    our_ids: set[str] = {
+        str(sid) for sid in df["scryfallID"].dropna().unique() if sid
+    }
+    _log(f"Found {len(our_ids)} unique Scryfall IDs in dataset.")
+
+    # Step 2: scryfallID → oracle_id map (from local bulk data)
+    _log("Building oracle_id map from local Scryfall bulk data…")
+    scryfall_to_oracle = _build_oracle_id_map()
+    _log(f"Mapped {len(scryfall_to_oracle):,} cards to oracle_id.")
+
+    # Step 3: download rulings bulk file
+    try:
+        rulings_url = _fetch_rulings_bulk_url()
+        rulings_raw = _download_rulings_bulk(rulings_url, output_func=output_func)
+    except (HTTPError, URLError, OSError, ValueError) as e:
+        _log(f"Failed to download rulings bulk file: {e}")
+        return
+
+    # Step 4: build oracle_id → [rulings] index
+    _log("Indexing rulings by oracle_id…")
+    oracle_rulings: dict[str, list[dict]] = {}
+    for entry in rulings_raw:
+        oid = entry.get("oracle_id", "")
+        if not oid:
+            continue
+        oracle_rulings.setdefault(oid, []).append({
+            "published_at": entry.get("published_at", ""),
+            "source": entry.get("source", ""),
+            "comment": entry.get("comment", ""),
+        })
+    _log(f"Indexed rulings for {len(oracle_rulings):,} oracle IDs.")
+
+    # Step 5: build scryfallID → rulings cache for our cards only
+    cache: dict[str, list[dict]] = {}
+    missing_oracle = 0
+    for sid in our_ids:
+        oracle_id = scryfall_to_oracle.get(sid)
+        if oracle_id:
+            cache[sid] = oracle_rulings.get(oracle_id, [])
+        else:
+            cache[sid] = []
+            missing_oracle += 1
+
+    if missing_oracle:
+        _log(f"Note: {missing_oracle} cards had no oracle_id in local bulk data (live fallback will handle them).")
+
+    RULINGS_CACHE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with open(RULINGS_CACHE_PATH, "w", encoding="utf-8") as f:
+        json.dump(cache, f, ensure_ascii=False)
+
+    total_rulings = sum(len(v) for v in cache.values())
+    _log(f"Rulings cache written: {len(cache):,} cards, {total_rulings:,} rulings total.")
+    _log(f"Output: {RULINGS_CACHE_PATH}")

--- a/code/file_setup/setup.py
+++ b/code/file_setup/setup.py
@@ -797,3 +797,25 @@ def run_full_pipeline(output_func=None, parallel: bool = True) -> None:
     _log("=" * 70)
     _log("Full pipeline complete")
     _log("=" * 70)
+
+
+def refresh_rulings_cache(output_func=None) -> None:
+    """Fetch and cache Scryfall rulings for all cards.
+
+    Downloads the Scryfall rulings bulk file (~25 MB, one request) and maps
+    rulings to cards in the dataset by oracle_id. Much faster than per-card
+    API calls — typically completes in 1-2 minutes.
+
+    This is an optional step that is NOT part of the default pipeline. Call it
+    independently to pre-populate card_files/processed/rulings_cache.json.
+    The live Scryfall fallback handles individual cache misses automatically.
+
+    Requires all_cards.parquet to already exist (run initial_setup() first).
+    Requires card_files/raw/scryfall_bulk_data.json for oracle_id mapping
+    (downloaded during initial_setup()).
+
+    Args:
+        output_func: Optional callable(str) for progress messages.
+    """
+    from code.file_setup.rulings_cache import build_rulings_cache
+    build_rulings_cache(output_func=output_func)

--- a/code/tests/test_rulings.py
+++ b/code/tests/test_rulings.py
@@ -1,0 +1,148 @@
+"""Tests for card rulings — service and route integration."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Service unit tests (code.web.services.rulings)
+# ---------------------------------------------------------------------------
+
+class TestRulingsService:
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def setup_method(self):
+        # Reset module-level cache before each test
+        import code.web.services.rulings as svc
+        svc._rulings_cache = None
+
+    def test_get_rulings_returns_cached(self, tmp_path, monkeypatch):
+        """Cache hit: returns data without making a network call."""
+        import code.web.services.rulings as svc
+
+        fake_cache = {
+            "abc-123": [
+                {"published_at": "2022-10-14", "source": "wotc", "comment": "Test ruling."}
+            ]
+        }
+        monkeypatch.setattr(svc, "RULINGS_CACHE_PATH", tmp_path / "rulings_cache.json")
+        (tmp_path / "rulings_cache.json").write_text(json.dumps(fake_cache))
+
+        result = self._run(svc.get_rulings("abc-123"))
+
+        assert len(result) == 1
+        assert result[0]["comment"] == "Test ruling."
+
+    def test_get_rulings_live_fallback(self, tmp_path, monkeypatch):
+        """Cache miss: fetches from Scryfall live and caches result."""
+        import code.web.services.rulings as svc
+
+        # Empty cache file
+        monkeypatch.setattr(svc, "RULINGS_CACHE_PATH", tmp_path / "rulings_cache.json")
+        (tmp_path / "rulings_cache.json").write_text(json.dumps({}))
+
+        live_rulings = [
+            {"published_at": "2023-01-01", "source": "scryfall", "comment": "Editorial note."}
+        ]
+
+        async def mock_live_fetch(scryfall_id):
+            return live_rulings
+
+        monkeypatch.setattr(svc, "_live_fetch", mock_live_fetch)
+
+        result = self._run(svc.get_rulings("def-456"))
+
+        assert result == live_rulings
+        # Result should now be in memory cache
+        assert svc._rulings_cache is not None
+        assert "def-456" in svc._rulings_cache
+
+    def test_get_rulings_network_error_returns_empty(self, tmp_path, monkeypatch):
+        """Network failure during live fetch returns empty list."""
+        import code.web.services.rulings as svc
+
+        monkeypatch.setattr(svc, "RULINGS_CACHE_PATH", tmp_path / "rulings_cache.json")
+        (tmp_path / "rulings_cache.json").write_text(json.dumps({}))
+
+        async def mock_live_fetch_fail(scryfall_id):
+            return []
+
+        monkeypatch.setattr(svc, "_live_fetch", mock_live_fetch_fail)
+
+        result = self._run(svc.get_rulings("missing-card"))
+        assert result == []
+
+    def test_get_rulings_empty_scryfall_id(self):
+        """Empty scryfall_id returns [] without any cache/network access."""
+        import code.web.services.rulings as svc
+        result = self._run(svc.get_rulings(""))
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# Route integration test
+# ---------------------------------------------------------------------------
+
+class TestCardDetailRulings:
+    """Verify rulings section is present in card detail page HTML."""
+
+    def test_card_detail_renders_rulings_section(self, monkeypatch):
+        """Card detail page includes a Rulings section."""
+        import sys
+        import pandas as pd
+        from fastapi.testclient import TestClient
+        from unittest.mock import MagicMock
+
+        # Import app first so card_browser is fully initialized before patching
+        from code.web.app import app
+        import code.web.routes.card_browser as cb
+        import code.web.services.rulings as svc
+
+        # Minimal card dataframe
+        fake_df = pd.DataFrame([{
+            "name": "Sol Ring",
+            "type": "Artifact",
+            "text": "Add one mana of any color.",
+            "manaValue": 1,
+            "power": None,
+            "toughness": None,
+            "edhrecRank": 1,
+            "rarity": "uncommon",
+            "colors": [],
+            "colorIdentity": "C",
+            "scryfallID": "test-scryfall-id",
+            "themeTags": "",
+            "isNew": False,
+            "price": None,
+            "ck_price": None,
+            "side": None,
+        }])
+
+        fake_rulings = [
+            {"published_at": "2022-10-14", "source": "wotc", "comment": "Mana from Sol Ring is colorless."}
+        ]
+
+        loader_mock = MagicMock()
+        loader_mock.load.return_value = fake_df
+        monkeypatch.setattr(cb, "get_loader", lambda: loader_mock)
+
+        sim_mock = MagicMock()
+        sim_mock.find_similar.return_value = []
+        monkeypatch.setattr(cb, "get_similarity", lambda: sim_mock)
+
+        # Pre-populate rulings service cache (no network call)
+        monkeypatch.setattr(svc, "_rulings_cache", {"test-scryfall-id": fake_rulings})
+
+        with TestClient(app) as client:
+            resp = client.get("/cards/Sol Ring")
+
+        assert resp.status_code == 200
+        assert "Rulings" in resp.text
+        assert "Mana from Sol Ring is colorless." in resp.text

--- a/code/web/routes/card_browser.py
+++ b/code/web/routes/card_browser.py
@@ -1202,8 +1202,95 @@ async def card_theme_autocomplete(
         return HTMLResponse(content=f'<div class="autocomplete-error">Error: {str(e)}</div>')
 
 
+@router.get("/{card_name:path}/similar")
+async def get_similar_cards_partial(request: Request, card_name: str):
+    """
+    HTMX endpoint: Returns just the similar cards section for a given card.
+    Used for refreshing similar cards without reloading the entire page.
+    
+    Note: Uses :path to capture DFC names with // in them.
+    Must be registered BEFORE the /{card_name:path} catch-all route.
+    """
+    try:
+        from urllib.parse import unquote
+        
+        # Decode URL-encoded card name
+        card_name = unquote(card_name)
+        
+        # Load cards data
+        loader = get_loader()
+        df = loader.load()
+        
+        # Get main card for theme tags
+        card_row = df[df['name'] == card_name]
+        if card_row.empty:
+            return templates.TemplateResponse(
+                "browse/cards/_similar_cards.html",
+                {
+                    "request": request,
+                    "similar_cards": [],
+                    "main_card_tags": [],
+                }
+            )
+        
+        card = card_row.iloc[0].to_dict()
+        main_card_tags = parse_theme_tags(card.get('themeTags', ''))
+        
+        # Calculate similar cards
+        similarity = get_similarity()
+        similar_cards = similarity.find_similar(
+            card_name,
+            threshold=0.8,
+            limit=15,
+            min_results=3,
+            adaptive=True
+        )
+        
+        # Enrich similar cards with full data
+        for similar in similar_cards:
+            similar_row = df[df['name'] == similar['name']]
+            if not similar_row.empty:
+                similar_data = similar_row.iloc[0].to_dict()
+                theme_tags_parsed = parse_theme_tags(similar_data.get('themeTags', ''))
+                similar.update(similar_data)
+                similar['themeTags'] = theme_tags_parsed
+        
+        logger.info(f"Similar cards refresh for '{card_name}': {len(similar_cards)} cards")
+        
+        return templates.TemplateResponse(
+            "browse/cards/_similar_cards.html",
+            {
+                "request": request,
+                "card": card,
+                "similar_cards": similar_cards,
+                "main_card_tags": main_card_tags,
+            }
+        )
+        
+    except Exception as e:
+        logger.error(f"Error loading similar cards for '{card_name}': {e}", exc_info=True)
+        # Try to get card data for error case too
+        try:
+            loader = get_loader()
+            df = loader.load()
+            card_row = df[df['name'] == card_name]
+            card = card_row.iloc[0].to_dict() if not card_row.empty else {"name": card_name}
+        except Exception:
+            card = {"name": card_name}
+        
+        return templates.TemplateResponse(
+            "browse/cards/_similar_cards.html",
+            {
+                "request": request,
+                "card": card,
+                "similar_cards": [],
+                "main_card_tags": [],
+            }
+        )
+
+
 @router.get("/{card_name:path}", response_class=HTMLResponse)
-async def card_detail(request: Request, card_name: str):
+async def card_detail(request: Request, card_name: str, ref: str = Query("", description="Referring page (owned)")):
     """
     Display detailed information about a single card with similar cards.
     
@@ -1251,7 +1338,7 @@ async def card_detail(request: Request, card_name: str):
         similar_cards = similarity.find_similar(
             card_name,
             threshold=0.8,  # Start at 80%
-            limit=5,        # Show 3-5 cards
+            limit=15,       # Show up to 15 cards
             min_results=3,  # Target minimum 3
             adaptive=True   # Enable adaptive thresholds (80% → 60%)
         )
@@ -1282,7 +1369,23 @@ async def card_detail(request: Request, card_name: str):
         
         # Get main card's theme tags for overlap highlighting
         main_card_tags = card.get('themeTags_parsed', [])
-        
+
+        # Fetch rulings (cache-first, live fallback)
+        from code.web.services.rulings import get_rulings
+        from urllib.parse import quote_plus
+        scryfall_id = card.get('scryfallID') or ''
+        rulings = await get_rulings(scryfall_id) if scryfall_id else []
+
+        # External links (URL-encoded so apostrophes/commas are safe)
+        _encoded_name = quote_plus(card_name)
+        scryfall_url = f"https://scryfall.com/search?q=%21%22{_encoded_name}%22"
+        gatherer_url = f"https://gatherer.wizards.com/Pages/Card/Details.aspx?name={_encoded_name}"
+
+        # Smart back button: go back to whichever page linked here
+        _ref = ref.strip().lower() if ref else ""
+        back_url  = "/owned" if _ref == "owned" else "/cards"
+        back_text = "Back to Owned Library" if _ref == "owned" else "Back to Card Browser"
+
         return templates.TemplateResponse(
             "browse/cards/detail.html",
             {
@@ -1290,6 +1393,11 @@ async def card_detail(request: Request, card_name: str):
                 "card": card,
                 "similar_cards": similar_cards,
                 "main_card_tags": main_card_tags,
+                "rulings": rulings,
+                "scryfall_url": scryfall_url,
+                "gatherer_url": gatherer_url,
+                "back_url": back_url,
+                "back_text": back_text,
             }
         )
         
@@ -1305,91 +1413,5 @@ async def card_detail(request: Request, card_name: str):
                 "back_text": "Back to Card Browser"
             },
             status_code=500
-        )
-
-
-@router.get("/{card_name:path}/similar")
-async def get_similar_cards_partial(request: Request, card_name: str):
-    """
-    HTMX endpoint: Returns just the similar cards section for a given card.
-    Used for refreshing similar cards without reloading the entire page.
-    
-    Note: Uses :path to capture DFC names with // in them
-    """
-    try:
-        from urllib.parse import unquote
-        
-        # Decode URL-encoded card name
-        card_name = unquote(card_name)
-        
-        # Load cards data
-        loader = get_loader()
-        df = loader.load()
-        
-        # Get main card for theme tags
-        card_row = df[df['name'] == card_name]
-        if card_row.empty:
-            return templates.TemplateResponse(
-                "browse/cards/_similar_cards.html",
-                {
-                    "request": request,
-                    "similar_cards": [],
-                    "main_card_tags": [],
-                }
-            )
-        
-        card = card_row.iloc[0].to_dict()
-        main_card_tags = parse_theme_tags(card.get('themeTags', ''))
-        
-        # Calculate similar cards
-        similarity = get_similarity()
-        similar_cards = similarity.find_similar(
-            card_name,
-            threshold=0.8,
-            limit=5,
-            min_results=3,
-            adaptive=True
-        )
-        
-        # Enrich similar cards with full data
-        for similar in similar_cards:
-            similar_row = df[df['name'] == similar['name']]
-            if not similar_row.empty:
-                similar_data = similar_row.iloc[0].to_dict()
-                theme_tags_parsed = parse_theme_tags(similar_data.get('themeTags', ''))
-                similar.update(similar_data)
-                similar['themeTags'] = theme_tags_parsed
-        
-        logger.info(f"Similar cards refresh for '{card_name}': {len(similar_cards)} cards")
-        
-        return templates.TemplateResponse(
-            "browse/cards/_similar_cards.html",
-            {
-                "request": request,
-                "card": card,
-                "similar_cards": similar_cards,
-                "main_card_tags": main_card_tags,
-            }
-        )
-        
-    except Exception as e:
-        logger.error(f"Error loading similar cards for '{card_name}': {e}", exc_info=True)
-        # Try to get card data for error case too
-        try:
-            loader = get_loader()
-            df = loader.load()
-            card_row = df[df['name'] == card_name]
-            card = card_row.iloc[0].to_dict() if not card_row.empty else {"name": card_name}
-        except Exception:
-            card = {"name": card_name}
-        
-        return templates.TemplateResponse(
-            "browse/cards/_similar_cards.html",
-            {
-                "request": request,
-                "card": card,
-                "similar_cards": [],
-                "main_card_tags": [],
-            }
         )
 

--- a/code/web/routes/owned.py
+++ b/code/web/routes/owned.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from fastapi import APIRouter, Request, UploadFile, File
+from fastapi import APIRouter, Request, UploadFile, File, Query
 from fastapi.responses import HTMLResponse, Response
 from ..app import templates
 from ..services import owned_store as store
@@ -106,8 +106,114 @@ def _build_owned_context(request: Request, notice: str | None = None, error: str
 
 
 @router.get("/", response_class=HTMLResponse)
-async def owned_index(request: Request) -> HTMLResponse:
+async def owned_index(
+    request: Request,
+    search: str = Query(""),
+    sort_by: str = Query("name"),
+    filter_type: str = Query(""),
+    filter_tags: list[str] = Query([]),
+    filter_color: str = Query(""),
+    cmc_min: str = Query(""),
+    cmc_max: str = Query(""),
+    power_min: str = Query(""),
+    power_max: str = Query(""),
+    tough_min: str = Query(""),
+    tough_max: str = Query(""),
+) -> HTMLResponse:
     ctx = _build_owned_context(request)
+
+    names: list[str] = ctx["names"]
+    tags_by_name: dict = ctx.get("tags_by_name") or {}
+    type_by_name: dict = ctx.get("type_by_name") or {}
+    colors_by_name: dict = ctx.get("colors_by_name") or {}
+    added_at_map: dict = ctx.get("added_at_map") or {}
+    total_count: int = ctx["count"]
+
+    # Search filter
+    if search:
+        sq = search.strip().lower()
+        names = [n for n in names if sq in n.lower()]
+
+    # Type filter
+    if filter_type:
+        ft = filter_type.lower()
+        names = [n for n in names if ft in (type_by_name.get(n) or "").lower()]
+
+    # Tag filter (AND logic: card must have ALL selected themes)
+    for ftag in filter_tags:
+        ftag_lower = ftag.lower()
+        names = [n for n in names if any(t.lower() == ftag_lower for t in (tags_by_name.get(n) or []))]
+
+    # Color filter
+    if filter_color:
+        fcode = _canon_color_code(list(filter_color.upper()))
+        names = [n for n in names if _canon_color_code(colors_by_name.get(n) or []) == fcode]
+
+    # CMC / Power / Toughness range filters
+    if cmc_min or cmc_max or power_min or power_max or tough_min or tough_max:
+        stats_map = store.get_stats_map()
+
+        def _to_float(s: str) -> float | None:
+            try:
+                return float(s) if s else None
+            except (ValueError, TypeError):
+                return None
+
+        cmc_lo = _to_float(cmc_min)
+        cmc_hi = _to_float(cmc_max)
+        pw_lo  = _to_float(power_min)
+        pw_hi  = _to_float(power_max)
+        th_lo  = _to_float(tough_min)
+        th_hi  = _to_float(tough_max)
+
+        def _in_range(val: object, lo: float | None, hi: float | None) -> bool:
+            if lo is None and hi is None:
+                return True
+            try:
+                v = float(val)  # type: ignore[arg-type]
+            except (ValueError, TypeError):
+                return False
+            return (lo is None or v >= lo) and (hi is None or v <= hi)
+
+        filtered: list[str] = []
+        for n in names:
+            s = stats_map.get(n) or {}
+            if not _in_range(s.get("manaValue"), cmc_lo, cmc_hi):
+                continue
+            if not _in_range(s.get("power"), pw_lo, pw_hi):
+                continue
+            if not _in_range(s.get("toughness"), th_lo, th_hi):
+                continue
+            filtered.append(n)
+        names = filtered
+
+    # Sort
+    if sort_by == "type":
+        names.sort(key=lambda n: (type_by_name.get(n) or "").lower())
+    elif sort_by == "color":
+        names.sort(key=lambda n: "".join(colors_by_name.get(n) or []))
+    elif sort_by == "tags":
+        names.sort(key=lambda n: len(tags_by_name.get(n) or []))
+    elif sort_by == "recent":
+        names.sort(key=lambda n: -(added_at_map.get(n) or 0))
+    # else "name": already A-Z from _build_owned_context
+
+    ctx.update({
+        "names": names,
+        "count": total_count,
+        "filtered_count": len(names),
+        "search": search,
+        "sort_by": sort_by,
+        "filter_type": filter_type,
+        "filter_tags": filter_tags,
+        "filter_color": filter_color,
+        "cmc_min": cmc_min,
+        "cmc_max": cmc_max,
+        "power_min": power_min,
+        "power_max": power_max,
+        "tough_min": tough_min,
+        "tough_max": tough_max,
+    })
     return templates.TemplateResponse("owned/index.html", ctx)
 
 
@@ -169,6 +275,24 @@ async def owned_remove(request: Request) -> HTMLResponse:
 
 
 # Bulk user-tag endpoints removed by request.
+
+
+@router.get("/search-autocomplete", response_class=HTMLResponse)
+async def owned_search_autocomplete(
+    q: str = Query(..., min_length=2),
+    limit: int = Query(10, ge=1, le=20),
+) -> HTMLResponse:
+    """Return card name suggestions from the owned library for the search autocomplete."""
+    names, _, _, _ = store.get_enriched()
+    ql = q.strip().lower()
+    matches = [n for n in names if ql in n.lower()][:limit]
+    if not matches:
+        return HTMLResponse(content='<div class="autocomplete-empty">No matches in owned library</div>')
+    html = "\n".join(
+        f'<div class="autocomplete-item" data-value="{n}" role="option">{n}</div>'
+        for n in matches
+    )
+    return HTMLResponse(content=html)
 
 
 """

--- a/code/web/routes/setup.py
+++ b/code/web/routes/setup.py
@@ -202,6 +202,45 @@ async def download_github():
         }, status_code=500)
 
 
+@router.get("/rulings-status")
+async def rulings_status():
+    """Return basic info about the rulings cache file."""
+    from code.file_setup.rulings_cache import RULINGS_CACHE_PATH
+    import json as _json_inner
+    import datetime
+
+    if not RULINGS_CACHE_PATH.exists():
+        return JSONResponse({"exists": False})
+
+    try:
+        stat = RULINGS_CACHE_PATH.stat()
+        built_at = datetime.datetime.fromtimestamp(stat.st_mtime).strftime("%Y-%m-%d %H:%M")
+        with open(RULINGS_CACHE_PATH, encoding="utf-8") as f:
+            data = _json_inner.load(f)
+        card_count = len(data)
+        return JSONResponse({"exists": True, "card_count": card_count, "built_at": built_at})
+    except Exception as e:
+        return JSONResponse({"exists": False, "error": str(e)})
+
+
+@router.post("/refresh-rulings")
+async def refresh_rulings():
+    """Start a background thread to rebuild the rulings cache from Scryfall."""
+    def _runner():
+        try:
+            print("[RULINGS THREAD] Starting rulings cache build...")
+            from code.file_setup.rulings_cache import build_rulings_cache
+            build_rulings_cache(output_func=print)
+            print("[RULINGS THREAD] Rulings cache build complete.")
+        except Exception as e:
+            import traceback
+            print(f"[RULINGS THREAD] Failed: {e}\n{traceback.format_exc()}")
+
+    t = threading.Thread(target=_runner, daemon=True)
+    t.start()
+    return JSONResponse({"ok": True, "message": "Rulings cache build started in background."}, status_code=202)
+
+
 @router.get("/", response_class=HTMLResponse)
 async def setup_index(request: Request) -> HTMLResponse:
     import code.settings as settings

--- a/code/web/services/owned_store.py
+++ b/code/web/services/owned_store.py
@@ -183,6 +183,22 @@ def _enrich_from_csvs(target_names: Iterable[str]) -> Dict[str, Dict[str, object
                     parts = [c.strip() for c in colors_raw.split(',') if c.strip()]
                     entry['colors'] = parts
 
+            # Numeric stats (manaValue, power, toughness)
+            if entry.get('manaValue') is None:
+                mv_raw = row.get('manaValue')
+                try:
+                    entry['manaValue'] = float(mv_raw) if mv_raw is not None else None
+                except (ValueError, TypeError):
+                    pass
+            if not entry.get('power'):
+                pw = str(row.get('power') or '').strip()
+                if pw and pw.lower() not in ('nan', 'none', ''):
+                    entry['power'] = pw
+            if not entry.get('toughness'):
+                th = str(row.get('toughness') or '').strip()
+                if th and th.lower() not in ('nan', 'none', ''):
+                    entry['toughness'] = th
+
     except Exception:
         # Defensive: return empty or partial meta
         pass
@@ -252,6 +268,56 @@ def get_enriched() -> Tuple[List[str], Dict[str, List[str]], Dict[str, str], Dic
         if cols:
             colors_by_name[n] = [str(x).upper() for x in cols if str(x)]
     return names, tags_by_name, type_by_name, colors_by_name
+
+
+def get_stats_map() -> Dict[str, Dict[str, object]]:
+    """Return {name: {manaValue, power, toughness}} for all owned names.
+    Falls back to a parquet lookup for any entries missing numeric stats.
+    """
+    data = _load_raw()
+    names: List[str] = [str(x).strip() for x in (data.get("names") or []) if str(x).strip()]
+    meta: Dict[str, Dict[str, object]] = data.get("meta") or {}
+
+    result: Dict[str, Dict[str, object]] = {}
+    missing: List[str] = []
+    for n in names:
+        info = meta.get(n) or {}
+        mv = info.get('manaValue')
+        entry: Dict[str, object] = {
+            'manaValue': float(mv) if mv is not None else None,
+            'power': info.get('power'),
+            'toughness': info.get('toughness'),
+        }
+        result[n] = entry
+        if entry['manaValue'] is None and entry['power'] is None:
+            missing.append(n)
+
+    # Batch parquet lookup for cards that weren't enriched yet
+    if missing:
+        try:
+            from deck_builder import builder_utils as bu
+            df = bu._load_all_cards_parquet()
+            if not df.empty:
+                want = {n.lower() for n in missing}
+                df['_nl'] = df['name'].str.lower()
+                for _, row in df[df['_nl'].isin(want)].iterrows():
+                    nm = str(row.get('name') or '').strip()
+                    if nm not in result:
+                        continue
+                    try:
+                        mv_raw = row.get('manaValue')
+                        result[nm]['manaValue'] = float(mv_raw) if mv_raw is not None else None
+                    except (ValueError, TypeError):
+                        pass
+                    pw = str(row.get('power') or '').strip()
+                    if pw and pw.lower() not in ('nan', 'none'):
+                        result[nm]['power'] = pw
+                    th = str(row.get('toughness') or '').strip()
+                    if th and th.lower() not in ('nan', 'none'):
+                        result[nm]['toughness'] = th
+        except Exception:
+            pass
+    return result
 
 
 # add_user_tag/remove_user_tag removed; user-defined tags are not persisted anymore

--- a/code/web/services/rulings.py
+++ b/code/web/services/rulings.py
@@ -1,0 +1,121 @@
+"""
+Rulings lookup service for the card detail view.
+
+Strategy (hybrid):
+1. Load rulings_cache.json once at startup (module-level singleton).
+2. On cache hit: return immediately, no network.
+3. On cache miss: fetch live from Scryfall, cache result in memory for the
+   process lifetime (not written to disk — persisted on next pipeline run).
+
+Live fetches are rate-limited to ≤10 req/s using an asyncio.Lock.
+"""
+
+import asyncio
+import json
+import logging
+import time
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+RULINGS_CACHE_PATH = Path("card_files/processed/rulings_cache.json")
+SCRYFALL_RULINGS_URL = "https://api.scryfall.com/cards/{scryfall_id}/rulings"
+_RATE_LIMIT_INTERVAL = 0.1  # 100ms between live fetches (10 req/s)
+_USER_AGENT = "MTGPythonDeckbuilder/1.0 (contact via GitHub)"
+
+# Module-level in-memory cache (loaded once)
+_rulings_cache: dict[str, list[dict]] | None = None
+_cache_lock = asyncio.Lock()
+_last_live_fetch: float = 0.0
+_live_lock = asyncio.Lock()
+
+
+def load_rulings_cache() -> dict[str, list[dict]]:
+    """Read rulings_cache.json from disk. Returns empty dict if not found."""
+    if not RULINGS_CACHE_PATH.exists():
+        logger.debug("rulings_cache.json not found; live fallback will be used.")
+        return {}
+    try:
+        with open(RULINGS_CACHE_PATH, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning(f"Could not load rulings cache: {e}")
+        return {}
+
+
+async def _ensure_cache_loaded() -> dict[str, list[dict]]:
+    """Lazily load the on-disk cache (thread-safe, loads once)."""
+    global _rulings_cache
+    if _rulings_cache is None:
+        async with _cache_lock:
+            if _rulings_cache is None:  # double-checked locking
+                _rulings_cache = load_rulings_cache()
+    return _rulings_cache
+
+
+async def _live_fetch(scryfall_id: str) -> list[dict]:
+    """Fetch rulings from Scryfall live. Rate-limited; returns [] on error."""
+    global _last_live_fetch
+    async with _live_lock:
+        now = time.monotonic()
+        wait = _RATE_LIMIT_INTERVAL - (now - _last_live_fetch)
+        if wait > 0:
+            await asyncio.sleep(wait)
+
+        url = SCRYFALL_RULINGS_URL.format(scryfall_id=scryfall_id)
+        try:
+            async with httpx.AsyncClient(
+                headers={"User-Agent": _USER_AGENT}, timeout=10.0
+            ) as client:
+                resp = await client.get(url)
+                _last_live_fetch = time.monotonic()
+                if resp.status_code == 404:
+                    return []
+                resp.raise_for_status()
+                data = resp.json()
+                return [
+                    {
+                        "published_at": r.get("published_at", ""),
+                        "source": r.get("source", ""),
+                        "comment": r.get("comment", ""),
+                    }
+                    for r in data.get("data", [])
+                ]
+        except httpx.HTTPError as e:
+            logger.warning(f"Scryfall rulings fetch failed for {scryfall_id}: {e}")
+            return []
+        except Exception as e:
+            logger.warning(f"Unexpected error fetching rulings for {scryfall_id}: {e}")
+            return []
+
+
+async def get_rulings(scryfall_id: str) -> list[dict]:
+    """
+    Return rulings for a card by Scryfall ID.
+
+    Checks in-memory cache first; falls back to a live Scryfall request on miss.
+    Caches live results in memory for the process lifetime.
+
+    Args:
+        scryfall_id: Scryfall UUID string.
+
+    Returns:
+        List of ruling dicts: [{"published_at", "source", "comment"}, ...]
+        Empty list if no rulings exist or any error occurs.
+    """
+    if not scryfall_id:
+        return []
+
+    cache = await _ensure_cache_loaded()
+
+    if scryfall_id in cache:
+        return cache[scryfall_id]
+
+    # Cache miss — fetch live and store in memory
+    logger.debug(f"Rulings cache miss for {scryfall_id}; fetching from Scryfall.")
+    rulings = await _live_fetch(scryfall_id)
+    cache[scryfall_id] = rulings
+    return rulings

--- a/code/web/static/styles.css
+++ b/code/web/static/styles.css
@@ -1754,6 +1754,19 @@ label{
   border-color:#9ca3af;
 }
 
+/* Card tile stats row */
+
+.tile-cmc {
+  font-size: 12px;
+  color: var(--muted);
+}
+
+.tile-pips {
+  display: flex;
+  gap: 2px;
+  align-items: center;
+}
+
 select,input[type="text"],input[type="number"]{
   background: var(--panel);
   color:var(--text);
@@ -2057,6 +2070,19 @@ small, .muted{
 .home-button.btn-primary:hover {
   background: #0c5aa6;
   border-color: #0c5aa6;
+}
+
+.home-button-import,
+.home-button.btn-secondary.home-button-import {
+  background: #0d47a1;
+  color: #fff;
+  border-color: #0d47a1;
+}
+
+.home-button-import:hover,
+.home-button.btn-secondary.home-button-import:hover {
+  background: #0a3472;
+  border-color: #0a3472;
 }
 
 /* Card grid for added cards (responsive, compact tiles) */
@@ -2975,6 +3001,87 @@ img.lqip.loaded {
   border: 1px solid var(--border);
   border-radius: 8px;
   padding: 1rem;
+  position: sticky;
+  top: var(--banner-h);
+  z-index: 5;
+  box-shadow: 0 3px 8px rgba(0,0,0,.35);
+}
+
+/* Filter collapse toggle */
+
+.filter-collapse-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.75rem;
+}
+
+.card-browser-filters.filters-collapsed .filter-collapse-bar {
+  margin-bottom: 0;
+}
+
+.filter-collapse-btn {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  cursor: pointer;
+  padding: 0.3rem 0.6rem;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  line-height: 1;
+  transition: background 0.15s;
+}
+
+.filter-collapse-btn:hover {
+  background: var(--hover);
+}
+
+.filter-collapse-btn .collapse-chevron {
+  transition: transform 0.2s ease;
+}
+
+.card-browser-filters.filters-collapsed .filter-collapse-btn .collapse-chevron {
+  transform: rotate(-180deg);
+}
+
+.card-browser-filters.filters-collapsed .filter-collapsible {
+  display: none;
+}
+
+/* Owned Library — management bar (upload / clear / export) */
+
+.owned-mgmt-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0.5rem 0 0.75rem;
+}
+
+/* Owned Library — sticky filter + bulk-action bar */
+
+.owned-filter-bar {
+  position: sticky;
+  top: var(--banner-h);
+  z-index: 5;
+  margin-bottom: 0.75rem;
+  box-shadow: 0 3px 8px rgba(0, 0, 0, 0.35);
+}
+
+/* Owned Library — card grid (full-page scroll, no box wrapper) */
+
+.owned-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 220px));
+  gap: 0.75rem;
+  list-style: none;
+  margin: 0;
+  padding: 0 0 2rem;
+  justify-content: start;
 }
 
 .filter-section {
@@ -3413,6 +3520,500 @@ img.lqip.loaded {
   font-size: 0.85rem;
   font-weight: 500;
 }
+
+/* --- Mana Symbols -------------------------------------------------------- */
+
+.mana-sym {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2em;
+  height: 2em;
+  border-radius: 50%;
+  font-size: 0.75em;
+  font-weight: 700;
+  vertical-align: middle;
+  margin: 0 0.1em;
+  line-height: 1;
+  border: 1px solid rgba(0,0,0,0.25);
+  box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+}
+
+.mana-generic {
+  background: #b0b0b0;
+  color: #111;
+}
+
+.mana-w       {
+  background: #f8f4d4;
+  color: #222;
+  border-color: #c4b87d;
+}
+
+.mana-u       {
+  background: #1469a0;
+  color: #fff;
+}
+
+.mana-b       {
+  background: #2a2020;
+  color: #ccc;
+  border-color: #555;
+}
+
+.mana-r       {
+  background: #d32029;
+  color: #fff;
+}
+
+.mana-g       {
+  background: #00733e;
+  color: #fff;
+}
+
+.mana-c       {
+  background: #c2c2c2;
+  color: #333;
+  border-color: #aaa;
+}
+
+.mana-s       {
+  background: #cde;
+  color: #222;
+}
+
+.mana-t       {
+  background: #888;
+  color: #fff;
+}
+
+.mana-q       {
+  background: #888;
+  color: #fff;
+}
+
+.mana-e       {
+  background: #a0c;
+  color: #fff;
+}
+
+.mana-hybrid {
+  background: linear-gradient(135deg, #b0b0b0 50%, #d4d4d4 50%);
+  color: #111;
+  width: 2em;
+  height: 2em;
+  position: relative;
+  overflow: hidden;
+}
+
+.mana-hybrid .mana-hyb-a,
+.mana-hybrid .mana-hyb-b {
+  position: absolute;
+  font-size: 0.58rem;
+  font-weight: 800;
+  line-height: 1;
+  text-shadow: 0 0 3px rgba(0,0,0,0.55);
+}
+
+.mana-hybrid .mana-hyb-a {
+  top: 1px;
+  left: 3px;
+}
+
+.mana-hybrid .mana-hyb-b {
+  bottom: 1px;
+  right: 3px;
+}
+
+/* --- End Mana Symbols ---------------------------------------------------- */
+
+/* --- Card Rulings -------------------------------------------------------- */
+
+.rulings-section {
+  margin-top: 0;
+}
+
+.rulings-heading {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.75rem;
+}
+
+/* Rulings as a clean 2-col table: date | ruling text */
+
+.rulings-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  font-size: 0.875rem;
+}
+
+.rulings-table .ruling-date-cell {
+  white-space: nowrap;
+  vertical-align: top;
+  padding: 0.6rem 0.75rem;
+  color: var(--muted);
+  font-size: 0.8rem;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--panel);
+  width: 6.5rem;
+}
+
+.rulings-table .ruling-text-cell {
+  padding: 0.6rem 0.85rem;
+  color: var(--text);
+  line-height: 1.55;
+  border-bottom: 1px solid var(--border);
+}
+
+.rulings-table .ruling-row:last-child .ruling-date-cell,
+.rulings-table .ruling-row:last-child .ruling-text-cell {
+  border-bottom: none;
+}
+
+.rulings-toggle {
+  margin-top: 0.75rem;
+  background: none;
+  border: 1px solid var(--border);
+  color: var(--ring);
+  padding: 0.4rem 1rem;
+  border-radius: 6px;
+  font-size: 0.85rem;
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.rulings-toggle:hover {
+  background: var(--ring);
+  color: white;
+  border-color: var(--ring);
+}
+
+.rulings-empty {
+  font-size: 0.9rem;
+  color: var(--muted);
+  font-style: italic;
+}
+
+/* --- End Card Rulings ---------------------------------------------------- */
+
+/* --- Card Detail Page Layout --------------------------------------------- */
+
+.card-detail-container {
+  max-width: 1800px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+}
+
+.card-title {
+  font-size: 2rem;
+  font-weight: bold;
+  margin-bottom: 0.4rem;
+  color: var(--text);
+  line-height: 1.2;
+}
+
+.card-type {
+  font-size: 1rem;
+  color: var(--muted);
+  margin-bottom: 0.9rem;
+}
+
+.card-colors {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 0.9rem;
+}
+
+.card-mana-cost {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.15rem;
+  margin-bottom: 0.9rem;
+}
+
+.ci-pips {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.3rem;
+  align-items: center;
+}
+
+.color-symbol {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: bold;
+  font-size: 13px;
+  border: 2px solid currentColor;
+}
+
+.color-W {
+  background: #F0E68C;
+  color: #000;
+}
+
+.color-U {
+  background: #0E68AB;
+  color: #fff;
+}
+
+.color-B {
+  background: #150B00;
+  color: #fff;
+}
+
+.color-R {
+  background: #D32029;
+  color: #fff;
+}
+
+.color-G {
+  background: #00733E;
+  color: #fff;
+}
+
+.color-C {
+  background: #ccc;
+  color: #000;
+}
+
+.card-text {
+  background: var(--panel);
+  padding: 1.25rem;
+  border-radius: 8px;
+  margin-bottom: 1.25rem;
+  line-height: 1.65;
+  border: 1px solid var(--border);
+  font-size: 0.95rem;
+}
+
+.similar-section {
+  margin-top: 2rem;
+  padding-top: 2rem;
+  border-top: 2px solid var(--border);
+}
+
+.card-detail-grid {
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  grid-template-rows: auto auto;
+  grid-template-areas:
+		"cd-image  cd-info"
+		"cd-price  cd-rulings";
+  gap: 1.75rem 2rem;
+  align-items: start;
+  margin-bottom: 3rem;
+}
+
+.card-area-image    {
+  grid-area: cd-image;
+}
+
+.card-area-info     {
+  grid-area: cd-info;
+}
+
+.card-area-price    {
+  grid-area: cd-price;
+}
+
+.card-area-rulings  {
+  grid-area: cd-rulings;
+}
+
+@media (max-width: 900px) {
+  .card-detail-grid {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+			"cd-image"
+			"cd-info"
+			"cd-price"
+			"cd-rulings";
+  }
+
+  .card-area-image {
+    max-width: 360px;
+    margin: 0 auto;
+    width: 100%;
+  }
+}
+
+/* Stats table */
+
+.card-stats-table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  margin-bottom: 1.25rem;
+  font-size: 0.9rem;
+}
+
+.card-stats-table th {
+  background: var(--panel);
+  color: var(--muted);
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  font-size: 0.75rem;
+  padding: 0.55rem 0.85rem;
+  text-align: left;
+  border-right: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+  width: 40%;
+}
+
+.card-stats-table td {
+  padding: 0.55rem 0.85rem;
+  font-weight: 600;
+  color: var(--text);
+  border-bottom: 1px solid var(--border);
+}
+
+.card-stats-table tr:last-child th,
+.card-stats-table tr:last-child td {
+  border-bottom: none;
+}
+
+/* Price panel (bottom-left on desktop) */
+
+.card-price-panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+}
+
+.card-price-panel-heading {
+  font-size: 0.75rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  color: var(--muted);
+  margin-bottom: 0.5rem;
+}
+
+.card-price-values {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.card-price-row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+}
+
+.card-price-source {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.5px;
+  padding: 0.15rem 0.45rem;
+  border-radius: 4px;
+  background: var(--ring);
+  color: #fff;
+  min-width: 2.5rem;
+  text-align: center;
+}
+
+.card-price-amount {
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.card-price-loading {
+  color: var(--muted);
+  font-size: 0.85rem;
+  font-style: italic;
+}
+
+/* Section heading shared style */
+
+.cd-section-heading {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-bottom: 0.75rem;
+}
+
+/* External links (Scryfall, EDHREC) */
+
+.scryfall-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.8rem;
+  color: var(--ring);
+  text-decoration: none;
+  margin-bottom: 0.85rem;
+  opacity: 0.85;
+  transition: opacity 0.15s;
+}
+
+.scryfall-link:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
+
+/* External link pill buttons (Scryfall, Gatherer, EDHREC) */
+
+.card-ext-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.85rem;
+}
+
+.ext-link-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--ring);
+  background: color-mix(in srgb, var(--ring) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--ring) 35%, transparent);
+  border-radius: 99px;
+  padding: 0.25rem 0.75rem;
+  text-decoration: none;
+  transition: background 0.15s, border-color 0.15s;
+  white-space: nowrap;
+}
+
+.ext-link-btn:hover {
+  background: color-mix(in srgb, var(--ring) 22%, transparent);
+  border-color: var(--ring);
+  text-decoration: none;
+}
+
+.stat-link {
+  color: inherit;
+  text-decoration: none;
+}
+
+.stat-link:hover {
+  text-decoration: underline;
+  color: var(--ring);
+}
+
+/* --- End Card Detail Page Layout ----------------------------------------- */
 
 .back-button {
   display: inline-flex;
@@ -6267,6 +6868,23 @@ footer.site-footer {
   display: none;
 }
 
+/* "Owned" badge on card thumbnails — top-right, green pill */
+
+.card-owned-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: rgba(34, 197, 94, 0.9);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 4px;
+  pointer-events: none;
+  z-index: 4;
+  white-space: nowrap;
+}
+
 /* "New" badge on card thumbnails — lower-right, teal pill */
 
 .card-new-badge {
@@ -6285,8 +6903,6 @@ footer.site-footer {
   line-height: 16px;
   letter-spacing: .03em;
 }
-
-/* "Reprint" badge on card thumbnails — lower-right, gray pill */
 
 /* When stacked above a New badge, shifts up by badge height (20px) + 4px gap */
 

--- a/code/web/static/tailwind.css
+++ b/code/web/static/tailwind.css
@@ -229,6 +229,10 @@ label{ display:inline-flex; flex-direction:column; gap:.25rem; margin-right:.75r
 .mana-R{ background:#ef4444; border-color:#b91c1c; }
 .mana-G{ background:#10b981; border-color:#047857; }
 .mana-C{ background:#d3d3d3; border-color:#9ca3af; }
+
+/* Card tile stats row */
+.tile-cmc { font-size: 12px; color: var(--muted); }
+.tile-pips { display: flex; gap: 2px; align-items: center; }
 select,input[type="text"],input[type="number"]{ background: var(--panel); color:var(--text); border:1px solid var(--border); border-radius:6px; padding:.35rem .4rem; }
 /* Range slider styling */
 input[type="range"]{ 
@@ -840,6 +844,83 @@ img.lqip.loaded { filter: blur(0); opacity: 1; }
 	border: 1px solid var(--border);
 	border-radius: 8px;
 	padding: 1rem;
+	position: sticky;
+	top: var(--banner-h);
+	z-index: 5;
+	box-shadow: 0 3px 8px rgba(0,0,0,.35);
+}
+
+/* Filter collapse toggle */
+.filter-collapse-bar {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	margin-bottom: 0.75rem;
+}
+
+.card-browser-filters.filters-collapsed .filter-collapse-bar {
+	margin-bottom: 0;
+}
+
+.filter-collapse-btn {
+	background: none;
+	border: 1px solid var(--border);
+	border-radius: 4px;
+	color: var(--text);
+	cursor: pointer;
+	padding: 0.3rem 0.6rem;
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	font-size: 0.9rem;
+	font-weight: 600;
+	line-height: 1;
+	transition: background 0.15s;
+}
+
+.filter-collapse-btn:hover {
+	background: var(--hover);
+}
+
+.filter-collapse-btn .collapse-chevron {
+	transition: transform 0.2s ease;
+}
+
+.card-browser-filters.filters-collapsed .filter-collapse-btn .collapse-chevron {
+	transform: rotate(-180deg);
+}
+
+.card-browser-filters.filters-collapsed .filter-collapsible {
+	display: none;
+}
+
+/* Owned Library — management bar (upload / clear / export) */
+.owned-mgmt-bar {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.5rem;
+	margin: 0.5rem 0 0.75rem;
+}
+
+/* Owned Library — sticky filter + bulk-action bar */
+.owned-filter-bar {
+	position: sticky;
+	top: var(--banner-h);
+	z-index: 5;
+	margin-bottom: 0.75rem;
+	box-shadow: 0 3px 8px rgba(0, 0, 0, 0.35);
+}
+
+/* Owned Library — card grid (full-page scroll, no box wrapper) */
+.owned-card-grid {
+	display: grid;
+	grid-template-columns: repeat(auto-fill, minmax(200px, 220px));
+	gap: 0.75rem;
+	list-style: none;
+	margin: 0;
+	padding: 0 0 2rem;
+	justify-content: start;
 }
 
 .filter-section {
@@ -1260,6 +1341,387 @@ img.lqip.loaded { filter: blur(0); opacity: 1; }
 	font-size: 0.85rem;
 	font-weight: 500;
 }
+
+/* --- Mana Symbols -------------------------------------------------------- */
+.mana-sym {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2em;
+	height: 2em;
+	border-radius: 50%;
+	font-size: 0.75em;
+	font-weight: 700;
+	vertical-align: middle;
+	margin: 0 0.1em;
+	line-height: 1;
+	border: 1px solid rgba(0,0,0,0.25);
+	box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+}
+.mana-generic { background: #b0b0b0; color: #111; }
+.mana-w       { background: #f8f4d4; color: #222; border-color: #c4b87d; }
+.mana-u       { background: #1469a0; color: #fff; }
+.mana-b       { background: #2a2020; color: #ccc; border-color: #555; }
+.mana-r       { background: #d32029; color: #fff; }
+.mana-g       { background: #00733e; color: #fff; }
+.mana-c       { background: #c2c2c2; color: #333; border-color: #aaa; }
+.mana-s       { background: #cde; color: #222; }
+.mana-t       { background: #888; color: #fff; }
+.mana-q       { background: #888; color: #fff; }
+.mana-e       { background: #a0c; color: #fff; }
+.mana-hybrid {
+	background: linear-gradient(135deg, #b0b0b0 50%, #d4d4d4 50%);
+	color: #111;
+	width: 2em;
+	height: 2em;
+	position: relative;
+	overflow: hidden;
+}
+.mana-hybrid .mana-hyb-a,
+.mana-hybrid .mana-hyb-b {
+	position: absolute;
+	font-size: 0.58rem;
+	font-weight: 800;
+	line-height: 1;
+	text-shadow: 0 0 3px rgba(0,0,0,0.55);
+}
+.mana-hybrid .mana-hyb-a { top: 1px;    left: 3px;  }
+.mana-hybrid .mana-hyb-b { bottom: 1px; right: 3px; }
+/* --- End Mana Symbols ---------------------------------------------------- */
+
+/* --- Card Rulings -------------------------------------------------------- */
+.rulings-section {
+	margin-top: 0;
+}
+
+.rulings-heading {
+	font-size: 0.75rem;
+	font-weight: 600;
+	color: var(--muted);
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	margin-bottom: 0.75rem;
+}
+
+/* Rulings as a clean 2-col table: date | ruling text */
+.rulings-table {
+	width: 100%;
+	border-collapse: collapse;
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	overflow: hidden;
+	font-size: 0.875rem;
+}
+
+.rulings-table .ruling-date-cell {
+	white-space: nowrap;
+	vertical-align: top;
+	padding: 0.6rem 0.75rem;
+	color: var(--muted);
+	font-size: 0.8rem;
+	border-right: 1px solid var(--border);
+	border-bottom: 1px solid var(--border);
+	background: var(--panel);
+	width: 6.5rem;
+}
+
+.rulings-table .ruling-text-cell {
+	padding: 0.6rem 0.85rem;
+	color: var(--text);
+	line-height: 1.55;
+	border-bottom: 1px solid var(--border);
+}
+
+.rulings-table .ruling-row:last-child .ruling-date-cell,
+.rulings-table .ruling-row:last-child .ruling-text-cell {
+	border-bottom: none;
+}
+
+.rulings-toggle {
+	margin-top: 0.75rem;
+	background: none;
+	border: 1px solid var(--border);
+	color: var(--ring);
+	padding: 0.4rem 1rem;
+	border-radius: 6px;
+	font-size: 0.85rem;
+	cursor: pointer;
+	transition: all 0.15s;
+}
+
+.rulings-toggle:hover {
+	background: var(--ring);
+	color: white;
+	border-color: var(--ring);
+}
+
+.rulings-empty {
+	font-size: 0.9rem;
+	color: var(--muted);
+	font-style: italic;
+}
+/* --- End Card Rulings ---------------------------------------------------- */
+
+/* --- Card Detail Page Layout --------------------------------------------- */
+.card-detail-container {
+	max-width: 1800px;
+	margin: 0 auto;
+	padding: 2rem 1rem;
+}
+
+.card-title {
+	font-size: 2rem;
+	font-weight: bold;
+	margin-bottom: 0.4rem;
+	color: var(--text);
+	line-height: 1.2;
+}
+
+.card-type {
+	font-size: 1rem;
+	color: var(--muted);
+	margin-bottom: 0.9rem;
+}
+
+.card-colors {
+	display: flex;
+	gap: 0.5rem;
+	margin-bottom: 0.9rem;
+}
+
+.card-mana-cost {
+	display: flex;
+	flex-wrap: wrap;
+	align-items: center;
+	gap: 0.15rem;
+	margin-bottom: 0.9rem;
+}
+
+.ci-pips {
+	display: inline-flex;
+	flex-wrap: wrap;
+	gap: 0.3rem;
+	align-items: center;
+}
+
+.color-symbol {
+	width: 26px;
+	height: 26px;
+	border-radius: 50%;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	font-weight: bold;
+	font-size: 13px;
+	border: 2px solid currentColor;
+}
+
+.color-W { background: #F0E68C; color: #000; }
+.color-U { background: #0E68AB; color: #fff; }
+.color-B { background: #150B00; color: #fff; }
+.color-R { background: #D32029; color: #fff; }
+.color-G { background: #00733E; color: #fff; }
+.color-C { background: #ccc; color: #000; }
+
+.card-text {
+	background: var(--panel);
+	padding: 1.25rem;
+	border-radius: 8px;
+	margin-bottom: 1.25rem;
+	line-height: 1.65;
+	border: 1px solid var(--border);
+	font-size: 0.95rem;
+}
+
+.similar-section {
+	margin-top: 2rem;
+	padding-top: 2rem;
+	border-top: 2px solid var(--border);
+}
+
+.card-detail-grid {
+	display: grid;
+	grid-template-columns: 360px 1fr;
+	grid-template-rows: auto auto;
+	grid-template-areas:
+		"cd-image  cd-info"
+		"cd-price  cd-rulings";
+	gap: 1.75rem 2rem;
+	align-items: start;
+	margin-bottom: 3rem;
+}
+
+.card-area-image    { grid-area: cd-image; }
+.card-area-info     { grid-area: cd-info; }
+.card-area-price    { grid-area: cd-price; }
+.card-area-rulings  { grid-area: cd-rulings; }
+
+@media (max-width: 900px) {
+	.card-detail-grid {
+		grid-template-columns: 1fr;
+		grid-template-areas:
+			"cd-image"
+			"cd-info"
+			"cd-price"
+			"cd-rulings";
+	}
+
+	.card-area-image { max-width: 360px; margin: 0 auto; width: 100%; }
+}
+
+/* Stats table */
+.card-stats-table {
+	width: 100%;
+	border-collapse: collapse;
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	overflow: hidden;
+	margin-bottom: 1.25rem;
+	font-size: 0.9rem;
+}
+
+.card-stats-table th {
+	background: var(--panel);
+	color: var(--muted);
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: 0.4px;
+	font-size: 0.75rem;
+	padding: 0.55rem 0.85rem;
+	text-align: left;
+	border-right: 1px solid var(--border);
+	border-bottom: 1px solid var(--border);
+	white-space: nowrap;
+	width: 40%;
+}
+
+.card-stats-table td {
+	padding: 0.55rem 0.85rem;
+	font-weight: 600;
+	color: var(--text);
+	border-bottom: 1px solid var(--border);
+}
+
+.card-stats-table tr:last-child th,
+.card-stats-table tr:last-child td {
+	border-bottom: none;
+}
+
+/* Price panel (bottom-left on desktop) */
+.card-price-panel {
+	background: var(--panel);
+	border: 1px solid var(--border);
+	border-radius: 8px;
+	padding: 1rem 1.25rem;
+}
+
+.card-price-panel-heading {
+	font-size: 0.75rem;
+	font-weight: 500;
+	text-transform: uppercase;
+	letter-spacing: 0.4px;
+	color: var(--muted);
+	margin-bottom: 0.5rem;
+}
+
+.card-price-values {
+	display: flex;
+	flex-direction: column;
+	gap: 0.35rem;
+}
+
+.card-price-row {
+	display: flex;
+	align-items: center;
+	gap: 0.6rem;
+}
+
+.card-price-source {
+	font-size: 0.7rem;
+	font-weight: 700;
+	letter-spacing: 0.5px;
+	padding: 0.15rem 0.45rem;
+	border-radius: 4px;
+	background: var(--ring);
+	color: #fff;
+	min-width: 2.5rem;
+	text-align: center;
+}
+
+.card-price-amount {
+	font-size: 1.1rem;
+	font-weight: 700;
+	color: var(--text);
+}
+
+.card-price-loading {
+	color: var(--muted);
+	font-size: 0.85rem;
+	font-style: italic;
+}
+
+/* Section heading shared style */
+.cd-section-heading {
+	font-size: 0.75rem;
+	font-weight: 600;
+	color: var(--muted);
+	text-transform: uppercase;
+	letter-spacing: 0.5px;
+	margin-bottom: 0.75rem;
+}
+
+/* External links (Scryfall, EDHREC) */
+.scryfall-link {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.3rem;
+	font-size: 0.8rem;
+	color: var(--ring);
+	text-decoration: none;
+	margin-bottom: 0.85rem;
+	opacity: 0.85;
+	transition: opacity 0.15s;
+}
+
+.scryfall-link:hover { opacity: 1; text-decoration: underline; }
+
+/* External link pill buttons (Scryfall, Gatherer, EDHREC) */
+.card-ext-links {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.5rem;
+	margin-bottom: 0.85rem;
+}
+
+.ext-link-btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.25rem;
+	font-size: 0.8rem;
+	font-weight: 500;
+	color: var(--ring);
+	background: color-mix(in srgb, var(--ring) 12%, transparent);
+	border: 1px solid color-mix(in srgb, var(--ring) 35%, transparent);
+	border-radius: 99px;
+	padding: 0.25rem 0.75rem;
+	text-decoration: none;
+	transition: background 0.15s, border-color 0.15s;
+	white-space: nowrap;
+}
+
+.ext-link-btn:hover {
+	background: color-mix(in srgb, var(--ring) 22%, transparent);
+	border-color: var(--ring);
+	text-decoration: none;
+}
+
+.stat-link {
+	color: inherit;
+	text-decoration: none;
+}
+
+.stat-link:hover { text-decoration: underline; color: var(--ring); }
+/* --- End Card Detail Page Layout ----------------------------------------- */
 
 .back-button {
 	display: inline-flex;
@@ -3993,6 +4455,22 @@ footer.site-footer {
 }
 .card-price-overlay:empty { display: none; }
 
+/* "Owned" badge on card thumbnails — top-right, green pill */
+.card-owned-badge {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background: rgba(34, 197, 94, 0.9);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 4px;
+  pointer-events: none;
+  z-index: 4;
+  white-space: nowrap;
+}
+
 /* "New" badge on card thumbnails — lower-right, teal pill */
 .card-new-badge {
   position: absolute;
@@ -4011,7 +4489,6 @@ footer.site-footer {
   letter-spacing: .03em;
 }
 
-/* "Reprint" badge on card thumbnails — lower-right, gray pill */
 /* When stacked above a New badge, shifts up by badge height (20px) + 4px gap */
 .card-reprint-badge {
   position: absolute;

--- a/code/web/static/ts/app.ts
+++ b/code/web/static/ts/app.ts
@@ -1348,7 +1348,11 @@ interface SkeletonManager {
       document.querySelectorAll('img[data-lqip]')
         .forEach(function(img){
           img.classList.add('lqip');
-          img.addEventListener('load', function(){ img.classList.add('loaded'); }, { once: true });
+          if ((img as HTMLImageElement).complete) {
+            img.classList.add('loaded');
+          } else {
+            img.addEventListener('load', function(){ img.classList.add('loaded'); }, { once: true });
+          }
         });
     }catch(_){ }
   });

--- a/code/web/templates/browse/cards/_card_tile.html
+++ b/code/web/templates/browse/cards/_card_tile.html
@@ -34,9 +34,7 @@
 
     {# Owned indicator #}
     {% if card.is_owned %}
-    <div style="position:absolute; top:4px; right:4px; background:rgba(34,197,94,0.9); color:white; padding:2px 6px; border-radius:4px; font-size:12px; font-weight:600;">
-      ✓ Owned
-    </div>
+    <div class="card-owned-badge">✓ Owned</div>
     {% endif %}
   </div>
 
@@ -57,18 +55,17 @@
     {# Mana cost and color identity #}
     <div class="card-browser-tile-stats">
       {% if card.manaValue is defined and card.manaValue is not none %}
-      <span style="font-size:12px; color:#cbd5e1;">CMC: {{ card.manaValue }}</span>
+      <span class="tile-cmc">CMC: {{ card.manaValue }}</span>
       {% endif %}
       
       {% if card.is_colorless %}
-      <div style="display:flex; gap:2px;">
-        <span class="mana mana-C" style="width:16px; height:16px; font-size:10px;" title="Colorless"></span>
+      <div class="tile-pips">
+        <span class="mana mana-C" title="Colorless"></span>
       </div>
       {% elif card.colorIdentity %}
-      <div style="display:flex; gap:2px;">
-        {% for color in card.colorIdentity %}
-          <span class="mana mana-{{ color }}" style="width:16px; height:16px; font-size:10px;" title="{{ color }}"></span>
-        {% endfor %}
+      <div class="tile-pips">
+        {% set ci_list = card.colorIdentity.replace(' ', '').split(',') if card.colorIdentity is string else card.colorIdentity %}
+        {% for c in ci_list %}{% if c %}<span class="mana mana-{{ c }}" title="{{ c }}"></span>{% endif %}{% endfor %}
       </div>
       {% endif %}
     </div>

--- a/code/web/templates/browse/cards/_similar_cards.html
+++ b/code/web/templates/browse/cards/_similar_cards.html
@@ -55,10 +55,10 @@
 
     .similar-cards-grid {
         display: grid;
-        grid-template-columns: repeat(auto-fill, 280px);
+        grid-template-columns: repeat(auto-fit, minmax(240px, 320px));
         gap: 1.25rem;
         margin-bottom: 2rem;
-        justify-content: start;
+        justify-content: center;
     }
 
     .similar-card-tile {
@@ -70,7 +70,8 @@
         display: flex;
         flex-direction: column;
         gap: 0.6rem;
-        width: 280px;
+        width: 100%;
+        margin: 0 auto;
     }
 
     .similar-card-tile:hover {

--- a/code/web/templates/browse/cards/detail.html
+++ b/code/web/templates/browse/cards/detail.html
@@ -2,275 +2,96 @@
 
 {% block title %}{{ card.name }} - Card Details{% endblock %}
 
-{% block head %}
-<style>
-    .card-detail-container {
-        max-width: 1400px;
-        margin: 0 auto;
-        padding: 2rem 1rem;
-    }
-
-    .card-detail-header {
-        display: flex;
-        gap: 2rem;
-        margin-bottom: 3rem;
-        flex-wrap: wrap;
-    }
-
-    .card-image-large {
-        flex: 0 0 auto;
-        max-width: 360px;
-        cursor: pointer;
-        transition: transform 0.2s;
-    }
-
-    .card-image-large:hover {
-        transform: scale(1.02);
-    }
-
-    .card-image-large img {
-        width: 100%;
-        height: auto;
-        border-radius: 12px;
-        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-    }
-
-    .card-info {
-        flex: 1;
-        min-width: 300px;
-    }
-
-    .card-title {
-        font-size: 2rem;
-        font-weight: bold;
-        margin-bottom: 0.5rem;
-        color: var(--text);
-    }
-
-    .card-type {
-        font-size: 1.1rem;
-        color: var(--muted);
-        margin-bottom: 1rem;
-    }
-
-    .card-stats {
-        display: flex;
-        gap: 2rem;
-        margin-bottom: 1.5rem;
-        flex-wrap: wrap;
-    }
-
-    .card-stat {
-        display: flex;
-        flex-direction: column;
-    }
-
-    .card-stat-label {
-        font-size: 0.85rem;
-        color: var(--muted);
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
-        margin-bottom: 0.25rem;
-    }
-
-    .card-stat-value {
-        font-size: 1.25rem;
-        font-weight: 600;
-        color: var(--text);
-    }
-
-    .card-text {
-        background: var(--panel);
-        padding: 1.5rem;
-        border-radius: 8px;
-        margin-bottom: 1.5rem;
-        line-height: 1.6;
-        white-space: pre-wrap;
-        border: 1px solid var(--border);
-    }
-
-    .card-colors {
-        display: flex;
-        gap: 0.5rem;
-        margin-bottom: 1rem;
-    }
-
-    .color-symbol {
-        width: 24px;
-        height: 24px;
-        border-radius: 50%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        font-weight: bold;
-        font-size: 14px;
-        border: 2px solid currentColor;
-    }
-
-    .color-W { background: #F0E68C; color: #000; }
-    .color-U { background: #0E68AB; color: #fff; }
-    .color-B { background: #150B00; color: #fff; }
-    .color-R { background: #D32029; color: #fff; }
-    .color-G { background: #00733E; color: #fff; }
-    .color-C { background: #ccc; color: #000; }
-
-    .card-tags {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem;
-        margin-bottom: 1rem;
-    }
-
-    .card-tag {
-        background: var(--ring);
-        color: white;
-        padding: 0.35rem 0.75rem;
-        border-radius: 16px;
-        font-size: 0.85rem;
-        font-weight: 500;
-    }
-
-    .back-button {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.5rem;
-        padding: 0.75rem 1.5rem;
-        background: var(--panel);
-        color: var(--text);
-        text-decoration: none;
-        border-radius: 8px;
-        border: 1px solid var(--border);
-        font-weight: 500;
-        transition: all 0.2s;
-        margin-bottom: 2rem;
-    }
-
-    .back-button:hover {
-        background: var(--ring);
-        color: white;
-        border-color: var(--ring);
-    }
-
-    .similar-section {
-        margin-top: 3rem;
-        padding-top: 2rem;
-        border-top: 2px solid var(--border);
-    }
-
-    /* Responsive adjustments */
-    @media (max-width: 768px) {
-        .card-detail-header {
-            flex-direction: column;
-            align-items: center;
-        }
-
-        .card-image-large {
-            max-width: 100%;
-        }
-
-        .card-stats {
-            gap: 1rem;
-        }
-
-        .card-title {
-            font-size: 1.5rem;
-        }
-    }
-</style>
-{% endblock %}
-
 {% block content %}
 <div class="card-detail-container">
     <!-- Back Button -->
-    <a href="/cards" class="back-button">
+    <a href="{{ back_url | default('/cards') }}" class="back-button">
         <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
             <path d="M12.707 5.293a1 1 0 010 1.414L9.414 10l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z"/>
         </svg>
-        Back to Card Browser
+        {{ back_text | default('Back to Card Browser') }}
     </a>
 
-    <!-- Card Header -->
-    <div class="card-detail-header">
-        <!-- Card Image (no hover on detail page) -->
-        <div class="card-image-large" style="position:relative;">
-            <img src="{{ card.name|card_image('normal') }}" 
-                 alt="{{ card.name }}" 
+    <!-- 2-column grid: [image | info] / [price | rulings] -->
+    <div class="card-detail-grid">
+
+        <!-- ── LEFT TOP: Card Image ───────────────────────────── -->
+        <div class="card-area-image card-image-large" style="position:relative;">
+            <img src="{{ card.name|card_image('normal') }}"
+                 alt="{{ card.name }}"
                  loading="lazy"
                  onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
-            {# Fallback for missing images #}
-            <div style="display:none; width:100%; height:680px; align-items:center; justify-content:center; background:#1a1d24; color:#9ca3af; font-size:18px; padding:2rem; text-align:center; border-radius:12px;">
+            <div style="display:none; width:100%; height:500px; align-items:center; justify-content:center; background:#1a1d24; color:#9ca3af; font-size:18px; padding:2rem; text-align:center; border-radius:12px;">
                 {{ card.name }}
             </div>
-            {% if show_new_badge and card.isNew %}<div class="card-new-badge" title="Recently Released" aria-hidden="true">New</div>{% endif %}
+            {% if show_new_badge and card.isNew %}
+            <div class="card-new-badge" title="Recently Released" aria-hidden="true">New</div>
+            {% endif %}
         </div>
 
-        <!-- Card Info -->
-        <div class="card-info">
+        <!-- ── RIGHT TOP: Card Info ───────────────────────────── -->
+        <div class="card-area-info">
             <h1 class="card-title">{{ card.name }}</h1>
-            
-            <div class="card-type">{{ card.type }}</div>
-
-            <!-- Color Identity -->
-            {% if card.colors %}
-            <div class="card-colors">
-                {% for color in card.colors %}
-                <span class="color-symbol color-{{ color }}">{{ color }}</span>
-                {% endfor %}
+            <div class="card-ext-links">
+                {% if scryfall_url %}<a href="{{ scryfall_url }}" target="_blank" rel="noopener" class="ext-link-btn">Scryfall ↗</a>{% endif %}
+                {% if gatherer_url %}<a href="{{ gatherer_url }}" target="_blank" rel="noopener" class="ext-link-btn">Gatherer ↗</a>{% endif %}
+                {% if card.edhrecRank %}<a href="https://edhrec.com/cards/{{ card.name | lower | replace(' ', '-') | replace(',', '') | replace("'", '') }}" target="_blank" rel="noopener" class="ext-link-btn">EDHREC ↗</a>{% endif %}
             </div>
+
+            <!-- Casting cost pip row -->
+            {% if card.manaCost %}
+            <div class="card-mana-cost">{{ card.manaCost }}</div>
             {% endif %}
 
-            <!-- Stats -->
-            <div class="card-stats">
+            <!-- Stats table -->
+            {% set type_parts = card.type.split(' — ') if card.type else [] %}
+            <table class="card-stats-table">
+                {% if type_parts|length > 1 %}
+                <tr>
+                    <th>{{ type_parts[0] }}</th>
+                    <td>{{ type_parts[1] }}</td>
+                </tr>
+                {% elif card.type %}
+                <tr>
+                    <th colspan="2">{{ card.type }}</th>
+                </tr>
+                {% endif %}
                 {% if card.manaValue is not none %}
-                <div class="card-stat">
-                    <span class="card-stat-label">Mana Value</span>
-                    <span class="card-stat-value">{{ card.manaValue }}</span>
-                </div>
+                <tr>
+                    <th>Mana Value</th>
+                    <td>{{ card.manaValue | int }}</td>
+                </tr>
                 {% endif %}
-
                 {% if card.power is not none and card.power != 'NaN' and card.power|string != 'nan' %}
-                <div class="card-stat">
-                    <span class="card-stat-label">Power / Toughness</span>
-                    <span class="card-stat-value">{{ card.power }} / {{ card.toughness }}</span>
-                </div>
+                <tr>
+                    <th>Power / Toughness</th>
+                    <td>{{ card.power }} / {{ card.toughness }}</td>
+                </tr>
                 {% endif %}
-
-                {% if card.edhrecRank %}
-                <div class="card-stat">
-                    <span class="card-stat-label">EDHREC Rank</span>
-                    <span class="card-stat-value">#{{ card.edhrecRank }}</span>
-                </div>
-                {% endif %}
-
                 {% if card.rarity %}
-                <div class="card-stat">
-                    <span class="card-stat-label">Rarity</span>
-                    <span class="card-stat-value">{{ card.rarity | capitalize }}</span>
-                </div>
+                <tr>
+                    <th>Rarity</th>
+                    <td>{{ card.rarity | capitalize }}</td>
+                </tr>
                 {% endif %}
-
-                <div class="card-stat" id="card-detail-price-wrap" style="display:none;">
-                    <span class="card-stat-label">Price</span>
-                    <span class="card-stat-value" id="card-detail-price-display"></span>
-                </div>
-            </div>
-            <script>
-            (function(){
-                var name = {{ card.name | tojson }};
-                fetch('/api/price/' + encodeURIComponent(name))
-                    .then(function(r){ return r.ok ? r.json() : null; })
-                    .then(function(d){
-                        if (!d) return;
-                        var parts = [];
-                        if (d.price != null) parts.push('<span class="price-src-label">TCG</span> $' + parseFloat(d.price).toFixed(2));
-                        if (d.ck_price != null) parts.push('<span class="price-src-label">CK</span> $' + parseFloat(d.ck_price).toFixed(2));
-                        if (parts.length) {
-                            document.getElementById('card-detail-price-display').innerHTML = parts.join(' <span class="price-sep">\u00B7</span> ');
-                            document.getElementById('card-detail-price-wrap').style.display = '';
-                        }
-                    }).catch(function(){});
-            })();
-            </script>
+                {% if card.edhrecRank %}
+                <tr>
+                    <th>EDHREC Rank</th>
+                    <td>#{{ card.edhrecRank | int }}</td>
+                </tr>
+                {% endif %}
+                {% if card.colorIdentity %}
+                <tr>
+                    <th>Color Identity</th>
+                    <td>
+                        {% set ci_list = card.colorIdentity.replace(' ', '').split(',') if card.colorIdentity is string else card.colorIdentity %}
+                        <span class="ci-pips">
+                        {% for c in ci_list %}{% if c %}<span class="color-symbol color-{{ c }}" title="{{ c }}"></span>{% endif %}{% endfor %}
+                        </span>
+                    </td>
+                </tr>
+                {% endif %}
+            </table>
 
             <!-- Oracle Text -->
             {% if card.text %}
@@ -279,6 +100,7 @@
 
             <!-- Theme Tags -->
             {% if card.themeTags_parsed and card.themeTags_parsed|length > 0 %}
+            <p class="cd-section-heading" style="margin-top:1rem;">Themes</p>
             <div class="card-tags">
                 {% for tag in card.themeTags_parsed %}
                 <span class="card-tag">{{ tag }}</span>
@@ -286,11 +108,155 @@
             </div>
             {% endif %}
         </div>
-    </div>
+
+        <!-- ── LEFT BOTTOM: Price ─────────────────────────────── -->
+        <div class="card-area-price card-price-panel">
+            <p class="card-price-panel-heading">Market Price</p>
+            <div class="card-price-values" id="card-price-values">
+                <span class="card-price-loading">Loading…</span>
+            </div>
+        </div>
+
+        <!-- ── RIGHT BOTTOM: Rulings ──────────────────────────── -->
+        <div class="card-area-rulings rulings-section">
+            <h3 class="rulings-heading">Rulings</h3>
+            {% if rulings %}
+            <table class="rulings-table">
+                {% for ruling in rulings %}
+                <tr class="ruling-row{% if loop.index > 3 %} ruling-hidden{% endif %}">
+                    <td class="ruling-date-cell">{{ ruling.published_at }}</td>
+                    <td class="ruling-text-cell">{{ ruling.comment }}</td>
+                </tr>
+                {% endfor %}
+            </table>
+            {% if rulings|length > 3 %}
+            <button class="rulings-toggle" onclick="toggleRulings(this)" data-count="{{ rulings|length }}">
+                Show all {{ rulings|length }} rulings
+            </button>
+            {% endif %}
+            {% else %}
+            <p class="rulings-empty">No official rulings for this card.</p>
+            {% endif %}
+        </div>
+
+    </div>{# end .card-detail-grid #}
 
     <!-- Similar Cards Section -->
     <div class="similar-section">
         {% include "browse/cards/_similar_cards.html" %}
     </div>
 </div>
+
+<script>
+// Price loader
+(function(){
+    var name = {{ card.name | tojson }};
+    fetch('/api/price/' + encodeURIComponent(name))
+        .then(function(r){ return r.ok ? r.json() : null; })
+        .then(function(d){
+            var el = document.getElementById('card-price-values');
+            if (!el) return;
+            if (!d || (d.price == null && d.ck_price == null)) {
+                el.innerHTML = '<span class="card-price-loading">No price data available.</span>';
+                return;
+            }
+            var html = '';
+            if (d.price != null) {
+                html += '<div class="card-price-row"><span class="card-price-source">TCG</span><span class="card-price-amount">$' + parseFloat(d.price).toFixed(2) + '</span></div>';
+            }
+            if (d.ck_price != null) {
+                html += '<div class="card-price-row"><span class="card-price-source">CK</span><span class="card-price-amount">$' + parseFloat(d.ck_price).toFixed(2) + '</span></div>';
+            }
+            el.innerHTML = html;
+        })
+        .catch(function(){
+            var el = document.getElementById('card-price-values');
+            if (el) el.innerHTML = '<span class="card-price-loading">Unavailable.</span>';
+        });
+})();
+
+// Mana symbol renderer
+(function(){
+    var MANA_CLASS = {
+        'W':'mana-w','U':'mana-u','B':'mana-b','R':'mana-r','G':'mana-g',
+        'C':'mana-c','S':'mana-s','T':'mana-t','Q':'mana-q','E':'mana-e'
+    };
+    var MANA_BG = {
+        'W':'#f8f4d4','U':'#1469a0','B':'#2a2020','R':'#d32029',
+        'G':'#00733e','C':'#c2c2c2','S':'#c8dde8','T':'#888','Q':'#888'
+    };
+    var MANA_DARK = {'U':1,'B':1,'R':1,'G':1,'T':1,'Q':1};
+    var MANA_DISPLAY = {'T':'<span style="display:inline-block;transform:rotate(180deg);line-height:1">↻</span>','Q':'↺'};
+    var NUM_WORDS = {
+        '0':'Zero','1':'One','2':'Two','3':'Three','4':'Four','5':'Five',
+        '6':'Six','7':'Seven','8':'Eight','9':'Nine','10':'Ten',
+        '11':'Eleven','12':'Twelve','13':'Thirteen','14':'Fourteen','15':'Fifteen',
+        '16':'Sixteen','20':'Twenty'
+    };
+    var COLOR_NAMES = {'W':'White','U':'Blue','B':'Black','R':'Red','G':'Green','C':'Colorless','S':'Snow'};
+    function symBg(s)  { return /^\d+$/.test(s) ? '#b0b0b0' : (MANA_BG[s.toUpperCase()] || '#b0b0b0'); }
+    function symFg(s)  { return (MANA_DARK[s.toUpperCase()] ? '#fff' : '#111'); }
+    function numWord(n) { return NUM_WORDS[n] || n; }
+    function manaTooltip(sym) {
+        var up = sym.toUpperCase();
+        if (up === 'T') return 'Tap';
+        if (up === 'Q') return 'Untap';
+        if (up === 'E') return 'Energy Counter';
+        if (sym.indexOf('/') !== -1) {
+            var p = sym.split('/');
+            var a = p[0], b = (p[1]||'');
+            if (b.toUpperCase() === 'P') {
+                return 'One ' + (COLOR_NAMES[a.toUpperCase()]||a) + ' Mana or 2 Life';
+            }
+            if (/^\d+$/.test(a)) {
+                return numWord(a) + ' Mana of Any Color or One ' + (COLOR_NAMES[b.toUpperCase()]||b) + ' Mana';
+            }
+            return 'One ' + (COLOR_NAMES[a.toUpperCase()]||a) + ' or One ' + (COLOR_NAMES[b.toUpperCase()]||b) + ' Mana';
+        }
+        if (/^\d+$/.test(sym)) {
+            if (sym === '0') return 'Zero Generic Mana';
+            return numWord(sym) + ' Mana of Any Color';
+        }
+        if (up === 'X' || up === 'Y' || up === 'Z') return up + ' Mana of Any Color';
+        var cn = COLOR_NAMES[up];
+        return cn ? 'One ' + cn + ' Mana' : sym;
+    }
+    function renderMana(el) {
+        if (!el) return;
+        el.innerHTML = el.innerHTML.replace(/\{([^}]+)\}/g, function(_, sym) {
+            var up = sym.toUpperCase();
+            var tip = manaTooltip(sym);
+            if (sym.indexOf('/') !== -1) {
+                var p = sym.split('/');
+                var c1 = symBg(p[0]), c2 = symBg(p[1]||'');
+                var f1 = symFg(p[0]), f2 = symFg(p[1]||'');
+                var bg = 'linear-gradient(135deg,' + c1 + ' 50%,' + c2 + ' 50%)';
+                return '<span class="mana-sym mana-hybrid" style="background:' + bg + '" title="' + tip + '">'
+                     + '<span class="mana-hyb-a" style="color:' + f1 + '">' + p[0] + '</span>'
+                     + '<span class="mana-hyb-b" style="color:' + f2 + '">' + (p[1]||'') + '</span>'
+                     + '</span>';
+            }
+            var cls = MANA_CLASS[up] || 'mana-generic';
+            var display = MANA_DISPLAY[up] || sym;
+            return '<span class="mana-sym ' + cls + '" title="' + tip + '">' + display + '</span>';
+        });
+    }
+    document.querySelectorAll('.card-text, .ruling-text-cell, .card-mana-cost').forEach(renderMana);
+})();
+
+// Rulings toggle
+function toggleRulings(btn) {
+    var expanded = btn.getAttribute('data-expanded') === '1';
+    if (expanded) {
+        document.querySelectorAll('.ruling-hidden').forEach(function(el){ el.style.display = 'none'; });
+        btn.setAttribute('data-expanded', '0');
+        btn.textContent = 'Show all ' + btn.getAttribute('data-count') + ' rulings';
+    } else {
+        document.querySelectorAll('.ruling-row').forEach(function(el){ el.style.display = ''; });
+        btn.setAttribute('data-expanded', '1');
+        btn.textContent = 'Show fewer rulings';
+    }
+}
+document.querySelectorAll('.ruling-hidden').forEach(function(el){ el.style.display = 'none'; });
+</script>
 {% endblock %}

--- a/code/web/templates/browse/cards/index.html
+++ b/code/web/templates/browse/cards/index.html
@@ -73,37 +73,46 @@
   {% endif %}
 
   {# Filters Panel #}
-  <div class="card-browser-filters" style="position: relative;">
-    {# Keyboard shortcuts help button (desktop only) #}
-    <button 
-      type="button" 
-      id="shortcuts-help-btn"
-      class="shortcuts-help-btn"
-      style="position: absolute; top: 0.5rem; right: 0.5rem; width: 28px; height: 28px; border-radius: 50%; background: #444; border: 1px solid #666; color: #fff; font-weight: bold; cursor: pointer; font-size: 16px; display: none; align-items: center; justify-content: center; padding: 0; line-height: 1;"
-      title="Keyboard Shortcuts"
-      onclick="toggleShortcutsHelp()"
-    >?</button>
-    
-    {# Shortcuts help tooltip #}
-    <div 
-      id="shortcuts-help-tooltip"
-      style="display: none; position: absolute; top: 2.5rem; right: 0.5rem; background: #2a2a2a; border: 1px solid #666; border-radius: 6px; padding: 1rem; min-width: 320px; max-width: 400px; z-index: 1000; box-shadow: 0 4px 6px rgba(0,0,0,0.3);"
-    >
-      <h4 style="margin-top: 0; margin-bottom: 0.75rem; font-size: 1.1rem;">Keyboard Shortcuts</h4>
-      <div style="font-size: 0.9rem; line-height: 1.6;">
-        <div style="margin-bottom: 0.5rem;"><strong>Enter</strong> - Add first theme match / Select autocomplete</div>
-        <div style="margin-bottom: 0.5rem;"><strong>Shift+Enter</strong> - Add current theme & apply filters</div>
-        <div style="margin-bottom: 0.5rem;"><strong>Escape</strong> - Close dropdown</div>
-        <div style="margin-bottom: 0.5rem;"><strong>Escape×2</strong> - Clear all filters (within 0.5s)</div>
-        <div style="margin-bottom: 0.5rem;"><strong>↑/↓</strong> - Navigate autocomplete</div>
+  <div class="card-browser-filters">
+    {# Collapse toggle bar #}
+    <div class="filter-collapse-bar">
+      <button type="button" class="filter-collapse-btn" id="filter-toggle-btn" onclick="toggleFilterPanel()" aria-expanded="true" title="Toggle filters">
+        <svg class="collapse-chevron" width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="2 5 7 10 12 5"/></svg>
+        Filters<span id="filter-active-count" style="font-size:0.8rem; color:var(--muted); font-weight:normal;"></span>
+      </button>
+      {# Keyboard shortcuts help button (desktop only) #}
+      <div style="position:relative;">
+        <button 
+          type="button" 
+          id="shortcuts-help-btn"
+          class="shortcuts-help-btn"
+          style="width: 28px; height: 28px; border-radius: 50%; background: #444; border: 1px solid #666; color: #fff; font-weight: bold; cursor: pointer; font-size: 16px; display: none; align-items: center; justify-content: center; padding: 0; line-height: 1;"
+          title="Keyboard Shortcuts"
+          onclick="toggleShortcutsHelp()"
+        >?</button>
+        {# Shortcuts help tooltip #}
+        <div 
+          id="shortcuts-help-tooltip"
+          style="display: none; position: absolute; top: 2.5rem; right: 0; background: #2a2a2a; border: 1px solid #666; border-radius: 6px; padding: 1rem; min-width: 320px; max-width: 400px; z-index: 1000; box-shadow: 0 4px 6px rgba(0,0,0,0.3);"
+        >
+          <h4 style="margin-top: 0; margin-bottom: 0.75rem; font-size: 1.1rem;">Keyboard Shortcuts</h4>
+          <div style="font-size: 0.9rem; line-height: 1.6;">
+            <div style="margin-bottom: 0.5rem;"><strong>Enter</strong> - Add first theme match / Select autocomplete</div>
+            <div style="margin-bottom: 0.5rem;"><strong>Shift+Enter</strong> - Add current theme & apply filters</div>
+            <div style="margin-bottom: 0.5rem;"><strong>Escape</strong> - Close dropdown</div>
+            <div style="margin-bottom: 0.5rem;"><strong>Escape×2</strong> - Clear all filters (within 0.5s)</div>
+            <div style="margin-bottom: 0.5rem;"><strong>↑/↓</strong> - Navigate autocomplete</div>
+          </div>
+          <button 
+            type="button" 
+            onclick="toggleShortcutsHelp()" 
+            style="margin-top: 0.75rem; padding: 0.4rem 0.8rem; background: #555; border: 1px solid #777; border-radius: 4px; color: #fff; cursor: pointer; width: 100%;"
+          >Close</button>
+        </div>
       </div>
-      <button 
-        type="button" 
-        onclick="toggleShortcutsHelp()" 
-        style="margin-top: 0.75rem; padding: 0.4rem 0.8rem; background: #555; border: 1px solid #777; border-radius: 4px; color: #fff; cursor: pointer; width: 100%;"
-      >Close</button>
     </div>
-    
+
+    <div class="filter-collapsible" id="filter-collapsible">
     {# Search bar #}
     <div class="filter-section">
       <form method="get" id="card-search-form">
@@ -332,6 +341,7 @@
         </div>
       </div>
     </div>
+    </div>{# end .filter-collapsible #}
   </div>
 
   {# Results info bar with page indicator #}
@@ -977,5 +987,41 @@ window.addEventListener('load', function() {
   {% endfor %}
   {% endif %}
 });
+</script>
+<script>
+(function() {
+  var panel = document.querySelector('.card-browser-filters');
+  if (!panel) return;
+  var STORAGE_KEY = 'cards-filter-collapsed';
+  function updateCount() {
+    var el = document.getElementById('filter-active-count');
+    if (!el) return;
+    var n = 0;
+    var si = document.getElementById('search-input');
+    if (si && si.value) n++;
+    var fc = document.getElementById('filter-color');
+    if (fc && fc.value) n++;
+    var ft = document.getElementById('filter-type');
+    if (ft && ft.value) n++;
+    var fr = document.getElementById('filter-rarity');
+    if (fr && fr.value) n++;
+    var fn = document.getElementById('filter-is-new');
+    if (fn && fn.checked) n++;
+    n += document.querySelectorAll('#selected-themes .theme-chip').length;
+    el.textContent = n > 0 ? ' (' + n + ' active)' : '';
+  }
+  window.toggleFilterPanel = function() {
+    var collapsed = panel.classList.toggle('filters-collapsed');
+    var btn = document.getElementById('filter-toggle-btn');
+    if (btn) btn.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+    localStorage.setItem(STORAGE_KEY, collapsed ? '1' : '0');
+  };
+  if (localStorage.getItem(STORAGE_KEY) === '1') {
+    panel.classList.add('filters-collapsed');
+    var btn = document.getElementById('filter-toggle-btn');
+    if (btn) btn.setAttribute('aria-expanded', 'false');
+  }
+  updateCount();
+})();
 </script>
 {% endblock %}

--- a/code/web/templates/owned/index.html
+++ b/code/web/templates/owned/index.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<section>
+<section class="owned-library-page">
   <div class="page-header">
     <h2>Owned Library</h2>
     <p class="muted">Upload .txt or .csv lists. We'll extract names and keep a de-duplicated library for the web UI.</p>
@@ -13,12 +13,12 @@
   <div class="notice" style="margin:.5rem 0;">{{ notice }}</div>
   {% endif %}
 
-  <form action="/owned/upload" method="post" enctype="multipart/form-data" style="margin:.5rem 0 1rem 0;">
-    <button type="button" class="btn" onclick="this.nextElementSibling.click();">Upload TXT/CSV</button>
-    <input id="upload-owned" type="file" name="file" accept=".txt,.csv" style="display:none" onchange="this.form.requestSubmit();" />
-  </form>
-
-  <div style="display:flex; gap:.5rem; align-items:center; margin-bottom:.75rem;">
+  {# Management bar: upload, clear, export #}
+  <div class="owned-mgmt-bar">
+    <form action="/owned/upload" method="post" enctype="multipart/form-data">
+      <button type="button" class="btn" onclick="this.nextElementSibling.click();">Upload TXT/CSV</button>
+      <input id="upload-owned" type="file" name="file" accept=".txt,.csv" style="display:none" onchange="this.form.requestSubmit();" />
+    </form>
     <form action="/owned/clear" method="post" style="display:inline;">
       <button type="submit" {% if count == 0 %}disabled{% endif %}>Clear Library</button>
     </form>
@@ -26,352 +26,464 @@
     <a href="/owned/export.csv" download class="btn{% if count == 0 %} disabled{% endif %}" {% if count == 0 %}aria-disabled="true" onclick="return false;"{% endif %}>Export CSV</a>
     <span class="muted">{{ count }} unique name{{ '' if count == 1 else 's' }} <span id="shown-count" style="margin-left:.25rem;">{% if count %}• {{ count }} shown{% endif %}</span></span>
   </div>
-  {% if names and names|length %}
-  <div id="bulk-bar" style="display:flex; align-items:center; gap:.5rem; flex-wrap:wrap; margin:.25rem 0 .5rem 0;">
-    <label style="display:flex; align-items:center; gap:.4rem;">
-      <input type="checkbox" id="select-all" /> Select all shown
-    </label>
-    <button type="button" id="btn-remove-selected" class="btn" disabled>Remove selected</button>
-    <button type="button" id="btn-remove-visible" class="btn" disabled>Remove visible</button>
-    <button type="button" id="btn-export-visible" class="btn" disabled>Export visible TXT</button>
-    <button type="button" id="btn-export-visible-csv" class="btn" disabled>Export visible CSV</button>
-  </div>
-  {% endif %}
 
   {% if names and names|length %}
-  <div class="filters" style="display:flex; flex-wrap:wrap; gap:8px; margin:.25rem 0 .5rem 0;">
-    <select id="sort-by" data-pref="owned:sort" style="background:var(--panel); color:var(--text); border:1px solid var(--border); border-radius:6px; padding:.3rem .5rem;">
-      <option value="name">Sort: A → Z</option>
-      <option value="type">Sort: Type</option>
-      <option value="color">Sort: Color</option>
-      <option value="tags">Sort: Tags</option>
-      <option value="recent">Sort: Recently added</option>
-    </select>
-    <select id="filter-type" data-pref="owned:type" style="background:var(--panel); color:var(--text); border:1px solid var(--border); border-radius:6px; padding:.3rem .5rem;">
-      <option value="">All Types</option>
-      {% for t in all_types %}<option value="{{ t }}">{{ t }}</option>{% endfor %}
-    </select>
-    <select id="filter-tag" data-pref="owned:tag" style="background:var(--panel); color:var(--text); border:1px solid var(--border); border-radius:6px; padding:.3rem .5rem; max-width:320px;">
-      <option value="">All Themes</option>
-      {% for t in all_tags %}<option value="{{ t }}">{{ t }}</option>{% endfor %}
-    </select>
-    <select id="filter-color" data-pref="owned:color" style="background:var(--panel); color:var(--text); border:1px solid var(--border); border-radius:6px; padding:.3rem .5rem;">
-      <option value="">All Colors</option>
-      {% for c in all_colors %}<option value="{{ c }}">{{ c }}</option>{% endfor %}
-      {% if color_combos and color_combos|length %}
-      <option value="" disabled>──────────</option>
-      {% for code, label in color_combos %}
-        <option value="{{ code }}">{{ label }}</option>
-      {% endfor %}
-      {% endif %}
-    </select>
-    <input id="filter-text" data-pref="owned:q" type="search" placeholder="Search name..." style="background:var(--panel); color:var(--text); border:1px solid var(--border); border-radius:6px; padding:.3rem .5rem; flex:1; min-width:200px;" />
-    <button type="button" id="clear-filters">Clear</button>
-  </div>
-  <div id="active-chips" class="muted" style="display:flex; flex-wrap:wrap; gap:6px; font-size:12px; margin:.25rem 0 .5rem 0;"></div>
-  {% endif %}
+  {# Sticky filter + bulk bar — card-browser style #}
+  <div class="owned-filter-bar card-browser-filters">
+    {# Collapse toggle bar #}
+    <div class="filter-collapse-bar">
+      <button type="button" class="filter-collapse-btn" id="filter-toggle-btn" onclick="toggleFilterPanel()" aria-expanded="true" title="Toggle filters">
+        <svg class="collapse-chevron" width="14" height="14" viewBox="0 0 14 14" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="2 5 7 10 12 5"/></svg>
+        Filters<span id="filter-active-count" style="font-size:0.8rem; color:var(--muted); font-weight:normal;"></span>
+      </button>
+    </div>
+    <div class="filter-collapsible" id="filter-collapsible">
+    <div class="filter-section">
+      {# Bulk actions row #}
+      <div id="bulk-bar" class="filter-row">
+        <label style="display:flex; align-items:center; gap:.4rem; white-space:nowrap;">
+          <input type="checkbox" id="select-all" /> Select all shown
+        </label>
+        <button type="button" id="btn-remove-selected" class="btn" disabled>Remove selected</button>
+        <button type="button" id="btn-remove-visible" class="btn" disabled>Remove visible</button>
+        <button type="button" id="btn-export-visible" class="btn" disabled>Export visible TXT</button>
+        <button type="button" id="btn-export-visible-csv" class="btn" disabled>Export visible CSV</button>
+      </div>
 
-  {% if names and names|length %}
-  <div id="owned-box" style="overflow:auto; border:1px solid var(--border); border-radius:8px; padding:.5rem; background:var(--panel); color:var(--text); min-height:240px;" {% if virtualize and count > 800 %}data-virtualize="1"{% endif %}>
-    <ul id="owned-grid" style="display:grid; grid-template-columns: repeat(auto-fill, minmax(240px, 1fr)); grid-auto-rows:auto; gap:4px 16px; list-style:none; margin:0; padding:0;">
-      {% for n in names %}
-      {% set tags = (tags_by_name.get(n, []) if tags_by_name else []) %}
-      {% set tline = (type_by_name.get(n, '') if type_by_name else '') %}
-      {% set cols = (colors_by_name.get(n, []) if colors_by_name else []) %}
-      {% set added_ts = (added_at_map.get(n) if added_at_map else None) %}
-      <li style="break-inside: avoid; overflow-wrap:anywhere;" data-type="{{ tline }}" data-tags="{{ (tags or [])|join('|') }}" data-colors="{{ (cols or [])|join('') }}" data-added="{{ added_ts if added_ts else '' }}">
-  <label class="owned-row" style="cursor:pointer;" tabindex="0" data-card-name="{{ n }}" data-original-name="{{ n }}">
-          <input type="checkbox" class="sel sr-only" aria-label="Select {{ n }}" />
-          <div class="owned-vstack">
-  <img class="card-thumb" loading="lazy" decoding="async" alt="{{ n }} image" src="{{ n|card_image('small') }}" data-card-name="{{ n }}" data-lqip="1" {% if tags %}data-tags="{{ (tags or [])|join(', ') }}"{% endif %}
-    srcset="{{ n|card_image('small') }} 160w, {{ n|card_image('normal') }} 488w"
-    sizes="160px" />
-            <span class="card-name"{% if tags %} data-tags="{{ (tags or [])|join(', ') }}"{% endif %}>{{ n }}</span>
-            {% if cols and cols|length %}
-            <div class="mana-group" aria-hidden="true">
-              {% for c in cols %}
-                <span class="mana mana-{{ c }}" title="{{ c }}"></span>
+      {# Search row — exact card browser layout #}
+      <div class="filter-row">
+        <label for="search-input">Search</label>
+        <div class="autocomplete-container" style="position:relative; flex:1; max-width:300px;">
+          <input
+            type="text"
+            id="search-input"
+            value="{{ search }}"
+            placeholder="Search card names..."
+            autocomplete="off"
+            role="combobox"
+            aria-autocomplete="list"
+            aria-controls="search-autocomplete-dropdown"
+            aria-expanded="false"
+            style="width:100%;"
+          />
+          <div id="search-autocomplete-dropdown" class="autocomplete-dropdown" role="listbox" aria-label="Card name suggestions"></div>
+        </div>
+        {% if search %}
+        <button type="button" class="btn" onclick="document.getElementById('search-input').value=''; applyFilter();" style="padding:.3rem .75rem;">Clear</button>
+        {% endif %}
+        <button type="button" class="btn" onclick="applyFilter()">Search</button>
+      </div>
+
+      {# Themes multi-select row — exact card browser layout #}
+      <div class="filter-row">
+        <label for="filter-theme-input">Themes (up to 5)</label>
+        <div style="flex:1; max-width:500px;">
+          <div id="selected-themes" style="display:flex; flex-wrap:wrap; gap:0.5rem; margin-bottom:0.5rem; min-height:2rem;">
+            {% if filter_tags %}
+              {% for t in filter_tags %}
+              <span class="theme-chip" data-theme="{{ t }}">
+                {{ t }}
+                <button type="button" onclick="removeTheme('{{ t }}')" style="margin-left:0.5rem; background:none; border:none; color:inherit; cursor:pointer; padding:0; font-weight:bold;">&times;</button>
+              </span>
               {% endfor %}
-            </div>
-            <span class="sr-only"> Colors: {{ cols|join(', ') }}</span>
             {% endif %}
           </div>
-        </label>
-        
-      </li>
-      {% endfor %}
-    </ul>
+          <div class="autocomplete-container" style="position:relative;">
+            <input
+              type="text"
+              id="filter-theme-input"
+              placeholder="Add theme..."
+              autocomplete="off"
+              role="combobox"
+              aria-autocomplete="list"
+              aria-controls="theme-autocomplete-dropdown"
+              aria-expanded="false"
+              style="width:100%;"
+            />
+            <div id="theme-autocomplete-dropdown" class="autocomplete-dropdown" role="listbox" aria-label="Theme suggestions"></div>
+          </div>
+        </div>
+      </div>
+
+      {# Filter controls row — exact card browser layout #}
+      <div class="filter-row">
+        {% if all_colors %}
+        <label for="filter-color">Color</label>
+        <select id="filter-color" onchange="applyFilter()">
+          <option value="">All Colors</option>
+          {% for c in all_colors %}<option value="{{ c }}" {% if filter_color == c %}selected{% endif %}>{{ c }}</option>{% endfor %}
+          {% if color_combos and color_combos|length %}
+          <option value="" disabled>──────────</option>
+          {% for code, label in color_combos %}<option value="{{ code }}" {% if filter_color == code %}selected{% endif %}>{{ label }}</option>{% endfor %}
+          {% endif %}
+        </select>
+        {% endif %}
+
+        {% if all_types %}
+        <label for="filter-type">Type</label>
+        <select id="filter-type" onchange="applyFilter()">
+          <option value="">All Types</option>
+          {% for t in all_types %}<option value="{{ t }}" {% if filter_type == t %}selected{% endif %}>{{ t }}</option>{% endfor %}
+        </select>
+        {% endif %}
+
+        <label for="filter-sort">Sort By</label>
+        <select id="filter-sort" onchange="applyFilter()">
+          <option value="name" {% if not sort_by or sort_by == 'name' %}selected{% endif %}>Name (A–Z)</option>
+          <option value="type" {% if sort_by == 'type' %}selected{% endif %}>Type</option>
+          <option value="color" {% if sort_by == 'color' %}selected{% endif %}>Color</option>
+          <option value="tags" {% if sort_by == 'tags' %}selected{% endif %}>Tags</option>
+          <option value="recent" {% if sort_by == 'recent' %}selected{% endif %}>Recently Added</option>
+        </select>
+
+        <button type="button" class="btn" onclick="applyFilter()">Apply Filters</button>
+        <button type="button" class="btn" onclick="window.location.href='/owned'" style="background-color: #666;">Clear Filters</button>
+      </div>
+
+      {# CMC + Power + Toughness range row #}
+      <div class="filter-row" style="margin-top: 0.5rem;">
+        <label for="filter-cmc-min">CMC Range</label>
+        <div style="display:flex; align-items:center; gap:0.5rem; flex:1; max-width:300px;">
+          <input type="number" id="filter-cmc-min" min="0" max="16"
+            value="{{ cmc_min if cmc_min is not none and cmc_min != '' else '' }}"
+            placeholder="Min" style="width:70px;" onchange="applyFilter()" />
+          <span>–</span>
+          <input type="number" id="filter-cmc-max" min="0" max="16"
+            value="{{ cmc_max if cmc_max is not none and cmc_max != '' else '' }}"
+            placeholder="Max" style="width:70px;" onchange="applyFilter()" />
+        </div>
+        <label for="filter-power-min">Power</label>
+        <div style="display:flex; align-items:center; gap:0.5rem; flex:1; max-width:250px;">
+          <input type="number" id="filter-power-min" min="0" max="99"
+            value="{{ power_min if power_min is not none and power_min != '' else '' }}"
+            placeholder="Min" style="width:70px;" onchange="applyFilter()" />
+          <span>–</span>
+          <input type="number" id="filter-power-max" min="0" max="99"
+            value="{{ power_max if power_max is not none and power_max != '' else '' }}"
+            placeholder="Max" style="width:70px;" onchange="applyFilter()" />
+        </div>
+        <label for="filter-tough-min">Toughness</label>
+        <div style="display:flex; align-items:center; gap:0.5rem; flex:1; max-width:250px;">
+          <input type="number" id="filter-tough-min" min="0" max="99"
+            value="{{ tough_min if tough_min is not none and tough_min != '' else '' }}"
+            placeholder="Min" style="width:70px;" onchange="applyFilter()" />
+          <span>–</span>
+          <input type="number" id="filter-tough-max" min="0" max="99"
+            value="{{ tough_max if tough_max is not none and tough_max != '' else '' }}"
+            placeholder="Max" style="width:70px;" onchange="applyFilter()" />
+        </div>
+      </div>
+    </div>
+    </div>{# end .filter-collapsible #}
   </div>
+
+  {# Results count bar #}
+  <div class="card-browser-info">
+    <span class="results-count">
+      {% if filtered_count is defined and filtered_count != count %}
+      Showing {{ filtered_count }} of {{ count }} cards
+      {% if search %} matching "{{ search }}"{% endif %}
+      {% else %}
+      {{ count }} card{{ '' if count == 1 else 's' }} in library
+      {% endif %}
+    </span>
+  </div>
+
+  {# Card grid — full-page scroll, no scroll-box wrapper #}
+  <ul id="owned-grid" class="owned-card-grid">
+    {% for n in names %}
+    {% set tags = (tags_by_name.get(n, []) if tags_by_name else []) %}
+    {% set tline = (type_by_name.get(n, '') if type_by_name else '') %}
+    {% set cols = (colors_by_name.get(n, []) if colors_by_name else []) %}
+    {% set added_ts = (added_at_map.get(n) if added_at_map else None) %}
+    <li data-type="{{ tline }}" data-tags="{{ (tags or [])|join('|') }}" data-colors="{{ (cols or [])|join('') }}" data-added="{{ added_ts if added_ts else '' }}">
+      <label class="owned-row" tabindex="0" data-card-name="{{ n }}" data-original-name="{{ n }}">
+        <input type="checkbox" class="sel sr-only" aria-label="Select {{ n }}" />
+        <div class="owned-vstack">
+          <img class="card-thumb" loading="lazy" decoding="async" alt="{{ n }} image"
+            src="{{ n|card_image('small') }}"
+            data-card-name="{{ n }}" data-lqip="1"
+            {% if tags %}data-tags="{{ (tags or [])|join(', ') }}"{% endif %}
+            srcset="{{ n|card_image('small') }} 160w, {{ n|card_image('normal') }} 488w"
+            sizes="160px" />
+          <span class="card-name"{% if tags %} data-tags="{{ (tags or [])|join(', ') }}"{% endif %}>{{ n }}</span>
+          {% if cols and cols|length %}
+          <div class="mana-group" aria-hidden="true">
+            {% for c in cols %}<span class="mana mana-{{ c }}" title="{{ c }}"></span>{% endfor %}
+          </div>
+          <span class="sr-only"> Colors: {{ cols|join(', ') }}</span>
+          {% endif %}
+          <a href="/cards/{{ n|urlencode }}?ref=owned" class="card-details-btn" onclick="event.stopPropagation()">Card Details</a>
+        </div>
+      </label>
+    </li>
+    {% endfor %}
+  </ul>
   {% else %}
   <p class="muted">No names yet. Upload a file to get started.</p>
   {% endif %}
 </section>
 
   <script>
-  (function(){
-    var grid = document.getElementById('owned-grid');
-    if (!grid) return;
-    var box = document.getElementById('owned-box');
-  var bulk = document.getElementById('bulk-bar');
-  var selAll = document.getElementById('select-all');
-  var btnRemoveSel = document.getElementById('btn-remove-selected');
-  var btnRemoveVis = document.getElementById('btn-remove-visible');
-  var btnExportVis = document.getElementById('btn-export-visible');
-  var btnExportVisCsv = document.getElementById('btn-export-visible-csv');
-  var fSort = document.getElementById('sort-by');
-  var fType = document.getElementById('filter-type');
-    var fTag = document.getElementById('filter-tag');
-    var fColor = document.getElementById('filter-color');
-    var fText = document.getElementById('filter-text');
-    var btnClear = document.getElementById('clear-filters');
-  var shownCount = document.getElementById('shown-count');
-  var chips = document.getElementById('active-chips');
-  
+// Build URL and redirect — same method as card browser
+function applyFilter() {
+  var search = (document.getElementById('search-input') || {value:''}).value || '';
+  var sort   = (document.getElementById('filter-sort')  || {value:''}).value || '';
+  var type   = (document.getElementById('filter-type')  || {value:''}).value || '';
+  var color  = (document.getElementById('filter-color') || {value:''}).value || '';
+  var cmcMin = (document.getElementById('filter-cmc-min')   || {value:''}).value || '';
+  var cmcMax = (document.getElementById('filter-cmc-max')   || {value:''}).value || '';
+  var pwMin  = (document.getElementById('filter-power-min') || {value:''}).value || '';
+  var pwMax  = (document.getElementById('filter-power-max') || {value:''}).value || '';
+  var thMin  = (document.getElementById('filter-tough-min') || {value:''}).value || '';
+  var thMax  = (document.getElementById('filter-tough-max') || {value:''}).value || '';
 
-    // State helpers for URL hash and localStorage
-    var state = {
-      get: function(k, d){ try{ var v=localStorage.getItem('mtg:'+k); return v!==null?JSON.parse(v):d; }catch(e){ return d; } },
-      set: function(k, v){ try{ localStorage.setItem('mtg:'+k, JSON.stringify(v)); }catch(e){} },
-      inHash: function(obj){ try{ var p=new URLSearchParams((location.hash||'').replace(/^#/,'')); Object.keys(obj||{}).forEach(function(k){ p.set(k, obj[k]); }); location.hash=p.toString(); }catch(e){} },
-      readHash: function(){ try{ return new URLSearchParams((location.hash||'').replace(/^#/,'')); }catch(e){ return new URLSearchParams(); } }
-    };
+  // Collect theme chips
+  var themeChips = document.querySelectorAll('#selected-themes .theme-chip');
+  var themes = Array.from(themeChips).map(function(c){ return c.dataset.theme; });
 
-    // Helper: build Scryfall image URL with optional cache-busting
-    function buildImageUrl(name, version, nocache){
-      var q = encodeURIComponent(name||'');
-      var url = '/api/images/' + (version||'small') + '/' + q;
-      if (nocache) url += '&t=' + Date.now();
-      return url;
-    }
+  var params = new URLSearchParams();
+  if (search) params.set('search', search);
+  if (sort && sort !== 'name') params.set('sort_by', sort);
+  if (type)   params.set('filter_type', type);
+  if (color)  params.set('filter_color', color);
+  if (cmcMin) params.set('cmc_min', cmcMin);
+  if (cmcMax) params.set('cmc_max', cmcMax);
+  if (pwMin)  params.set('power_min', pwMin);
+  if (pwMax)  params.set('power_max', pwMax);
+  if (thMin)  params.set('tough_min', thMin);
+  if (thMax)  params.set('tough_max', thMax);
+  themes.forEach(function(t){ params.append('filter_tags', t); });
 
-    // Resize the container to fill the viewport height
-    function sizeBox(){
-      if (!box) return;
-      try {
-        var rect = box.getBoundingClientRect();
-        var margin = 16; // breathing room at bottom
-        var vh = window.innerHeight || document.documentElement.clientHeight || 0;
-        var h = Math.max(240, Math.floor(vh - rect.top - margin));
-        box.style.height = h + 'px';
-      } catch(_){}
-    }
-    function debounce(fn, delay){ var t=null; return function(){ var a=arguments, c=this; if(t) clearTimeout(t); t=setTimeout(function(){ fn.apply(c,a); }, delay); }; }
-    var debouncedSize = debounce(sizeBox, 100);
-    sizeBox();
-    window.addEventListener('resize', debouncedSize);
+  var qs = params.toString();
+  window.location.href = '/owned' + (qs ? '?' + qs : '');
+}
 
-    function passType(li, val){ if (!val) return true; var t=(li.getAttribute('data-type')||'').toLowerCase(); return t.indexOf(val.toLowerCase())!==-1; }
-    function passTag(li, val){ if (!val) return true; var ts=(li.getAttribute('data-tags')||''); if (!ts) return false; var parts=ts.split('|'); return parts.some(function(x){return x.toLowerCase()===val.toLowerCase();}); }
-    function canonCode(raw){
-      var s = (raw||'').toUpperCase();
-      var order = ['W','U','B','R','G'];
-      var out = [];
-      for (var i=0;i<order.length;i++){
-        var ch = order[i];
-        if (s.indexOf(ch) !== -1) out.push(ch);
-      }
-      if (out.length === 0){
-        // Treat empty or explicit C as colorless
-        if (s.indexOf('C') !== -1 || s === '') return 'C';
-        return '';
-      }
-      return out.join('');
-    }
-    function passColor(li, val){
-      if (!val) return true;
-      var cs=(li.getAttribute('data-colors')||'');
-      var vcode = canonCode(val);
-      var ccode = canonCode(cs);
-      if (!vcode) return true; // if somehow invalid selection
-      return ccode === vcode;
-    }
-    function passText(li, val){ if (!val) return true; var txt=(li.textContent||'').toLowerCase(); return txt.indexOf(val.toLowerCase())!==-1; }
+// '/' shortcut focuses search
+document.addEventListener('keydown', function(e) {
+  if (e.target && (/input|textarea|select/i).test(e.target.tagName)) return;
+  if (e.key === '/') {
+    var si = document.getElementById('search-input');
+    if (si) { e.preventDefault(); si.focus(); si.select && si.select(); }
+  }
+});
 
-    function updateShownCount(){
-      if (!shownCount) return;
-      var total = 0;
-      Array.prototype.forEach.call(grid.children, function(li){ if (li.style.display !== 'none') total++; });
-      shownCount.textContent = (total > 0 ? '• ' + total + ' shown' : '');
-  // Enable/disable bulk buttons
-  var anyVisible = total > 0;
-  [btnRemoveVis, btnExportVis, btnExportVisCsv].forEach(function(b){ if (b) b.disabled = !anyVisible; });
-  updateSelectedState();
-    }
+// Search name autocomplete
+(function() {
+  var searchInput = document.getElementById('search-input');
+  var dropdown    = document.getElementById('search-autocomplete-dropdown');
+  if (!searchInput || !dropdown) return;
 
-    function apply(){
-      var vt = fType ? fType.value : '';
-      var vtag = fTag ? fTag.value : '';
-      var vc = fColor ? fColor.value : '';
-      var vx = fText ? fText.value.trim() : '';
-      Array.prototype.forEach.call(grid.children, function(li){
-        var ok = passType(li, vt) && passTag(li, vtag) && passColor(li, vc) && passText(li, vx);
-        li.style.display = ok ? '' : 'none';
-      });
-      resort();
-      updateShownCount();
-  renderChips();
-      // Persist
-      if (fSort && fSort.hasAttribute('data-pref')) state.set(fSort.getAttribute('data-pref'), fSort.value);
-      if (fType && fType.hasAttribute('data-pref')) state.set(fType.getAttribute('data-pref'), fType.value);
-      if (fTag && fTag.hasAttribute('data-pref')) state.set(fTag.getAttribute('data-pref'), fTag.value);
-      if (fColor && fColor.hasAttribute('data-pref')) state.set(fColor.getAttribute('data-pref'), fColor.value);
-      if (fText && fText.hasAttribute('data-pref')) state.set(fText.getAttribute('data-pref'), fText.value);
-      // Update URL hash
-      try{ state.inHash({ o_sort: (fSort?fSort.value:''), o_type: vt, o_tag: vtag, o_color: vc, o_q: vx }); }catch(_){ }
-    }
-    function renderChips(){
-      if (!chips) return;
-      var items = [];
-      if (fType && fType.value) items.push({ k:'Type', v: fType.value, clear: function(){ fType.value=''; apply(); } });
-      if (fTag && fTag.value) items.push({ k:'Theme', v: fTag.value, clear: function(){ fTag.value=''; apply(); } });
-      if (fColor && fColor.value) items.push({ k:'Colors', v: fColor.value, clear: function(){ fColor.value=''; apply(); } });
-      if (fText && fText.value) items.push({ k:'Search', v: fText.value, clear: function(){ fText.value=''; apply(); } });
-      chips.innerHTML = '';
-      if (!items.length){ chips.style.display='none'; return; }
-      chips.style.display='flex';
-      items.forEach(function(it){
-        var span = document.createElement('span');
-        span.style.border = '1px solid var(--border)';
-        span.style.borderRadius = '16px';
-        span.style.padding = '2px 8px';
-        span.style.background = '#0f1115';
-        span.textContent = it.k+': '+it.v+' ×';
-        span.style.cursor = 'pointer';
-        span.title = 'Clear '+it.k;
-        span.addEventListener('click', function(){ it.clear(); });
-        chips.appendChild(span);
-      });
-    }
+  var selectedIndex = -1;
+  var debounceTimer = null;
+  var lastEscapeTime = 0;
 
-  // Bulk user-tag add/remove controls removed by request; inline chip removal remains supported.
+  var fetchSuggestions = function() {
+    var q = searchInput.value.trim();
+    if (q.length < 2) { dropdown.innerHTML = ''; return; }
+    fetch('/owned/search-autocomplete?q=' + encodeURIComponent(q))
+      .then(function(r){ return r.text(); })
+      .then(function(html){ dropdown.innerHTML = html; })
+      .catch(function(){ dropdown.innerHTML = ''; });
+  };
 
-    function resort(){
-      if (!fSort) return;
-      var mode = fSort.value || 'name';
-      var lis = Array.prototype.slice.call(grid.children);
-      // Only consider visible items, but keep hidden in place after visible ones to avoid DOM thrash
-      var visible = lis.filter(function(li){ return li.style.display !== 'none'; });
-      var hidden = lis.filter(function(li){ return li.style.display === 'none'; });
-      function byName(a,b){ return (a.textContent||'').toLowerCase().localeCompare((b.textContent||'').toLowerCase()); }
-      function byType(a,b){ return (a.getAttribute('data-type')||'').toLowerCase().localeCompare((b.getAttribute('data-type')||'').toLowerCase()); }
-      function byColor(a,b){ return (a.getAttribute('data-colors')||'').localeCompare((b.getAttribute('data-colors')||'')); }
-      function byTags(a,b){ var ac=(a.getAttribute('data-tags')||'').split('|').filter(Boolean).length; var bc=(b.getAttribute('data-tags')||'').split('|').filter(Boolean).length; return ac-bc || byName(a,b); }
-      function byRecent(a,b){ var ta=parseInt(a.getAttribute('data-added')||'0',10); var tb=parseInt(b.getAttribute('data-added')||'0',10); return (tb-ta) || byName(a,b); }
-      var cmp = byName;
-      if (mode === 'type') cmp = byType;
-      else if (mode === 'color') cmp = byColor;
-      else if (mode === 'tags') cmp = byTags;
-      else if (mode === 'recent') cmp = byRecent;
-      visible.sort(cmp);
-      // Re-append in new order
-      var frag = document.createDocumentFragment();
-      visible.forEach(function(li){ frag.appendChild(li); });
-      hidden.forEach(function(li){ frag.appendChild(li); });
-      grid.appendChild(frag);
-    }
-
-    function getVisibleNames(){
-      var out=[];
-      Array.prototype.forEach.call(grid.children, function(li){
-        if (li.style.display === 'none') return;
-        var span = li.querySelector('[data-card-name]');
-        if (span) out.push(span.getAttribute('data-card-name'));
-      });
-      return out;
-    }
-    function getSelectedNames(){
-      var out=[];
-      Array.prototype.forEach.call(grid.children, function(li){
-        var cb = li.querySelector('input.sel');
-        if (cb && cb.checked){ var span = li.querySelector('[data-card-name]'); if (span) out.push(span.getAttribute('data-card-name')); }
-      });
-      return out;
-    }
-    function updateSelectedState(){
-      if (!bulk) return;
-      var selected = getSelectedNames();
-      if (btnRemoveSel) btnRemoveSel.disabled = selected.length === 0;
-      if (selAll){
-        // Reflect if all visible are selected
-        var vis = getVisibleNames();
-        selAll.checked = (vis.length>0 && selected.length === vis.length);
-        selAll.indeterminate = (selected.length>0 && selected.length < vis.length);
-      }
-      // Toggle selected class for visual feedback
-      Array.prototype.forEach.call(grid.children, function(li){
-        var cb = li.querySelector('input.sel');
-        li.classList.toggle('is-selected', !!(cb && cb.checked));
-      });
-    }
-
-    if (selAll){
-      selAll.addEventListener('change', function(){
-        var on = !!selAll.checked;
-        Array.prototype.forEach.call(grid.children, function(li){ if (li.style.display==='none') return; var cb=li.querySelector('input.sel'); if (cb) cb.checked = on; });
-        updateSelectedState();
-      });
-    }
-    grid.addEventListener('change', function(e){ if (e.target && e.target.classList && e.target.classList.contains('sel')) updateSelectedState(); });
-    // Keyboard: allow Enter/Space on the row to toggle selection
-    grid.addEventListener('keydown', function(e){
-      if (!(e.key === 'Enter' || e.key === ' ')) return;
-      var row = e.target && e.target.closest && e.target.closest('label.owned-row');
-      if (!row) return;
-      e.preventDefault();
-      var cb = row.querySelector('input.sel');
-      if (cb){ cb.checked = !cb.checked; cb.dispatchEvent(new Event('change', { bubbles:true })); }
-    });
-
-    function postJSON(url, body){ return fetch(url, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body||{}) }).then(function(r){ if (r.ok) return r.text(); throw new Error('Request failed'); }); }
-    function formPost(url, names){
-      var fd = new FormData(); fd.append('names', names.join(','));
-      return fetch(url, { method:'POST', body: fd }).then(function(r){ if (r.ok) return r.text(); throw new Error('Request failed'); });
-    }
-    function confirmRemove(count){
-      return window.confirm('Remove '+count+' item'+(count===1?'':'s')+' from Owned? This cannot be undone.');
-    }
-    if (btnRemoveVis) btnRemoveVis.addEventListener('click', function(){ var names=getVisibleNames(); if(!names.length) return; if(!confirmRemove(names.length)) return; sessionStorage.setItem('mtg:toastAfterReload', JSON.stringify({msg:'Removed '+names.length+' visible name'+(names.length===1?'':'s')+'.', type:'success'})); formPost('/owned/remove', names).then(function(html){ document.documentElement.innerHTML = html; }).catch(function(){ alert('Remove failed'); }); });
-    if (btnRemoveSel) btnRemoveSel.addEventListener('click', function(){ var names=getSelectedNames(); if(!names.length) return; if(!confirmRemove(names.length)) return; sessionStorage.setItem('mtg:toastAfterReload', JSON.stringify({msg:'Removed '+names.length+' selected name'+(names.length===1?'':'s')+'.', type:'success'})); formPost('/owned/remove', names).then(function(html){ document.documentElement.innerHTML = html; }).catch(function(){ alert('Remove failed'); }); });
-    if (btnExportVis) btnExportVis.addEventListener('click', function(){ var names=getVisibleNames(); if(!names.length) return; postJSON('/owned/export-visible', { names: names }).then(function(txt){ var a=document.createElement('a'); a.href=URL.createObjectURL(new Blob([txt],{type:'text/plain'})); a.download='owned_visible.txt'; a.click(); }); });
-    if (btnExportVisCsv) btnExportVisCsv.addEventListener('click', function(){ var names=getVisibleNames(); if(!names.length) return; postJSON('/owned/export-visible.csv', { names: names }).then(function(csv){ var a=document.createElement('a'); a.href=URL.createObjectURL(new Blob([csv],{type:'text/csv'})); a.download='owned_visible.csv'; a.click(); }); });
-
-    // Keyboard helpers: '/' focus search, Esc clear filters
-    document.addEventListener('keydown', function(e){
-      if (e.target && (/input|textarea|select/i).test(e.target.tagName)) return;
-      if (e.key === '/') { if (fText){ e.preventDefault(); fText.focus(); fText.select && fText.select(); } }
-      else if (e.key === 'Escape'){ if (fText && fText.value){ fText.value=''; apply(); } }
-    });
-
-  // Hydrate from URL hash/localStorage
-  try{
-    var params = state.readHash();
-    var hv;
-    if (fSort){ hv = params.get('o_sort'); if (!hv) hv = state.get(fSort.getAttribute('data-pref'), 'name'); if (hv) fSort.value = hv; }
-    if (fType){ hv = params.get('o_type'); if (!hv) hv = state.get(fType.getAttribute('data-pref'), ''); if (hv !== null && typeof hv !== 'undefined') fType.value = hv; }
-    if (fTag){ hv = params.get('o_tag'); if (!hv) hv = state.get(fTag.getAttribute('data-pref'), ''); if (hv !== null && typeof hv !== 'undefined') fTag.value = hv; }
-    if (fColor){ hv = params.get('o_color'); if (!hv) hv = state.get(fColor.getAttribute('data-pref'), ''); if (hv !== null && typeof hv !== 'undefined') fColor.value = hv; }
-    if (fText){ hv = params.get('o_q'); if (!hv && hv !== '') hv = state.get(fText.getAttribute('data-pref'), ''); if (typeof hv === 'string') fText.value = hv; }
-  }catch(_){ }
-
-  if (fSort) fSort.addEventListener('change', function(){ resort(); apply(); });
-  if (fType) fType.addEventListener('change', apply);
-    if (fTag) fTag.addEventListener('change', apply);
-    if (fColor) fColor.addEventListener('change', apply);
-  if (fText) fText.addEventListener('input', apply);
-  if (btnClear) btnClear.addEventListener('click', function(){
-    if(fSort)fSort.value='name'; if(fType)fType.value=''; if(fTag)fTag.value=''; if(fColor)fColor.value=''; if(fText)fText.value='';
-    apply();
+  searchInput.addEventListener('input', function() {
+    clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(fetchSuggestions, 150);
   });
-  // Initial state
-  apply();
 
-  // Thumbnail retry now handled by global binder in base.html
+  var getItems = function() { return Array.from(dropdown.querySelectorAll('.autocomplete-item')); };
+  var selectItem = function(i) {
+    getItems().forEach(function(item, idx) { item.classList.toggle('selected', idx === i); });
+    selectedIndex = i;
+  };
+  var applyItem = function() {
+    var items = getItems();
+    var item = items[selectedIndex];
+    if (item && item.dataset.value) { searchInput.value = item.dataset.value; dropdown.innerHTML = ''; selectedIndex = -1; applyFilter(); }
+  };
 
-  // User tag chip UI removed by request.
-  })();
+  new MutationObserver(function() {
+    selectedIndex = -1;
+    getItems().forEach(function(i){ i.classList.remove('selected'); });
+    searchInput.setAttribute('aria-expanded', dropdown.children.length > 0 ? 'true' : 'false');
+  }).observe(dropdown, { childList: true });
+
+  document.body.addEventListener('click', function(e) {
+    var item = e.target.closest('.autocomplete-item');
+    if (item && item.dataset.value && dropdown.contains(item)) { e.preventDefault(); searchInput.value = item.dataset.value; dropdown.innerHTML = ''; applyFilter(); }
+  });
+  document.addEventListener('click', function(e) { if (!e.target.closest('.autocomplete-container')) { dropdown.innerHTML = ''; selectedIndex = -1; } });
+
+  searchInput.addEventListener('keydown', function(e) {
+    var items = getItems();
+    if (e.key === 'Escape') {
+      var now = Date.now();
+      if (items.length) { dropdown.innerHTML = ''; selectedIndex = -1; lastEscapeTime = now; e.preventDefault(); }
+      else if (now - lastEscapeTime < 500) { e.preventDefault(); window.location.href = '/owned'; }
+      else { lastEscapeTime = now; e.preventDefault(); }
+    } else if (e.key === 'ArrowDown' && items.length) { e.preventDefault(); selectItem(selectedIndex < items.length - 1 ? selectedIndex + 1 : 0); }
+    else if (e.key === 'ArrowUp' && items.length) { e.preventDefault(); selectItem(selectedIndex > 0 ? selectedIndex - 1 : items.length - 1); }
+    else if (e.key === 'Enter') {
+      if (e.shiftKey) { e.preventDefault(); applyFilter(); }
+      else if (selectedIndex >= 0 && items.length) { e.preventDefault(); applyItem(); }
+    }
+  });
+  dropdown.addEventListener('mouseover', function(e) { var item = e.target.closest('.autocomplete-item'); if (item) { var idx = getItems().indexOf(item); if (idx >= 0) selectItem(idx); } });
+})();
+
+// Multi-select theme filter — exact copy of card browser behaviour
+(function() {
+  var themeInput     = document.getElementById('filter-theme-input');
+  var themeDropdown  = document.getElementById('theme-autocomplete-dropdown');
+  var themesContainer = document.getElementById('selected-themes');
+  if (!themeInput || !themeDropdown) return;
+
+  var selectedIndex  = -1;
+  var debounceTimer  = null;
+  var selectedThemes = new Set();
+  var lastEscapeTime = 0;
+
+  // Seed from existing chips (server-rendered on page load)
+  themesContainer.querySelectorAll('.theme-chip').forEach(function(c){ selectedThemes.add(c.dataset.theme); });
+
+  var updateInputState = function() {
+    if (selectedThemes.size >= 5) {
+      themeInput.disabled = true; themeInput.placeholder = 'Maximum 5 themes selected'; themeInput.classList.add('disabled');
+    } else {
+      themeInput.disabled = false; themeInput.placeholder = 'Add theme...'; themeInput.classList.remove('disabled');
+    }
+  };
+  updateInputState();
+
+  var fetchThemes = function() {
+    var q = themeInput.value.trim();
+    if (q.length < 2) { themeDropdown.innerHTML = ''; return; }
+    fetch('/cards/theme-autocomplete?q=' + encodeURIComponent(q))
+      .then(function(r){ return r.text(); })
+      .then(function(html){ themeDropdown.innerHTML = html; })
+      .catch(function(){ themeDropdown.innerHTML = ''; });
+  };
+
+  window.addTheme = function(theme) {
+    if (selectedThemes.size >= 5 || selectedThemes.has(theme)) return;
+    selectedThemes.add(theme);
+    var chip = document.createElement('span');
+    chip.className = 'theme-chip';
+    chip.dataset.theme = theme;
+    chip.innerHTML = theme + ' <button type="button" onclick="removeTheme(\'' + theme.replace(/'/g, "\\'") + '\')" style="margin-left:0.5rem; background:none; border:none; color:inherit; cursor:pointer; padding:0; font-weight:bold;">&times;</button>';
+    themesContainer.appendChild(chip);
+    themeInput.value = '';
+    themeDropdown.innerHTML = '';
+    selectedIndex = -1;
+    updateInputState();
+    if (selectedThemes.size < 5 && window.innerWidth >= 768) requestAnimationFrame(function(){ themeInput.focus(); });
+  };
+
+  window.removeTheme = function(theme) {
+    selectedThemes.delete(theme);
+    var chip = themesContainer.querySelector('.theme-chip[data-theme="' + theme + '"]');
+    if (chip) chip.remove();
+    updateInputState();
+  };
+
+  themeInput.addEventListener('input', function() { clearTimeout(debounceTimer); debounceTimer = setTimeout(fetchThemes, 150); });
+
+  var getItems = function() { return Array.from(themeDropdown.querySelectorAll('.autocomplete-item')); };
+  var selectItem = function(i) { getItems().forEach(function(item, idx){ item.classList.toggle('selected', idx === i); }); selectedIndex = i; };
+  var applyItem  = function() { var items = getItems(); var item = items[selectedIndex]; if (item && item.dataset.value) addTheme(item.dataset.value); };
+
+  new MutationObserver(function() {
+    selectedIndex = -1;
+    getItems().forEach(function(i){ i.classList.remove('selected'); });
+    themeInput.setAttribute('aria-expanded', themeDropdown.children.length > 0 ? 'true' : 'false');
+  }).observe(themeDropdown, { childList: true });
+
+  document.body.addEventListener('click', function(e) {
+    var item = e.target.closest('.autocomplete-item');
+    if (item && item.dataset.value && themeDropdown.contains(item)) { e.preventDefault(); addTheme(item.dataset.value); }
+  });
+  document.addEventListener('click', function(e) { if (!e.target.closest('#filter-theme-input') && !e.target.closest('#theme-autocomplete-dropdown')) { themeDropdown.innerHTML = ''; selectedIndex = -1; } });
+
+  themeInput.addEventListener('keydown', function(e) {
+    var items = getItems();
+    var hasItems = items.length > 0;
+    if (e.key === 'Escape') {
+      var now = Date.now();
+      if (hasItems) { themeDropdown.innerHTML = ''; selectedIndex = -1; lastEscapeTime = now; e.preventDefault(); }
+      else if (now - lastEscapeTime < 500) { e.preventDefault(); window.location.href = '/owned'; }
+      else { lastEscapeTime = now; e.preventDefault(); }
+    } else if (e.key === 'ArrowDown' && hasItems) { e.preventDefault(); selectItem(selectedIndex < items.length - 1 ? selectedIndex + 1 : 0); }
+    else if (e.key === 'ArrowUp'   && hasItems) { e.preventDefault(); selectItem(selectedIndex > 0 ? selectedIndex - 1 : items.length - 1); }
+    else if (e.key === 'Enter') {
+      e.preventDefault();
+      if (e.shiftKey) {
+        if (hasItems) { if (selectedIndex >= 0) applyItem(); else { selectItem(0); applyItem(); } setTimeout(applyFilter, 50); }
+        else applyFilter();
+      } else if (selectedIndex >= 0 && hasItems) applyItem();
+      else if (hasItems) { selectItem(0); applyItem(); }
+    }
+  });
+  themeDropdown.addEventListener('mouseover', function(e) { var item = e.target.closest('.autocomplete-item'); if (item) { var idx = getItems().indexOf(item); if (idx >= 0) selectItem(idx); } });
+})();
+
+// Bulk action + selection
+(function(){
+  var grid = document.getElementById('owned-grid');
+  if (!grid) return;
+  var selAll    = document.getElementById('select-all');
+  var btnRemSel = document.getElementById('btn-remove-selected');
+  var btnRemVis = document.getElementById('btn-remove-visible');
+  var btnExpVis = document.getElementById('btn-export-visible');
+  var btnExpCsv = document.getElementById('btn-export-visible-csv');
+
+  function getVisibleNames() { var out=[]; Array.prototype.forEach.call(grid.children, function(li){ var s=li.querySelector('[data-card-name]'); if(s) out.push(s.getAttribute('data-card-name')); }); return out; }
+  function getSelectedNames() { var out=[]; Array.prototype.forEach.call(grid.children, function(li){ var cb=li.querySelector('input.sel'); if(cb&&cb.checked){ var s=li.querySelector('[data-card-name]'); if(s) out.push(s.getAttribute('data-card-name')); } }); return out; }
+  function updateState() {
+    var sel=getSelectedNames(), vis=getVisibleNames();
+    if(btnRemSel) btnRemSel.disabled=sel.length===0;
+    if(btnRemVis) btnRemVis.disabled=vis.length===0;
+    if(btnExpVis) btnExpVis.disabled=vis.length===0;
+    if(btnExpCsv) btnExpCsv.disabled=vis.length===0;
+    if(selAll){ selAll.checked=(vis.length>0&&sel.length===vis.length); selAll.indeterminate=(sel.length>0&&sel.length<vis.length); }
+    Array.prototype.forEach.call(grid.children, function(li){ var cb=li.querySelector('input.sel'); li.classList.toggle('is-selected',!!(cb&&cb.checked)); });
+  }
+
+  if(selAll) selAll.addEventListener('change', function(){ var on=!!selAll.checked; Array.prototype.forEach.call(grid.children, function(li){ var cb=li.querySelector('input.sel'); if(cb) cb.checked=on; }); updateState(); });
+  grid.addEventListener('change', function(e){ if(e.target&&e.target.classList.contains('sel')) updateState(); });
+  grid.addEventListener('keydown', function(e){ if(!(e.key==='Enter'||e.key===' ')) return; var row=e.target&&e.target.closest&&e.target.closest('label.owned-row'); if(!row) return; e.preventDefault(); var cb=row.querySelector('input.sel'); if(cb){ cb.checked=!cb.checked; cb.dispatchEvent(new Event('change',{bubbles:true})); } });
+
+  function postJSON(url,body){ return fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body||{})}).then(function(r){ if(r.ok) return r.text(); throw new Error('failed'); }); }
+  function formPost(url,names){ var fd=new FormData(); fd.append('names',names.join(',')); return fetch(url,{method:'POST',body:fd}).then(function(r){ if(r.ok) return r.text(); throw new Error('failed'); }); }
+  function confirmRemove(n){ return window.confirm('Remove '+n+' item'+(n===1?'':'s')+' from Owned? This cannot be undone.'); }
+
+  if(btnRemVis) btnRemVis.addEventListener('click', function(){ var ns=getVisibleNames(); if(!ns.length) return; if(!confirmRemove(ns.length)) return; sessionStorage.setItem('mtg:toastAfterReload',JSON.stringify({msg:'Removed '+ns.length+' visible name'+(ns.length===1?'':'s')+'.', type:'success'})); formPost('/owned/remove',ns).then(function(html){ document.documentElement.innerHTML=html; }).catch(function(){ alert('Remove failed'); }); });
+  if(btnRemSel) btnRemSel.addEventListener('click', function(){ var ns=getSelectedNames(); if(!ns.length) return; if(!confirmRemove(ns.length)) return; sessionStorage.setItem('mtg:toastAfterReload',JSON.stringify({msg:'Removed '+ns.length+' selected name'+(ns.length===1?'':'s')+'.', type:'success'})); formPost('/owned/remove',ns).then(function(html){ document.documentElement.innerHTML=html; }).catch(function(){ alert('Remove failed'); }); });
+  if(btnExpVis) btnExpVis.addEventListener('click', function(){ var ns=getVisibleNames(); if(!ns.length) return; postJSON('/owned/export-visible',{names:ns}).then(function(txt){ var a=document.createElement('a'); a.href=URL.createObjectURL(new Blob([txt],{type:'text/plain'})); a.download='owned_visible.txt'; a.click(); }); });
+  if(btnExpCsv) btnExpCsv.addEventListener('click', function(){ var ns=getVisibleNames(); if(!ns.length) return; postJSON('/owned/export-visible.csv',{names:ns}).then(function(csv){ var a=document.createElement('a'); a.href=URL.createObjectURL(new Blob([csv],{type:'text/csv'})); a.download='owned_visible.csv'; a.click(); }); });
+
+  updateState();
+})();
   </script>
 <style>
   .sr-only{ position:absolute; width:1px; height:1px; padding:0; margin:-1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; border:0; }
+  /* Autocomplete dropdown */
+  .autocomplete-container { position: relative; }
+  .autocomplete-dropdown {
+    position: absolute; top: 100%; left: 0; right: 0; z-index: 1000;
+    background: var(--panel); border: 1px solid var(--border); border-top: none;
+    border-radius: 0 0 6px 6px; max-height: 300px; overflow-y: auto;
+    box-shadow: 0 4px 6px rgba(0,0,0,.3); color: var(--text);
+  }
+  .autocomplete-dropdown:empty { display: none; }
+  .autocomplete-item { padding: .75rem; cursor: pointer; border-bottom: 1px solid var(--border); transition: background .15s; }
+  .autocomplete-item:last-child { border-bottom: none; }
+  .autocomplete-item:hover, .autocomplete-item.selected { background: var(--bg); }
+  .autocomplete-item.selected { border-left: 3px solid var(--ring); padding-left: calc(.75rem - 3px); }
+  .autocomplete-empty { padding: .75rem; text-align: center; color: var(--muted); font-size: .85rem; }
+  /* Theme chips */
+  .theme-chip { display:inline-flex; align-items:center; background:var(--accent,.38bdf8); color:#fff; border-radius:16px; padding:3px 10px; font-size:.85rem; gap:.25rem; }
+  /* Mana dots */
   .mana{ display:inline-block; width:14px; height:14px; border-radius:50%; box-sizing:border-box; }
   .mana-W{ background:#f9fafb; border:1px solid #d1d5db; }
   .mana-U{ background:#3b82f6; }
@@ -379,13 +491,6 @@
   .mana-R{ background:#ef4444; }
   .mana-G{ background:#10b981; }
   .mana-C{ background:#9ca3af; border:1px solid #6b7280; }
-  /* Subtle scrollbar styling for the owned list box */
-  #owned-box{ scrollbar-width: thin; scrollbar-color: rgba(148,163,184,.35) transparent; }
-  #owned-box:hover{ scrollbar-color: rgba(148,163,184,.6) transparent; }
-  #owned-box::-webkit-scrollbar{ width:8px; height:8px; }
-  #owned-box::-webkit-scrollbar-track{ background: transparent; }
-  #owned-box::-webkit-scrollbar-thumb{ background-color: rgba(148,163,184,.35); border-radius:8px; }
-  #owned-box:hover::-webkit-scrollbar-thumb{ background-color: rgba(148,163,184,.6); }
   /* Owned item layout */
   #owned-grid{ justify-items:center; }
   .owned-row{ display:flex; align-items:center; justify-content:center; gap:.5rem; border:1px solid transparent; border-radius:8px; padding:.5rem; width:100%; max-width:220px; margin:0 auto; }
@@ -396,4 +501,36 @@
   .mana-group{ display:flex; gap:4px; justify-content:center; }
   .card-name{ display:block; }
 </style>
+<script>
+(function() {
+  var panel = document.querySelector('.card-browser-filters');
+  if (!panel) return;
+  var STORAGE_KEY = 'owned-filter-collapsed';
+  function updateCount() {
+    var el = document.getElementById('filter-active-count');
+    if (!el) return;
+    var n = 0;
+    var si = document.getElementById('search-input');
+    if (si && si.value) n++;
+    var fc = document.getElementById('filter-color');
+    if (fc && fc.value) n++;
+    var ft = document.getElementById('filter-type');
+    if (ft && ft.value) n++;
+    n += document.querySelectorAll('#selected-themes .theme-chip').length;
+    el.textContent = n > 0 ? ' (' + n + ' active)' : '';
+  }
+  window.toggleFilterPanel = function() {
+    var collapsed = panel.classList.toggle('filters-collapsed');
+    var btn = document.getElementById('filter-toggle-btn');
+    if (btn) btn.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+    localStorage.setItem(STORAGE_KEY, collapsed ? '1' : '0');
+  };
+  if (localStorage.getItem(STORAGE_KEY) === '1') {
+    panel.classList.add('filters-collapsed');
+    var btn = document.getElementById('filter-toggle-btn');
+    if (btn) btn.setAttribute('aria-expanded', 'false');
+  }
+  updateCount();
+})();
+</script>
 {% endblock %}

--- a/code/web/templates/setup/index.html
+++ b/code/web/templates/setup/index.html
@@ -166,6 +166,18 @@
     <span class="muted" style="align-self:center; font-size:.85rem;">Rebuilds price data from local Scryfall bulk data (requires Setup to have run).</span>
   </div>
   {% endif %}
+
+  <details style="margin-top:1.25rem;" open>
+    <summary>Card Rulings Cache</summary>
+    <div style="margin-top:.5rem; padding:1rem; border:1px solid var(--border); background:var(--panel); border-radius:8px;">
+      <div class="muted">Status:</div>
+      <div style="margin-top:.25rem;" id="rulings-cache-status">Checking…</div>
+    </div>
+  </details>
+  <div style="margin-top:.75rem; display:flex; gap:.5rem; flex-wrap:wrap;">
+    {{ button('Refresh Rulings Cache', variant='primary', onclick='refreshRulingsCache()', attrs='id="btn-refresh-rulings"') }}
+    <span class="muted" style="align-self:center; font-size:.85rem;">Downloads Scryfall rulings bulk file (~25 MB, one request). Live fallback handles misses automatically.</span>
+  </div>
 </section>
 <script>
 (function(){
@@ -641,8 +653,7 @@
   setInterval(pollSimilarityStatus, 10000); // Poll every 10s
   {% endif %}
 
-  window.refreshPriceCache = function(){
-    var btn = document.getElementById('btn-refresh-prices');
+  window.refreshPriceCache = function(){    var btn = document.getElementById('btn-refresh-prices');
     if (btn) { btn.disabled = true; btn.textContent = 'Refreshing…'; }
     fetch('/api/price/refresh', { method: 'POST' })
       .then(function(r){ return r.json(); })
@@ -671,6 +682,46 @@
   // Initialize image status polling
   pollImageStatus();
   setInterval(pollImageStatus, 10000); // Poll every 10s
+
+  // Rulings cache status
+  function pollRulingsStatus(){
+    fetch('/setup/rulings-status', { cache: 'no-store' })
+      .then(function(r){ return r.json(); })
+      .then(function(data){
+        var el = document.getElementById('rulings-cache-status');
+        if (!el) return;
+        if (data.exists) {
+          el.textContent = 'Cache found — ' + data.card_count.toLocaleString() + ' cards • Last built: ' + data.built_at;
+          el.style.color = '';
+        } else {
+          el.textContent = 'No cache yet. Click "Refresh Rulings Cache" to build it. The live Scryfall fallback handles misses until then.';
+          el.style.color = '#94a3b8';
+        }
+      })
+      .catch(function(){
+        var el = document.getElementById('rulings-cache-status');
+        if (el) el.textContent = 'Unable to check status.';
+      });
+  }
+
+  window.refreshRulingsCache = function(){
+    var btn = document.getElementById('btn-refresh-rulings');
+    if (!confirm('Download Scryfall rulings bulk file (~25 MB) and build the local cache? This runs in the background and takes 1-2 minutes.')) return;
+    if (btn) { btn.disabled = true; btn.textContent = 'Building… (check container logs)'; }
+    fetch('/setup/refresh-rulings', { method: 'POST' })
+      .then(function(r){ return r.json(); })
+      .then(function(data){
+        if (data.ok) {
+          if (btn) btn.textContent = 'Running in background — check logs for progress.';
+          setTimeout(function(){ if (btn) { btn.disabled = false; btn.textContent = 'Refresh Rulings Cache'; } pollRulingsStatus(); }, 10000);
+        } else {
+          if (btn) { btn.disabled = false; btn.textContent = 'Start failed — see logs'; setTimeout(function(){ btn.textContent = 'Refresh Rulings Cache'; }, 3000); }
+        }
+      })
+      .catch(function(){ if (btn) { btn.disabled = false; btn.textContent = 'Refresh Rulings Cache'; } });
+  };
+
+  pollRulingsStatus();
 
   setInterval(poll, 3000);
   poll();

--- a/code/web/templates/themes/catalog_simple.html
+++ b/code/web/templates/themes/catalog_simple.html
@@ -2,10 +2,8 @@
 {% block content %}
 <div class="page-header">
   <h2>Themes</h2>
+  <p class="muted" style="font-size:.875rem;">See a theme that's missing or might be set up wrong? <a href="https://github.com/mwisnowski/mtg_python_deckbuilder/issues/new?template=general-theme-request.md" target="_blank" rel="noopener" style="color: var(--accent); text-decoration: underline;">Submit a request here</a>.</p>
 </div>
-<p style="margin-bottom: 1rem; font-size: .875rem;">
-  See a theme that's missing or might be set up wrong? <a href="https://github.com/mwisnowski/mtg_python_deckbuilder/issues/new?template=general-theme-request.md" target="_blank" rel="noopener" style="color: var(--accent); text-decoration: underline;">Submit a request here</a>.
-</p>
 <div id="theme-catalog-simple">
   <div class="flex gap-3 flex-wrap mb-3.5 items-end">
     <div class="flex-1 min-w-[220px] relative">


### PR DESCRIPTION
## Summary

Overhauls the card detail page with a full redesign, adds official rulings (Scryfall bulk data cache), and significantly improves the owned library UX with filtering parity to the card browser. Also adds cross-navigation between the owned library and card detail pages.

## Changes

### Added
- **Card detail page** (`/cards/{name}`): 2-column grid layout with stats table, oracle text with inline mana symbols, theme tag chips, external links, live price panel, official rulings panel (expandable), and similar cards section (up to 15)
- **Rulings service** (`code/web/services/rulings.py`): cache-first lookup with rate-limited live Scryfall fallback
- **Rulings cache builder** (`code/file_setup/rulings_cache.py`): downloads Scryfall bulk rulings file, writes `card_files/processed/rulings_cache.json` keyed by scryfallID; integrated into setup pipeline
- **Owned library redesign**: sticky/collapsible filter panel, CMC/power/toughness range filters, theme multi-select with chip UI, card name autocomplete, full-page scroll
- **Card Details button** on owned library tiles linking to `/cards/{name}?ref=owned`
- **Smart back button** on card detail page: reads `ref` query param to show "Back to Owned Library" or "Back to Card Browser"
- **Collapsible filter panels** on both card browser and owned library with `localStorage` persistence and active filter count badge
- **Card browser sticky filter bar**

### Fixed
- **Similar cards refresh button 404**: `/{card_name:path}/similar` HTMX endpoint moved before the `/{card_name:path}` catch-all route — the greedy `:path` matcher was capturing `/similar` as part of the card name
- **LQIP blur on cached images**: `img.complete` guard prevents already-loaded images from staying blurred permanently

See `CHANGELOG.md` for full details.