### PR TITLE
feat: user authentication, admin panel, audit log, and SMTP email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -204,6 +204,24 @@ TERM=xterm-256color                 # Terminal color capability.
 DEBIAN_FRONTEND=noninteractive      # Suppress apt UI in Docker builds.
 
 ############################
+# User Authentication
+############################
+# SESSION_SECRET=change-me-to-a-long-random-secret  # Required in production.
+#   Generate with: openssl rand -hex 32
+#   If unset, a random key is generated per restart (all sessions invalidated on restart).
+# SESSION_SECURE_COOKIES=0          # 1=set Secure flag on session cookie (requires HTTPS).
+
+# SMTP (password reset emails)
+# If SMTP_HOST is not set, reset URLs are written to the app log instead of emailed.
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=587                     # 587=STARTTLS (default), 465=SSL
+# SMTP_USERNAME=user@example.com
+# SMTP_PASSWORD=your-smtp-password
+# SMTP_FROM=noreply@example.com
+# SMTP_TLS=1                        # 1=STARTTLS (default for port 587); 0=plain
+# SMTP_SSL=0                        # 1=SSL (use with port 465)
+
+############################
 # Editorial / Theme Catalog (Phase D) – Advanced
 ############################
 # The following variables control automated theme catalog generation,

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ RELEASE_NOTES.md
 .venv/
 __pycache__/
 
+# Secrets — never commit credentials
+secrets.env
+
 .github/*.md
 
 config/themes/catalog/
@@ -35,6 +38,7 @@ card_files/*
 
 deck_files/
 dist/
+data/
 
 logs/
 !logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,18 @@ This format follows Keep a Changelog principles and aims for Semantic Versioning
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- **User accounts**: Self-service registration, login, logout, and per-user file isolation (`deck_files/{user_id}/`, `owned_cards/{user_id}/`, `config/{user_id}/`)
+- **Admin panel** (`/admin/`): Create, deactivate, and delete accounts; grant/revoke admin role; change passwords when SMTP is not configured (hides Change Password when users can self-serve via forgot-password)
+- **Env-based admin account**: Synthetic admin configured via `ADMIN_USERNAME`/`ADMIN_PASSWORD` in `secrets.env`; disable with `ADMIN_ENABLED=0` after promoting a real DB user to admin
+- **Profile page** (`/auth/profile`): Authenticated users can change their own password
+- **Audit log** (`/admin/audit`): Login, logout, failed attempts, registration, and all admin actions recorded; capped at 10,000 rows
+- **Welcome & account-created emails**: New registrants receive a welcome email; admin-created accounts receive a set-password link — both require SMTP to be configured
+- **Password reset**: Forgot-password flow with signed, time-limited email tokens; reset URL logged instead when SMTP is not configured; form replaced with a "contact your administrator" message when SMTP is disabled
+- **Login rate limiting**: Per-IP (5 attempts / 10 min) and per-username (10 attempts / 15 min) lockout to slow brute-force attempts
+- **`secrets.env` / `secrets.env.example`**: Gitignored credential file (`SESSION_SECRET`, `ADMIN_*`, `SMTP_*`) loaded via compose `env_file`; example template committed for reference
 
 ### Changed
-_No unreleased changes yet_
-
-### Fixed
-_No unreleased changes yet_
-
-### Removed
-_No unreleased changes yet_
+- Setup, Diagnostics, and Logs pages restricted to admin accounts; non-admin users see an informational note on the homepage when setup has not been run
 
 ## [4.8.3] - 2026-07-14
 ### Fixed

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -365,10 +365,36 @@ See `.env.example` for the full catalog. Common knobs:
 
 Advanced editorial and theme-catalog knobs (`EDITORIAL_*`, `SPLASH_ADAPTIVE`, etc.) are documented inline in `docker-compose.yml` and `.env.example`.
 
+### User authentication & email
+
+Sensitive credentials (`SESSION_SECRET`, admin account, SMTP) belong in `secrets.env` — not in `docker-compose.yml`. Copy `secrets.env.example` to `secrets.env` and fill in your values; the file is gitignored and loaded automatically at compose startup.
+
+```bash
+cp secrets.env.example secrets.env
+# edit secrets.env with your actual values
+```
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SESSION_SECRET` | _(random)_ | Secret key used to sign session cookies. **Set this in production** — if unset, a random key is generated on each restart, invalidating all existing sessions. Generate with `openssl rand -hex 32`. Set in `secrets.env`. |
+| `SESSION_SECURE_COOKIES` | `0` | Set to `1` to add the `Secure` flag to session cookies (requires HTTPS). |
+| `ADMIN_USERNAME` | _(unset)_ | Username for the env-based admin account. If unset, no synthetic admin exists. Set in `secrets.env`. |
+| `ADMIN_PASSWORD` | _(unset)_ | Password for the env-based admin account. Set in `secrets.env`. |
+| `ADMIN_ENABLED` | `1` | Set to `0` to disable the env-based admin after promoting a DB user to admin role. |
+| `ENABLE_SMTP` | `1` | Set to `0` to disable email delivery even when SMTP credentials are present in `secrets.env`. |
+| `SMTP_HOST` | _(unset)_ | SMTP server hostname. If unset (or `ENABLE_SMTP=0`), password-reset URLs are written to the app log instead of emailed. Set in `secrets.env`. |
+| `SMTP_PORT` | `587` | SMTP port. Use `587` for STARTTLS (default) or `465` for SSL. |
+| `SMTP_USERNAME` | _(unset)_ | SMTP login username. Set in `secrets.env`. |
+| `SMTP_PASSWORD` | _(unset)_ | SMTP login password. Set in `secrets.env`. |
+| `SMTP_FROM` | _(unset)_ | Sender address for emails (e.g. `noreply@example.com`). Set in `secrets.env`. |
+| `SMTP_TLS` | `1` | `1` = STARTTLS (default for port 587); `0` = plain. |
+| `SMTP_SSL` | `0` | `1` = SSL (use with port 465). |
+
 ## Shared volumes
 
 | Host path | Container path | Contents |
 | --- | --- | --- |
+| `data/` | `/app/data` | SQLite user database (`users.db`). Persist this volume to keep user accounts across restarts. |
 | `deck_files/` | `/app/deck_files` | CSV/TXT exports, summary JSON, compliance reports. |
 | `logs/` | `/app/logs` | Application logs and taxonomy snapshots. |
 | `csv_files/` | `/app/csv_files` | Card datasets, commander catalog, tagging flags. |
@@ -399,3 +425,7 @@ Use the `--compat-snapshot` or other script arguments as needed.
 - **Long first boot:** dataset downloads and tagging can take several minutes the first time. Watch progress at `/setup`.
 - **Random build hangs:** lower `RANDOM_MAX_ATTEMPTS` or raise `RANDOM_TIMEOUT_MS`, and confirm your theme overrides are valid slugs via `/themes/`.
 - **Commander catalog outdated:** rerun the refresh command above or delete `card_files/processed/.tagging_complete.json` to force a full rebuild on next start.
+- **Can't log in / sessions reset on restart:** confirm `SESSION_SECRET` is set in `secrets.env` and not left blank.
+- **Admin account not working:** verify `ADMIN_USERNAME` and `ADMIN_PASSWORD` are set in `secrets.env` (plain `KEY=VALUE` format, no quotes). Check that `ADMIN_ENABLED` is not `0`.
+- **Password-reset emails not arriving:** confirm `SMTP_HOST` is set and `ENABLE_SMTP=1` in `secrets.env`/`docker-compose.yml`. If SMTP is not configured, reset links are printed to the app log (`logs/`).
+- **Rate-limited login:** per-IP lockout (5 attempts/10 min) and per-username lockout (10 attempts/15 min) are in-memory and reset on container restart.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A web-first Commander/EDH deckbuilder with a shared core for CLI, headless, and 
   - [Diagnostics](#diagnostics)
   - [View Logs](#view-logs)
   - [Help & Guides](#help--guides)
+- [User accounts](#user-accounts)
 - [CLI & headless flows](#cli--headless-flows)
 - [Data, exports, and volumes](#data-exports-and-volumes)
 - [Environment variables](#environment-variables)
@@ -49,6 +50,8 @@ Pick the path that fits your setup. All commands target Windows PowerShell.
 docker compose up --build --no-deps -d web
 ```
 The Web UI starts on http://localhost:8080. First boot seeds data, refreshes decks, and tags cards automatically (see env defaults in `docker-compose.yml`). Use `docker compose stop web` / `docker compose start web` to pause or resume.
+
+> **Production tip**: copy `secrets.env.example` to `secrets.env` and fill in `SESSION_SECRET`, `ADMIN_USERNAME`/`ADMIN_PASSWORD`, and SMTP credentials before your first start. The file is gitignored and loaded automatically by compose.
 
 ### Option 2: Docker Hub image
 ```powershell
@@ -250,6 +253,48 @@ Browse all user guides without leaving the browser.
 
 ---
 
+## User accounts
+
+### Guest mode
+The app works without any sign-up. Unauthenticated visitors automatically use a shared Guest account; decks and configs are saved per-session but are not private.
+
+### Registration & login
+- Register at `/auth/register` (username, email, password).
+- Log in at `/auth/login`; a session cookie is set on success.
+- Your decks, owned-card lists, and saved configs are isolated in user-specific directories.
+- **Login protection**: 5 failed attempts per IP in 10 minutes, or 10 failed attempts for the same username in 15 minutes, triggers a temporary lockout.
+
+### Admin account
+An env-based admin account is used to access the admin panel and restricted pages (Setup, Diagnostics, Logs) before any DB users are promoted to admin.
+
+1. Copy `secrets.env.example` to `secrets.env`.
+2. Set `ADMIN_USERNAME`, `ADMIN_PASSWORD`, and `SESSION_SECRET` (generate with `openssl rand -hex 32`).
+3. Restart the container. Log in with those credentials to access `/admin/`.
+4. Once you have promoted a DB user to admin via the admin panel, you can disable the env account with `ADMIN_ENABLED=0`.
+
+### Admin panel (`/admin/`)
+- Create, activate/deactivate, and delete user accounts
+- Grant or revoke admin role (cannot revoke your own admin)
+- Change user passwords (shown only when SMTP is not configured)
+- View the audit log (`/admin/audit`) — last 200 auth and admin events
+
+### Profile page (`/auth/profile`)
+Logged-in users can change their own password from the profile page.
+
+### Password reset & SMTP
+Set `SMTP_HOST` (and other `SMTP_*` vars) in `secrets.env` to enable email. Three email types are sent when SMTP is configured:
+- **Welcome email** — on self-registration
+- **Account-created email** — when admin creates a user (includes a one-time set-password link)
+- **Password-reset email** — via the "Forgot password?" flow
+
+When SMTP is not configured, the "Forgot password?" page shows a "contact your administrator" message instead of the email form. Reset URLs are written to the app log for development use.
+
+Set `ENABLE_SMTP=0` in `docker-compose.yml` to disable email delivery without removing credentials from `secrets.env`.
+
+See [`DOCKER.md`](DOCKER.md) for the full list of SMTP and auth env vars.
+
+---
+
 ## CLI & headless flows
 The CLI and headless runners share the builder core.
 - Launch menu-driven CLI: `python code/main.py`.
@@ -288,6 +333,7 @@ Automatic land count and basics-to-duals ratio based on deck speed and color int
 ## Data, exports, and volumes
 | Host path | Container path | Purpose |
 | --- | --- | --- |
+| `data/` | `/app/data` | SQLite user database (`users.db`) — persist to keep accounts across restarts |
 | `deck_files/` | `/app/deck_files` | CSV/TXT exports, compliance JSON, summary JSON |
 | `logs/` | `/app/logs` | Application logs, taxonomy snapshots |
 | `csv_files/` | `/app/csv_files` | Card datasets, commander catalog, tagging metadata |
@@ -388,6 +434,21 @@ Most defaults are defined in `docker-compose.yml` and documented in `.env.exampl
 | `THEME_MIN_CARDS` | `5` | Minimum card count for themes. Themes with fewer cards are stripped from catalogs, JSON files, and parquet metadata during setup/tagging. Set to 1 to keep all themes. |
 | `WEB_PREFETCH` | `0` | Hover-intent prefetch on the Finished Decks page; preloads the deck view after a 100 ms hover delay to eliminate CSV-parse wait on click. |
 
+### User accounts & email
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `SESSION_SECRET` | _(random)_ | Secret key for signing session cookies. Set in production or sessions reset on every restart. Set in `secrets.env`. |
+| `SESSION_SECURE_COOKIES` | `0` | `1` = add `Secure` flag to cookies (requires HTTPS). |
+| `ADMIN_USERNAME` | _(unset)_ | Username for the env-based admin account. If unset, no synthetic admin exists. Set in `secrets.env`. |
+| `ADMIN_PASSWORD` | _(unset)_ | Password for the env-based admin account. Set in `secrets.env`. |
+| `ADMIN_ENABLED` | `1` | Set to `0` to disable the env-based admin after promoting a DB user to admin role. |
+| `ENABLE_SMTP` | `1` | Set to `0` to disable email delivery even when SMTP credentials are present. |
+| `SMTP_HOST` | _(unset)_ | SMTP server. If unset (or `ENABLE_SMTP=0`), password-reset links are logged instead of emailed. Set in `secrets.env`. |
+| `SMTP_PORT` | `587` | SMTP port (`587` STARTTLS / `465` SSL). |
+| `SMTP_USERNAME` / `SMTP_PASSWORD` | _(unset)_ | SMTP credentials. Set in `secrets.env`. |
+| `SMTP_FROM` | _(unset)_ | Sender address for all transactional emails. |
+| `SMTP_TLS` / `SMTP_SSL` | `1` / `0` | STARTTLS or SSL mode. |
+
 ### Paths & overrides
 | Variable | Default | Purpose |
 | --- | --- | --- |
@@ -468,6 +529,9 @@ When adding features, favor the web UI first, keep public builder APIs stable, a
 - **Owned-only build fails**: Confirm owned files were uploaded correctly and that `owned_cards/` is mounted.
 - **Random build stalls**: Lower `RANDOM_MAX_ATTEMPTS`, increase `RANDOM_TIMEOUT_MS`, and verify selected themes exist via `/themes/`.
 - **Commander list outdated**: Rerun the commander refresh script or Initial Setup.
+- **Sessions reset on restart**: Set `SESSION_SECRET` in `secrets.env` — without it a new random key is generated each time.
+- **Admin login not working**: Verify `ADMIN_USERNAME` and `ADMIN_PASSWORD` are set in `secrets.env` (plain `KEY=VALUE` format) and `ADMIN_ENABLED` is not `0`.
+- **Password-reset emails not arriving**: Confirm `SMTP_HOST` is set in `secrets.env` and `ENABLE_SMTP=1`. Reset URLs are logged to `logs/` when SMTP is not configured.
 
 ---
 

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -2,13 +2,18 @@
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- **User accounts**: Self-service registration, login, logout, and per-user file isolation
+- **Admin panel** (`/admin/`): Create, deactivate, and delete accounts; grant/revoke admin role; change passwords when SMTP is not configured (hides Change Password when users can self-serve via forgot-password)
+- **Env-based admin account**: Synthetic admin configured via `secrets.env`; disable with `ADMIN_ENABLED=0` after promoting a real DB user to admin
+- **Profile page** (`/auth/profile`): Authenticated users can change their own password
+- **Audit log** (`/admin/audit`): All auth and admin actions recorded, capped at 10,000 rows
+- **Welcome & account-created emails**: New registrants and admin-created accounts receive emails when SMTP is configured
+- **Password reset**: Forgot-password flow with time-limited tokens; URL logged when SMTP is not configured; form replaced with a "contact your administrator" message when SMTP is disabled
+- **Login rate limiting**: Per-IP and per-username lockout
+- **`secrets.env` / `secrets.env.example`**: Gitignored credential file for `SESSION_SECRET`, admin credentials, and SMTP settings
 
 ### Changed
-_No unreleased changes yet_
+- Setup, Diagnostics, and Logs pages restricted to admin accounts
 
 ### Fixed
-_No unreleased changes yet_
-
-### Removed
 _No unreleased changes yet_

--- a/code/tests/test_user_auth.py
+++ b/code/tests/test_user_auth.py
@@ -1,0 +1,550 @@
+"""Auth tests — grows across milestones.
+
+M1 coverage: user_db CRUD, password hashing, guest account.
+M2 coverage: session cookie signing, get_current_user / get_required_user, reset tokens.
+M3 coverage: auth routes (login, register, logout, forgot, reset) via TestClient.
+M4 coverage: email service — graceful degradation + SMTP send path.
+Uses a temp SQLite DB so no real data/ file is created or modified.
+"""
+from __future__ import annotations
+
+import pytest
+from pathlib import Path
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    """Redirect user_db to a temp directory so tests never touch data/users.db."""
+    import code.web.services.user_db as user_db
+    monkeypatch.setattr(user_db, "_DATA_DIR", tmp_path)
+    monkeypatch.setattr(user_db, "_DB_PATH", tmp_path / "users.db")
+    user_db.init_db()
+    yield
+
+
+# ---------------------------------------------------------------------------
+# M1: user_db
+# ---------------------------------------------------------------------------
+
+def test_create_user_hashes_password():
+    from code.web.services.user_db import create_user
+
+    user = create_user("alice", "alice@example.com", "hunter2")
+    assert user["password_hash"] != "hunter2"
+    assert user["password_hash"].startswith("$2b$")
+
+
+def test_verify_password_correct():
+    from code.web.services.user_db import create_user, verify_password
+
+    user = create_user("bob", "bob@example.com", "correcthorse")
+    assert verify_password("correcthorse", user["password_hash"]) is True
+
+
+def test_verify_password_wrong():
+    from code.web.services.user_db import create_user, verify_password
+
+    user = create_user("carol", "carol@example.com", "mypass")
+    assert verify_password("wrongpass", user["password_hash"]) is False
+
+
+def test_get_user_by_email_found():
+    from code.web.services.user_db import create_user, get_user_by_email
+
+    create_user("dave", "dave@example.com", "pw")
+    found = get_user_by_email("dave@example.com")
+    assert found is not None
+    assert found["username"] == "dave"
+
+
+def test_get_user_by_email_not_found():
+    from code.web.services.user_db import get_user_by_email
+
+    assert get_user_by_email("nobody@example.com") is None
+
+
+def test_get_user_by_id():
+    from code.web.services.user_db import create_user, get_user_by_id
+
+    user = create_user("eve", "eve@example.com", "pw")
+    found = get_user_by_id(user["id"])
+    assert found is not None
+    assert found["email"] == "eve@example.com"
+
+
+def test_duplicate_email_raises():
+    from code.web.services.user_db import create_user
+
+    create_user("frank", "dup@example.com", "pw1")
+    with pytest.raises(ValueError, match="already registered"):
+        create_user("frank2", "dup@example.com", "pw2")
+
+
+def test_duplicate_username_raises():
+    from code.web.services.user_db import create_user
+
+    create_user("grace", "grace@example.com", "pw1")
+    with pytest.raises(ValueError, match="already registered"):
+        create_user("grace", "grace2@example.com", "pw2")
+
+
+def test_ensure_guest_user_idempotent():
+    from code.web.services.user_db import ensure_guest_user, get_guest_user
+
+    ensure_guest_user()
+    ensure_guest_user()  # second call must not raise or duplicate
+    guest = get_guest_user()
+    assert guest is not None
+    assert guest["is_guest"] is True
+    assert guest["username"] == "guest"
+
+
+def test_update_password():
+    from code.web.services.user_db import create_user, update_password, verify_password
+
+    user = create_user("henry", "henry@example.com", "oldpass")
+    update_password(user["id"], "newpass")
+    # re-fetch
+    from code.web.services.user_db import get_user_by_id
+    updated = get_user_by_id(user["id"])
+    assert verify_password("newpass", updated["password_hash"]) is True
+    assert verify_password("oldpass", updated["password_hash"]) is False
+
+
+def test_user_is_active_by_default():
+    from code.web.services.user_db import create_user
+
+    user = create_user("iris", "iris@example.com", "pw")
+    assert user["is_active"] is True
+    assert user["is_guest"] is False
+
+
+def test_email_normalised_to_lowercase():
+    from code.web.services.user_db import create_user, get_user_by_email
+
+    create_user("jake", "JAKE@EXAMPLE.COM", "pw")
+    found = get_user_by_email("jake@example.com")
+    assert found is not None
+
+
+# ---------------------------------------------------------------------------
+# M2: auth — session cookies & reset tokens
+# ---------------------------------------------------------------------------
+
+import asyncio
+from unittest.mock import MagicMock
+
+
+def _mock_request(cookie_value: str | None = None) -> MagicMock:
+    req = MagicMock()
+    req.cookies = {
+        "mtg_session": cookie_value
+    } if cookie_value else {}
+    return req
+
+
+def _mock_response() -> MagicMock:
+    resp = MagicMock()
+    resp.set_cookie = MagicMock()
+    resp.delete_cookie = MagicMock()
+    return resp
+
+
+def test_create_and_decode_session_cookie():
+    from code.web.services.auth import create_session_cookie, _decode_session_token
+
+    resp = _mock_response()
+    create_session_cookie(resp, "user-uuid-123")
+    resp.set_cookie.assert_called_once()
+    _, kwargs = resp.set_cookie.call_args
+    token = kwargs["value"]
+    assert _decode_session_token(token) == "user-uuid-123"
+
+
+def test_clear_session_cookie():
+    from code.web.services.auth import clear_session_cookie
+
+    resp = _mock_response()
+    clear_session_cookie(resp)
+    resp.delete_cookie.assert_called_once_with(
+        key="mtg_session", httponly=True, samesite="lax"
+    )
+
+
+def test_decode_tampered_token_returns_none():
+    from code.web.services.auth import _decode_session_token
+
+    assert _decode_session_token("tampered.garbage.token") is None
+
+
+def test_get_current_user_with_valid_cookie():
+    from code.web.services.auth import create_session_cookie, _decode_session_token, get_current_user
+    from code.web.services.user_db import create_user, ensure_guest_user
+
+    ensure_guest_user()
+    user = create_user("session_user", "sess@example.com", "pw")
+    resp = _mock_response()
+    create_session_cookie(resp, user["id"])
+    _, kwargs = resp.set_cookie.call_args
+    token = kwargs["value"]
+
+    req = _mock_request(token)
+    result = asyncio.run(get_current_user(req))
+    assert result["id"] == user["id"]
+    assert result["username"] == "session_user"
+
+
+def test_get_current_user_no_cookie_returns_guest():
+    from code.web.services.auth import get_current_user
+    from code.web.services.user_db import ensure_guest_user
+
+    ensure_guest_user()
+    req = _mock_request()
+    result = asyncio.run(get_current_user(req))
+    assert result["is_guest"] is True
+
+
+def test_get_current_user_bad_cookie_returns_guest():
+    from code.web.services.auth import get_current_user
+    from code.web.services.user_db import ensure_guest_user
+
+    ensure_guest_user()
+    req = _mock_request("totally.invalid.cookie")
+    result = asyncio.run(get_current_user(req))
+    assert result["is_guest"] is True
+
+
+def test_get_required_user_raises_for_guest():
+    from fastapi import HTTPException
+    from code.web.services.auth import get_required_user
+    from code.web.services.user_db import ensure_guest_user
+
+    ensure_guest_user()
+    req = _mock_request()
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(get_required_user(req))
+    assert exc_info.value.status_code == 401
+
+
+def test_get_required_user_passes_for_authenticated():
+    from code.web.services.auth import create_session_cookie, get_required_user
+    from code.web.services.user_db import create_user, ensure_guest_user
+
+    ensure_guest_user()
+    user = create_user("req_user", "req@example.com", "pw")
+    resp = _mock_response()
+    create_session_cookie(resp, user["id"])
+    _, kwargs = resp.set_cookie.call_args
+    token = kwargs["value"]
+
+    req = _mock_request(token)
+    result = asyncio.run(get_required_user(req))
+    assert result["username"] == "req_user"
+
+
+def test_reset_token_roundtrip():
+    from code.web.services.auth import create_reset_token, verify_reset_token
+
+    token = create_reset_token("user@example.com")
+    assert verify_reset_token(token) == "user@example.com"
+
+
+def test_reset_token_tampered_returns_none():
+    from code.web.services.auth import verify_reset_token
+
+    assert verify_reset_token("bad.token.value") is None
+
+
+def test_reset_token_email_lowercased():
+    from code.web.services.auth import create_reset_token, verify_reset_token
+
+    token = create_reset_token("USER@EXAMPLE.COM")
+    assert verify_reset_token(token) == "user@example.com"
+
+
+# ---------------------------------------------------------------------------
+# M3: auth routes via TestClient
+# ---------------------------------------------------------------------------
+
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def client(_isolated_db):
+    """TestClient wired to the real FastAPI app with an isolated DB."""
+    from code.web.services.user_db import ensure_guest_user
+    ensure_guest_user()
+    from code.web.app import app
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+def test_login_page_renders(client):
+    resp = client.get("/auth/login")
+    assert resp.status_code == 200
+    assert "Log In" in resp.text
+
+
+def test_register_page_renders(client):
+    resp = client.get("/auth/register")
+    assert resp.status_code == 200
+    assert "Sign Up" in resp.text or "Create Account" in resp.text
+
+
+def test_register_and_login_flow(client):
+    # Register
+    resp = client.post("/auth/register", data={
+        "username": "flowuser", "email": "flow@example.com",
+        "password": "password123", "confirm": "password123",
+    }, follow_redirects=False)
+    assert resp.status_code == 303
+    assert resp.headers["location"] == "/"
+    assert "mtg_session" in resp.cookies
+
+    # Logout
+    resp2 = client.post("/auth/logout", follow_redirects=False)
+    assert resp2.status_code == 303
+
+    # Login
+    resp3 = client.post("/auth/login", data={
+        "login": "flow@example.com", "password": "password123",
+    }, follow_redirects=False)
+    assert resp3.status_code == 303
+    assert "mtg_session" in resp3.cookies
+
+
+def test_login_bad_password_returns_400(client):
+    from code.web.services.user_db import create_user
+    create_user("badpw", "badpw@example.com", "rightpassword")
+    resp = client.post("/auth/login", data={
+        "login": "badpw@example.com", "password": "wrongpassword",
+    })
+    assert resp.status_code == 400
+    assert "Invalid username/email or password" in resp.text
+
+
+def test_register_password_mismatch_returns_400(client):
+    resp = client.post("/auth/register", data={
+        "username": "x", "email": "x@x.com",
+        "password": "password1", "confirm": "password2",
+    })
+    assert resp.status_code == 400
+    assert "do not match" in resp.text
+
+
+def test_register_duplicate_email_returns_400(client):
+    client.post("/auth/register", data={
+        "username": "dup1", "email": "dup@example.com",
+        "password": "password1", "confirm": "password1",
+    })
+    resp = client.post("/auth/register", data={
+        "username": "dup2", "email": "dup@example.com",
+        "password": "password2", "confirm": "password2",
+    })
+    assert resp.status_code == 400
+    assert "already registered" in resp.text
+
+
+def test_forgot_page_renders(client):
+    resp = client.get("/auth/forgot")
+    assert resp.status_code == 200
+    assert "Forgot Password" in resp.text
+
+
+def test_forgot_post_always_shows_submitted(client):
+    # Non-existent email should still show submitted (no enumeration)
+    resp = client.post("/auth/forgot", data={"email": "nobody@example.com"})
+    assert resp.status_code == 200
+    assert "reset link" in resp.text.lower() or "inbox" in resp.text.lower()
+
+
+def test_reset_token_expired_returns_error(client):
+    resp = client.get("/auth/reset/bad.token.value")
+    assert resp.status_code == 200
+    assert "invalid or has expired" in resp.text.lower()
+
+
+def test_reset_flow(client):
+    from code.web.services.user_db import create_user, verify_password, get_user_by_email
+    from code.web.services.auth import create_reset_token
+    from code.web.routes.auth import _token_hash
+    from code.web.services.user_db import set_reset_token_hash
+
+    create_user("resetme", "resetme@example.com", "oldpassword")
+    user = get_user_by_email("resetme@example.com")
+    token = create_reset_token("resetme@example.com")
+    set_reset_token_hash(user["id"], _token_hash(token))
+
+    resp = client.post(f"/auth/reset/{token}", data={
+        "password": "newpassword", "confirm": "newpassword",
+    }, follow_redirects=False)
+    assert resp.status_code == 303
+    assert "/auth/login" in resp.headers["location"]
+
+    # Old password no longer works
+    updated = get_user_by_email("resetme@example.com")
+    assert verify_password("newpassword", updated["password_hash"])
+    assert not verify_password("oldpassword", updated["password_hash"])
+
+
+def test_reset_token_reuse_rejected(client):
+    from code.web.services.user_db import create_user, get_user_by_email
+    from code.web.services.auth import create_reset_token
+    from code.web.routes.auth import _token_hash
+    from code.web.services.user_db import set_reset_token_hash
+
+    create_user("onetime", "onetime@example.com", "oldpassword")
+    user = get_user_by_email("onetime@example.com")
+    token = create_reset_token("onetime@example.com")
+    set_reset_token_hash(user["id"], _token_hash(token))
+
+    # First use succeeds
+    client.post(f"/auth/reset/{token}", data={
+        "password": "newpassword", "confirm": "newpassword",
+    }, follow_redirects=False)
+
+    # Second use is rejected
+    resp = client.post(f"/auth/reset/{token}", data={
+        "password": "anotherpass", "confirm": "anotherpass",
+    })
+    assert "already been used" in resp.text
+
+
+# ---------------------------------------------------------------------------
+# M4: email service
+# ---------------------------------------------------------------------------
+
+import asyncio
+from unittest.mock import AsyncMock, patch, MagicMock
+
+
+def test_send_password_reset_no_smtp_logs_url(caplog):
+    """When SMTP_HOST is unset, log the URL and return without raising."""
+    import logging
+    from code.web.services import email as email_mod
+
+    original = email_mod._SMTP_HOST
+    try:
+        email_mod._SMTP_HOST = ""
+        with caplog.at_level(logging.WARNING, logger="code.web.services.email"):
+            asyncio.run(email_mod.send_password_reset("user@example.com", "http://localhost/reset/tok"))
+        assert any("http://localhost/reset/tok" in r.message for r in caplog.records)
+    finally:
+        email_mod._SMTP_HOST = original
+
+
+def test_send_password_reset_builds_correct_message():
+    """Email message has the right subject, to, and reset URL in body."""
+    from code.web.services.email import _build_reset_email
+
+    msg = _build_reset_email("user@example.com", "http://example.com/reset/abc")
+    assert msg["Subject"] == "MTG Deckbuilder \u2014 Reset your password"
+    assert msg["To"] == "user@example.com"
+    # Both plain-text and HTML parts contain the URL
+    payloads = [p.get_payload() for p in msg.get_payload()]
+    combined = " ".join(payloads)
+    assert "http://example.com/reset/abc" in combined
+
+
+def test_send_password_reset_calls_smtp(monkeypatch):
+    """When SMTP_HOST is set, aiosmtplib.SMTP is invoked correctly."""
+    from code.web.services import email as email_mod
+
+    mock_smtp = MagicMock()
+    mock_smtp.connect = AsyncMock()
+    mock_smtp.starttls = AsyncMock()
+    mock_smtp.login = AsyncMock()
+    mock_smtp.send_message = AsyncMock()
+    mock_smtp.quit = AsyncMock()
+
+    monkeypatch.setattr(email_mod, "_SMTP_HOST", "smtp.example.com")
+    monkeypatch.setattr(email_mod, "_SMTP_PORT", 587)
+    monkeypatch.setattr(email_mod, "_SMTP_USERNAME", "user")
+    monkeypatch.setattr(email_mod, "_SMTP_PASSWORD", "pass")
+    monkeypatch.setattr(email_mod, "_SMTP_TLS", True)
+    monkeypatch.setattr(email_mod, "_SMTP_SSL", False)
+    monkeypatch.setattr(email_mod.aiosmtplib, "SMTP", lambda **_: mock_smtp)
+
+    asyncio.run(email_mod.send_password_reset("to@example.com", "http://x.com/reset/t"))
+
+    mock_smtp.connect.assert_awaited_once()
+    mock_smtp.starttls.assert_awaited_once()
+    mock_smtp.login.assert_awaited_once_with("user", "pass")
+    mock_smtp.send_message.assert_awaited_once()
+    mock_smtp.quit.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# M5+M6: per-user file path scoping
+# ---------------------------------------------------------------------------
+
+def test_deck_dir_scoped_by_user(tmp_path, monkeypatch):
+    """Authenticated users get deck_files/{user_id}/ not deck_files/."""
+    import code.web.routes.decks as decks_mod
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("DECK_CONFIG", raising=False)
+
+    result = decks_mod._deck_dir("abc-123")
+    assert result == (tmp_path / "deck_files" / "abc-123").resolve()
+
+
+def test_deck_dir_guest(tmp_path, monkeypatch):
+    """Guest users get deck_files/guest/."""
+    import code.web.routes.decks as decks_mod
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("DECK_CONFIG", raising=False)
+
+    result = decks_mod._deck_dir("guest")
+    assert result == (tmp_path / "deck_files" / "guest").resolve()
+
+
+def test_config_dir_scoped_by_user(tmp_path, monkeypatch):
+    """Authenticated users get config/{user_id}/."""
+    import code.web.routes.configs as configs_mod
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("DECK_CONFIG", raising=False)
+
+    result = configs_mod._config_dir("user-xyz")
+    assert result == (tmp_path / "config" / "user-xyz").resolve()
+
+
+def test_owned_store_user_isolation(tmp_path, monkeypatch):
+    """Two different users have separate owned card stores."""
+    import code.web.services.owned_store as store
+    monkeypatch.setenv("OWNED_CARDS_DIR", str(tmp_path / "owned_cards"))
+
+    store.add_names(["Black Lotus"], "user-a")
+    store.add_names(["Sol Ring"], "user-b")
+
+    names_a = {n.lower() for n in store.get_names("user-a")}
+    names_b = {n.lower() for n in store.get_names("user-b")}
+    assert "black lotus" in names_a
+    assert "sol ring" in names_b
+    # No cross-contamination
+    assert "sol ring" not in names_a
+    assert "black lotus" not in names_b
+
+
+def test_forgot_route_shows_submitted_without_smtp(client, caplog):
+    """Forgot POST still shows success page when SMTP is unconfigured."""
+    import logging
+    from code.web.services.user_db import create_user
+    from code.web.services import email as email_mod
+
+    create_user("smtptest", "smtptest@example.com", "password1")
+
+    original = email_mod._SMTP_HOST
+    try:
+        email_mod._SMTP_HOST = ""
+        with caplog.at_level(logging.WARNING, logger="code.web.services.email"):
+            resp = client.post("/auth/forgot", data={"email": "smtptest@example.com"})
+        assert resp.status_code == 200
+        assert "reset link" in resp.text.lower() or "inbox" in resp.text.lower()
+        assert any("smtptest" not in r.message for r in caplog.records)  # URL logged, not email
+    finally:
+        email_mod._SMTP_HOST = original
+

--- a/code/type_definitions.py
+++ b/code/type_definitions.py
@@ -49,6 +49,18 @@ PlaneswalkerDF = pd.DataFrame
 NonPlaneswalkerDF = pd.DataFrame
 SorceryDF = pd.DataFrame
 
+# Auth / user accounts
+class User(TypedDict):
+    id: str               # UUID or "__admin__" for the synthetic admin account
+    username: str
+    email: str
+    password_hash: str
+    is_guest: bool
+    is_active: bool
+    is_admin: bool
+    created_at: float     # unix timestamp
+    updated_at: float     # unix timestamp
+
 # Bracket compliance typing
 Verdict = Literal["PASS", "WARN", "FAIL"]
 

--- a/code/web/app.py
+++ b/code/web/app.py
@@ -22,6 +22,9 @@ from .services.combo_utils import detect_all as _detect_all
 from .services.theme_catalog_loader import prewarm_common_filters, load_index
 from .services.commander_catalog_loader import load_commander_catalog
 from .services.tasks import get_session, new_sid, set_session_value
+from .services.user_db import init_db, ensure_guest_user
+from .services.audit_db import init_audit_db
+from .services.auth import AuthMiddleware
 from code.exceptions import DeckBuilderError
 from .utils.responses import deck_builder_error_response
 
@@ -43,6 +46,13 @@ async def _lifespan(app: FastAPI):  # pragma: no cover - simple infra glue
 
     Failures in warm tasks are intentionally swallowed to avoid blocking app start.
     """
+    # Initialise SQLite user store and ensure guest account exists
+    try:
+        init_db()
+        ensure_guest_user()
+        init_audit_db()
+    except Exception:
+        logger.exception("user_db: startup init failed — auth will not work")
     # Prewarm theme filter cache (guarded internally by env flag)
     try:
         prewarm_common_filters()
@@ -113,6 +123,7 @@ async def _lifespan(app: FastAPI):  # pragma: no cover - simple infra glue
 
 app = FastAPI(title="MTG Deckbuilder Web UI", lifespan=_lifespan)
 app.add_middleware(GZipMiddleware, minimum_size=500)
+app.add_middleware(AuthMiddleware)
 
 # Mount static if present
 if _STATIC_DIR.exists():
@@ -139,6 +150,10 @@ def _price_cache_built_at() -> "str | None":
         return None
 
 templates.env.globals["_price_cache_ts"] = _price_cache_built_at
+
+# Expose SMTP availability so templates can conditionally hide email-dependent UI
+from .services.email import is_smtp_configured as _is_smtp_configured
+templates.env.globals["smtp_configured"] = _is_smtp_configured()
 
 # Add custom Jinja2 filter for card image URLs
 def card_image_url(card_name: str, size: str = "normal") -> str:
@@ -951,7 +966,12 @@ async def request_id_middleware(request: Request, call_next):
 
 @app.get("/", response_class=HTMLResponse)
 async def home(request: Request) -> HTMLResponse:
-    return templates.TemplateResponse("home.html", {"request": request, "version": os.getenv("APP_VERSION", "dev")})
+    from .services.orchestrator import is_setup_ready
+    return templates.TemplateResponse("home.html", {
+        "request": request,
+        "version": os.getenv("APP_VERSION", "dev"),
+        "setup_ready": is_setup_ready(),
+    })
 
 
 @app.get("/docs/components", response_class=HTMLResponse)
@@ -2388,6 +2408,8 @@ from .routes import compare as compare_routes  # noqa: E402
 from .routes import api as api_routes  # noqa: E402
 from .routes import price as price_routes  # noqa: E402
 from .routes import docs as docs_routes  # noqa: E402
+from .routes import auth as auth_routes  # noqa: E402
+from .routes import admin as admin_routes  # noqa: E402
 app.include_router(build_routes.router)
 app.include_router(build_validation_routes.router, prefix="/build")
 app.include_router(build_multicopy_routes.router, prefix="/build")
@@ -2415,6 +2437,8 @@ app.include_router(compare_routes.router)
 app.include_router(docs_routes.router)
 app.include_router(api_routes.router)
 app.include_router(price_routes.router)
+app.include_router(auth_routes.router)
+app.include_router(admin_routes.router)
 
 # Warm validation cache early to reduce first-call latency in tests and dev
 try:
@@ -2605,8 +2629,10 @@ async def logs_page(
     level: str | None = Query(None),
 ) -> Response:
     if not SHOW_LOGS:
-        # Respect feature flag
         raise HTTPException(status_code=404, detail="Not Found")
+    _u = getattr(request.state, "current_user", None)
+    if not (_u and _u.get("is_admin")):
+        raise HTTPException(status_code=403, detail="Admin access required.")
     # Reuse status_logs logic
     data = await status_logs(tail=tail, q=q, level=level)
     lines: list[str]
@@ -2627,7 +2653,10 @@ async def logs_page(
 
 # Error trigger route for demoing HTMX/global error handling (feature-flagged)
 @app.get("/diagnostics/trigger-error")
-async def trigger_error(kind: str = Query("http")):
+async def trigger_error(request: Request, kind: str = Query("http")):
+    _u = getattr(request.state, "current_user", None)
+    if not (_u and _u.get("is_admin")):
+        raise HTTPException(status_code=403, detail="Admin access required.")
     if kind == "http":
         raise HTTPException(status_code=418, detail="Teapot: example error for testing")
     raise RuntimeError("Example unhandled error for testing")
@@ -2637,6 +2666,9 @@ async def trigger_error(kind: str = Query("http")):
 async def diagnostics_home(request: Request) -> HTMLResponse:
     if not SHOW_DIAGNOSTICS:
         raise HTTPException(status_code=404, detail="Not Found")
+    _u = getattr(request.state, "current_user", None)
+    if not (_u and _u.get("is_admin")):
+        raise HTTPException(status_code=403, detail="Admin access required.")
     # Build a sanitized context and pre-render to surface template errors clearly
     try:
         summary = load_merge_summary() or {"updated_at": None, "colors": {}}
@@ -2682,6 +2714,9 @@ async def diagnostics_perf(request: Request) -> HTMLResponse:
     """Synthetic scroll performance page (diagnostics only)."""
     if not SHOW_DIAGNOSTICS:
         raise HTTPException(status_code=404, detail="Not Found")
+    _u = getattr(request.state, "current_user", None)
+    if not (_u and _u.get("is_admin")):
+        raise HTTPException(status_code=403, detail="Admin access required.")
     return templates.TemplateResponse("diagnostics/perf.html", {"request": request})
 
 
@@ -2690,6 +2725,9 @@ async def diagnostics_quality(request: Request) -> HTMLResponse:
     """Theme catalog quality dashboard (diagnostics only)."""
     if not SHOW_DIAGNOSTICS:
         raise HTTPException(status_code=404, detail="Not Found")
+    _u = getattr(request.state, "current_user", None)
+    if not (_u and _u.get("is_admin")):
+        raise HTTPException(status_code=403, detail="Admin access required.")
     
     from .services.theme_catalog_loader import load_index as _load_idx
     

--- a/code/web/routes/admin.py
+++ b/code/web/routes/admin.py
@@ -1,0 +1,299 @@
+"""Admin routes — user management (create, change password, delete).
+
+Only accessible when logged in as the admin account (is_admin=True).
+Admin credentials come from ADMIN_USERNAME / ADMIN_PASSWORD env vars —
+they are never stored in the database.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+
+from fastapi import APIRouter, Request, Form
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from ..app import templates
+from ..services.user_db import (
+    create_user,
+    list_all_users,
+    delete_user,
+    update_password,
+    get_user_by_id,
+    set_user_admin,
+    set_user_active,
+    set_reset_token_hash,
+)
+from ..services.auth import create_reset_token, _get_client_ip
+from ..services.email import send_account_created_email
+from ..services.audit_db import log_event as _audit
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+logger = logging.getLogger(__name__)
+
+
+def _token_hash(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _require_admin(request: Request):
+    """Return current user or redirect. Raises nothing — callers check the return."""
+    user = getattr(request.state, "current_user", None)
+    return user if (user and user.get("is_admin")) else None
+
+
+# ---------------------------------------------------------------------------
+# Dashboard
+# ---------------------------------------------------------------------------
+
+@router.get("/", response_class=HTMLResponse)
+async def admin_index(request: Request):
+    if not _require_admin(request):
+        return RedirectResponse("/auth/login", status_code=303)
+    users = list_all_users()
+    return templates.TemplateResponse("admin/index.html", {
+        "request": request,
+        "users": users,
+        "error": None,
+        "success": None,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Create user
+# ---------------------------------------------------------------------------
+
+@router.post("/users/create", response_class=HTMLResponse)
+async def admin_create_user(
+    request: Request,
+    username: str = Form(...),
+    email: str = Form(...),
+    password: str = Form(...),
+):
+    if not _require_admin(request):
+        return RedirectResponse("/auth/login", status_code=303)
+    current = _require_admin(request)
+    ip = _get_client_ip(request)
+    users = list_all_users()
+    try:
+        new_user = create_user(username.strip(), email.strip(), password)
+        # Send set-password email so admin doesn't need to share credentials
+        try:
+            token = create_reset_token(email.strip())
+            set_reset_token_hash(new_user["id"], _token_hash(token))
+            set_pw_url = str(request.url_for("reset_page", token=token))
+            await send_account_created_email(email.strip(), username.strip(), set_pw_url)
+        except Exception:
+            logger.error("account-created email failed for %s", username.strip())
+        _audit("admin_create", user_id=current["id"], username=current["username"], ip=ip,
+               detail=f"created user '{username.strip()}'")
+        users = list_all_users()
+        return templates.TemplateResponse("admin/index.html", {
+            "request": request,
+            "users": users,
+            "error": None,
+            "success": f"User '{username.strip()}' created.",
+        })
+    except ValueError as exc:
+        return templates.TemplateResponse("admin/index.html", {
+            "request": request,
+            "users": users,
+            "error": str(exc),
+            "success": None,
+        }, status_code=400)
+
+
+# ---------------------------------------------------------------------------
+# Change password
+# ---------------------------------------------------------------------------
+
+@router.post("/users/{user_id}/password", response_class=HTMLResponse)
+async def admin_change_password(
+    request: Request,
+    user_id: str,
+    new_password: str = Form(...),
+):
+    if not _require_admin(request):
+        return RedirectResponse("/auth/login", status_code=303)
+    users = list_all_users()
+    user = get_user_by_id(user_id)
+    if not user:
+        return templates.TemplateResponse("admin/index.html", {
+            "request": request,
+            "users": users,
+            "error": "User not found.",
+            "success": None,
+        }, status_code=404)
+    if len(new_password) < 8:
+        return templates.TemplateResponse("admin/index.html", {
+            "request": request,
+            "users": users,
+            "error": "Password must be at least 8 characters.",
+            "success": None,
+        }, status_code=400)
+    try:
+        update_password(user_id, new_password)
+        current = _require_admin(request)
+        _audit("admin_change_password", user_id=current["id"], username=current["username"],
+               ip=_get_client_ip(request), detail=f"changed password for '{user['username']}'")
+        users = list_all_users()
+        return templates.TemplateResponse("admin/index.html", {
+            "request": request,
+            "users": users,
+            "error": None,
+            "success": f"Password updated for '{user['username']}'.",
+        })
+    except ValueError as exc:
+        return templates.TemplateResponse("admin/index.html", {
+            "request": request,
+            "users": users,
+            "error": str(exc),
+            "success": None,
+        }, status_code=400)
+
+
+# ---------------------------------------------------------------------------
+# Grant / revoke admin
+# ---------------------------------------------------------------------------
+
+@router.post("/users/{user_id}/grant-admin", response_class=HTMLResponse)
+async def admin_grant_admin(request: Request, user_id: str):
+    if not _require_admin(request):
+        return RedirectResponse("/auth/login", status_code=303)
+    try:
+        set_user_admin(user_id, True)
+        current = _require_admin(request)
+        users = list_all_users()
+        user = get_user_by_id(user_id)
+        _audit("admin_grant_admin", user_id=current["id"], username=current["username"],
+               ip=_get_client_ip(request), detail=f"granted admin to '{user['username'] if user else user_id}'")
+        return templates.TemplateResponse("admin/index.html", {
+            "request": request, "users": users,
+            "error": None, "success": f"Admin granted to '{user['username'] if user else user_id}'.",
+        })
+    except ValueError as exc:
+        users = list_all_users()
+        return templates.TemplateResponse("admin/index.html", {
+            "request": request, "users": users,
+            "error": str(exc), "success": None,
+        }, status_code=400)
+
+
+@router.post("/users/{user_id}/revoke-admin", response_class=HTMLResponse)
+async def admin_revoke_admin(request: Request, user_id: str):
+    if not _require_admin(request):
+        return RedirectResponse("/auth/login", status_code=303)
+    current = _require_admin(request)
+    if current["id"] == user_id:
+        users = list_all_users()
+        return templates.TemplateResponse("admin/index.html", {
+            "request": request, "users": users,
+            "error": "You cannot revoke your own admin access.", "success": None,
+        }, status_code=400)
+    try:
+        set_user_admin(user_id, False)
+        current = _require_admin(request)
+        users = list_all_users()
+        user = get_user_by_id(user_id)
+        _audit("admin_revoke_admin", user_id=current["id"], username=current["username"],
+               ip=_get_client_ip(request), detail=f"revoked admin from '{user['username'] if user else user_id}'")
+        return templates.TemplateResponse("admin/index.html", {
+            "request": request, "users": users,
+            "error": None, "success": f"Admin revoked from '{user['username'] if user else user_id}'.",
+        })
+    except ValueError as exc:
+        users = list_all_users()
+        return templates.TemplateResponse("admin/index.html", {
+            "request": request, "users": users,
+            "error": str(exc), "success": None,
+        }, status_code=400)
+
+
+# ---------------------------------------------------------------------------
+# Toggle active
+# ---------------------------------------------------------------------------
+
+@router.post("/users/{user_id}/toggle-active", response_class=HTMLResponse)
+async def admin_toggle_active(request: Request, user_id: str):
+    if not _require_admin(request):
+        return RedirectResponse("/auth/login", status_code=303)
+    current = _require_admin(request)
+    if current["id"] == user_id:
+        users = list_all_users()
+        return templates.TemplateResponse("admin/index.html", {
+            "request": request, "users": users,
+            "error": "You cannot deactivate your own account.", "success": None,
+        }, status_code=400)
+    target = get_user_by_id(user_id)
+    if not target:
+        users = list_all_users()
+        return templates.TemplateResponse("admin/index.html", {
+            "request": request, "users": users,
+            "error": "User not found.", "success": None,
+        }, status_code=404)
+    try:
+        new_state = not target["is_active"]
+        set_user_active(user_id, new_state)
+        _audit("admin_toggle_active", user_id=current["id"], username=current["username"],
+               ip=_get_client_ip(request),
+               detail=f"{'activated' if new_state else 'deactivated'} '{target['username']}'")
+        users = list_all_users()
+        label = "activated" if new_state else "deactivated"
+        return templates.TemplateResponse("admin/index.html", {
+            "request": request, "users": users,
+            "error": None, "success": f"User '{target['username']}' {label}.",
+        })
+    except ValueError as exc:
+        users = list_all_users()
+        return templates.TemplateResponse("admin/index.html", {
+            "request": request, "users": users,
+            "error": str(exc), "success": None,
+        }, status_code=400)
+
+
+# ---------------------------------------------------------------------------
+# Delete user
+# ---------------------------------------------------------------------------
+
+@router.post("/users/{user_id}/delete", response_class=HTMLResponse)
+async def admin_delete_user(
+    request: Request,
+    user_id: str,
+):
+    if not _require_admin(request):
+        return RedirectResponse("/auth/login", status_code=303)
+    current = _require_admin(request)
+    target = get_user_by_id(user_id)
+    try:
+        delete_user(user_id)
+        _audit("admin_delete", user_id=current["id"], username=current["username"],
+               ip=_get_client_ip(request), detail=f"deleted user '{target['username'] if target else user_id}'")
+        users = list_all_users()
+        return templates.TemplateResponse("admin/index.html", {
+            "request": request, "users": users,
+            "error": None, "success": "User deleted.",
+        })
+    except ValueError as exc:
+        users = list_all_users()
+        return templates.TemplateResponse("admin/index.html", {
+            "request": request, "users": users,
+            "error": str(exc), "success": None,
+        }, status_code=400)
+
+
+# ---------------------------------------------------------------------------
+# Audit log
+# ---------------------------------------------------------------------------
+
+@router.get("/audit", response_class=HTMLResponse)
+async def admin_audit(request: Request):
+    if not _require_admin(request):
+        return RedirectResponse("/auth/login", status_code=303)
+    from ..services.audit_db import get_recent_events
+    import datetime as _dt
+    events = get_recent_events(200)
+    for e in events:
+        e["created_at_fmt"] = _dt.datetime.fromtimestamp(e["created_at"]).strftime("%Y-%m-%d %H:%M:%S")
+    return templates.TemplateResponse("admin/audit.html", {
+        "request": request,
+        "events": events,
+    })

--- a/code/web/routes/auth.py
+++ b/code/web/routes/auth.py
@@ -1,0 +1,332 @@
+"""Auth routes: login, register, logout, forgot password, reset password."""
+from __future__ import annotations
+
+import hashlib
+import logging
+
+from fastapi import APIRouter, Request, Form
+from fastapi.responses import HTMLResponse, RedirectResponse
+
+from ..app import templates
+from ..services.auth import (
+    create_session_cookie,
+    clear_session_cookie,
+    create_reset_token,
+    verify_reset_token,
+    is_admin_login,
+    _ADMIN_ID,
+    _get_client_ip,
+    check_rate_limit,
+    record_failed_login,
+    clear_failed_logins,
+    check_username_rate_limit,
+    record_failed_username,
+    clear_failed_username,
+)
+from ..services.user_db import (
+    create_user,
+    get_user_by_email,
+    get_user_by_login,
+    verify_password,
+    update_password,
+    set_reset_token_hash,
+    consume_reset_token,
+)
+from ..services.email import send_password_reset, send_welcome_email
+from ..services.audit_db import log_event as _audit
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+logger = logging.getLogger(__name__)
+
+
+def _token_hash(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+def _current_user(request: Request):
+    return getattr(request.state, "current_user", None)
+
+
+# ---------------------------------------------------------------------------
+# Login
+# ---------------------------------------------------------------------------
+
+@router.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request, reset: str = ""):
+    if _current_user(request) and not _current_user(request).get("is_guest"):
+        return RedirectResponse("/", status_code=303)
+    return templates.TemplateResponse("auth/login.html", {
+        "request": request,
+        "error": None,
+        "reset_success": reset == "1",
+    })
+
+
+@router.post("/login", response_class=HTMLResponse)
+async def login_post(
+    request: Request,
+    login: str = Form(...),
+    password: str = Form(...),
+):
+    ip = _get_client_ip(request)
+    if check_rate_limit(ip):
+        _audit("rate_limited_ip", ip=ip, username=login)
+        return templates.TemplateResponse("auth/login.html", {
+            "request": request,
+            "error": "Too many failed login attempts. Please wait 10 minutes and try again.",
+            "reset_success": False,
+        }, status_code=429)
+    if check_username_rate_limit(login):
+        _audit("rate_limited_username", ip=ip, username=login)
+        return templates.TemplateResponse("auth/login.html", {
+            "request": request,
+            "error": "Too many failed login attempts. Please wait 15 minutes and try again.",
+            "reset_success": False,
+        }, status_code=429)
+    # Check admin credentials first (bypasses DB entirely)
+    if is_admin_login(login, password):
+        clear_failed_logins(ip)
+        clear_failed_username(login)
+        _audit("login", username=login, ip=ip)
+        resp = RedirectResponse("/", status_code=303)
+        create_session_cookie(resp, _ADMIN_ID)
+        return resp
+    user = get_user_by_login(login)
+    if not user or not verify_password(password, user["password_hash"]) or not user["is_active"]:
+        record_failed_login(ip)
+        record_failed_username(login)
+        _audit("login_failed", ip=ip, username=login)
+        return templates.TemplateResponse("auth/login.html", {
+            "request": request,
+            "error": "Invalid username/email or password.",
+            "reset_success": False,
+        }, status_code=400)
+    clear_failed_logins(ip)
+    clear_failed_username(login)
+    _audit("login", user_id=user["id"], username=user["username"], ip=ip)
+    resp = RedirectResponse("/", status_code=303)
+    create_session_cookie(resp, user["id"])
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Register
+# ---------------------------------------------------------------------------
+
+@router.get("/register", response_class=HTMLResponse)
+async def register_page(request: Request):
+    if _current_user(request) and not _current_user(request).get("is_guest"):
+        return RedirectResponse("/", status_code=303)
+    return templates.TemplateResponse("auth/register.html", {
+        "request": request,
+        "error": None,
+    })
+
+
+@router.post("/register", response_class=HTMLResponse)
+async def register_post(
+    request: Request,
+    username: str = Form(...),
+    email: str = Form(...),
+    password: str = Form(...),
+    confirm: str = Form(...),
+):
+    import os as _os
+    admin_username = _os.getenv("ADMIN_USERNAME", "").strip().lower()
+    if admin_username and username.strip().lower() == admin_username:
+        return templates.TemplateResponse("auth/register.html", {
+            "request": request,
+            "error": "That username is not available.",
+        }, status_code=400)
+    if password != confirm:
+        return templates.TemplateResponse("auth/register.html", {
+            "request": request,
+            "error": "Passwords do not match.",
+        }, status_code=400)
+    if len(password) < 8:
+        return templates.TemplateResponse("auth/register.html", {
+            "request": request,
+            "error": "Password must be at least 8 characters.",
+        }, status_code=400)
+    try:
+        user = create_user(username.strip(), email.strip(), password)
+    except ValueError as exc:
+        return templates.TemplateResponse("auth/register.html", {
+            "request": request,
+            "error": str(exc),
+        }, status_code=400)
+    login_url = str(request.url_for("login_page"))
+    try:
+        await send_welcome_email(email.strip(), username.strip(), login_url)
+    except Exception:
+        logger.error("Welcome email failed for new user %s", username.strip())
+    _audit("register", user_id=user["id"], username=user["username"], ip=_get_client_ip(request))
+    resp = RedirectResponse("/", status_code=303)
+    create_session_cookie(resp, user["id"])
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Logout
+# ---------------------------------------------------------------------------
+
+@router.post("/logout")
+async def logout(request: Request):
+    user = _current_user(request)
+    if user and not user.get("is_guest"):
+        _audit("logout", user_id=user["id"], username=user["username"], ip=_get_client_ip(request))
+    resp = RedirectResponse("/", status_code=303)
+    clear_session_cookie(resp)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Forgot password
+# ---------------------------------------------------------------------------
+
+@router.get("/forgot", response_class=HTMLResponse)
+async def forgot_page(request: Request):
+    return templates.TemplateResponse("auth/forgot.html", {
+        "request": request,
+        "submitted": False,
+        "error": None,
+    })
+
+
+@router.post("/forgot", response_class=HTMLResponse)
+async def forgot_post(request: Request, email: str = Form(...)):
+    user = get_user_by_email(email)
+    if user and not user["is_guest"] and user["is_active"]:
+        token = create_reset_token(email)
+        set_reset_token_hash(user["id"], _token_hash(token))
+        reset_url = str(request.url_for("reset_page", token=token))
+        try:
+            await send_password_reset(email, reset_url)
+        except Exception:
+            logger.error("Failed to send reset email to %s", email)
+    # Always show "submitted" to avoid email enumeration
+    return templates.TemplateResponse("auth/forgot.html", {
+        "request": request,
+        "submitted": True,
+        "error": None,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Reset password
+# ---------------------------------------------------------------------------
+
+@router.get("/reset/{token}", response_class=HTMLResponse, name="reset_page")
+async def reset_page(request: Request, token: str):
+    email = verify_reset_token(token)
+    if not email:
+        return templates.TemplateResponse("auth/reset.html", {
+            "request": request,
+            "token": token,
+            "error": "This link is invalid or has expired.",
+            "expired": True,
+        })
+    return templates.TemplateResponse("auth/reset.html", {
+        "request": request,
+        "token": token,
+        "error": None,
+        "expired": False,
+    })
+
+
+@router.post("/reset/{token}", response_class=HTMLResponse)
+async def reset_post(
+    request: Request,
+    token: str,
+    password: str = Form(...),
+    confirm: str = Form(...),
+):
+    email = verify_reset_token(token)
+    if not email:
+        return templates.TemplateResponse("auth/reset.html", {
+            "request": request,
+            "token": token,
+            "error": "This link is invalid or has expired.",
+            "expired": True,
+        })
+    if password != confirm:
+        return templates.TemplateResponse("auth/reset.html", {
+            "request": request,
+            "token": token,
+            "error": "Passwords do not match.",
+            "expired": False,
+        }, status_code=400)
+    if len(password) < 8:
+        return templates.TemplateResponse("auth/reset.html", {
+            "request": request,
+            "token": token,
+            "error": "Password must be at least 8 characters.",
+            "expired": False,
+        }, status_code=400)
+    user = get_user_by_email(email)
+    if not user:
+        return templates.TemplateResponse("auth/reset.html", {
+            "request": request,
+            "token": token,
+            "error": "Account not found.",
+            "expired": True,
+        })
+    if not consume_reset_token(user["id"], _token_hash(token)):
+        return templates.TemplateResponse("auth/reset.html", {
+            "request": request,
+            "token": token,
+            "error": "This link has already been used.",
+            "expired": True,
+        })
+    update_password(user["id"], password)
+    _audit("password_reset_complete", user_id=user["id"], username=user["username"], ip=_get_client_ip(request))
+    return RedirectResponse("/auth/login?reset=1", status_code=303)
+
+
+# ---------------------------------------------------------------------------
+# Profile (self-service password change)
+# ---------------------------------------------------------------------------
+
+@router.get("/profile", response_class=HTMLResponse, name="profile_page")
+async def profile_page(request: Request):
+    user = _current_user(request)
+    if not user or user.get("is_guest"):
+        return RedirectResponse("/auth/login", status_code=303)
+    return templates.TemplateResponse("auth/profile.html", {
+        "request": request,
+        "error": None,
+        "success": None,
+    })
+
+
+@router.post("/profile/password", response_class=HTMLResponse)
+async def profile_change_password(
+    request: Request,
+    current_password: str = Form(...),
+    new_password: str = Form(...),
+    confirm: str = Form(...),
+):
+    user = _current_user(request)
+    if not user or user.get("is_guest"):
+        return RedirectResponse("/auth/login", status_code=303)
+
+    def _err(msg: str):
+        return templates.TemplateResponse("auth/profile.html", {
+            "request": request, "error": msg, "success": None,
+        }, status_code=400)
+
+    if user["id"] == _ADMIN_ID:
+        return _err("The admin password is managed via environment variables and cannot be changed here.")
+    if not verify_password(current_password, user["password_hash"]):
+        return _err("Current password is incorrect.")
+    if new_password != confirm:
+        return _err("New passwords do not match.")
+    if len(new_password) < 8:
+        return _err("New password must be at least 8 characters.")
+    update_password(user["id"], new_password)
+    _audit("password_change", user_id=user["id"], username=user["username"], ip=_get_client_ip(request))
+    return templates.TemplateResponse("auth/profile.html", {
+        "request": request,
+        "error": None,
+        "success": "Password updated successfully.",
+    })

--- a/code/web/routes/build_newflow.py
+++ b/code/web/routes/build_newflow.py
@@ -44,6 +44,18 @@ from ..services import custom_theme_manager as theme_mgr
 router = APIRouter()
 
 
+def _user_deck_dir(request: Request) -> str:
+    """Return the scoped deck export directory string for the current user."""
+    import os
+    from pathlib import Path
+    u = getattr(getattr(request, "state", None), "current_user", None)
+    uid = str(u["id"]) if (u and not u.get("is_guest") and u.get("id")) else "guest"
+    base = os.getenv("DECK_EXPORTS")
+    if base:
+        return str((Path(base) / uid).resolve())
+    return str((Path.cwd() / "deck_files" / uid).resolve())
+
+
 # Pre-built JS-serialisable map of multi-copy archetypes for client-side popup detection.
 # Keys are lowercased card names; values contain what the popup needs.
 _ARCHETYPE_JS_MAP: dict[str, dict] = {
@@ -1012,6 +1024,7 @@ async def build_new_submit(
     if "replace_mode" not in sess:
         sess["replace_mode"] = True
     # Centralized staged context creation
+    sess["deck_dir"] = _user_deck_dir(request)
     sess["build_ctx"] = start_ctx_from_session(sess)
     
     # Validate and normalize build_count
@@ -1089,6 +1102,9 @@ async def build_new_submit(
             logging.getLogger(__name__).warning(f"[Batch] Failed to load color identity for {sess.get('commander')}: {e}")
             pass  # Not critical, synergy builder will skip basics if missing
         
+        # Include per-user deck directory so batch builds export to the right path
+        batch_config["deck_dir"] = _user_deck_dir(request)
+
         # Queue the batch
         batch_id = queue_builds(batch_config, build_count, sid)
         

--- a/code/web/routes/build_wizard.py
+++ b/code/web/routes/build_wizard.py
@@ -39,6 +39,18 @@ from .build_multicopy import _rebuild_ctx_with_multicopy
 router = APIRouter()
 
 
+def _user_deck_dir(request: Request) -> str:
+    """Return the scoped deck export directory string for the current user."""
+    import os
+    from pathlib import Path
+    u = getattr(getattr(request, "state", None), "current_user", None)
+    uid = str(u["id"]) if (u and not u.get("is_guest") and u.get("id")) else "guest"
+    base = os.getenv("DECK_EXPORTS")
+    if base:
+        return str((Path(base) / uid).resolve())
+    return str((Path.cwd() / "deck_files" / uid).resolve())
+
+
 def _merge_hx_trigger(response: Any, payload: dict[str, Any]) -> None:
     """Merge HX-Trigger header data into response."""
     if not payload or response is None:
@@ -968,6 +980,7 @@ async def build_step5_start(request: Request) -> HTMLResponse:
     try:
         import time as _time
         sess["build_id"] = str(int(_time.time() * 1000))
+        sess["deck_dir"] = _user_deck_dir(request)
         sess["build_ctx"] = start_ctx_from_session(sess)
         show_skipped = False
         try:
@@ -1014,6 +1027,7 @@ async def build_step5_continue(request: Request) -> HTMLResponse:
         return resp
     # Ensure build context exists; if not, start it first
     if not sess.get("build_ctx"):
+        sess["deck_dir"] = _user_deck_dir(request)
         sess["build_ctx"] = start_ctx_from_session(sess)
     else:
         # If context exists already, rebuild ONLY when the multi-copy selection changed or hasn't been applied yet
@@ -1105,6 +1119,7 @@ async def build_step5_rerun(request: Request) -> HTMLResponse:
         return resp
     # Rerun requires an existing context; if missing, create it and run first stage as rerun
     if not sess.get("build_ctx"):
+        sess["deck_dir"] = _user_deck_dir(request)
         sess["build_ctx"] = start_ctx_from_session(sess)
     else:
         # Ensure latest locks are reflected in the existing context
@@ -1207,6 +1222,7 @@ async def build_step5_rewind(request: Request, to: str = Form(...)) -> HTMLRespo
             ctx["last_visible_idx"] = int(target_i) - 1
     except Exception:
         # As a fallback, restart ctx and run forward until target
+        sess["deck_dir"] = _user_deck_dir(request)
         sess["build_ctx"] = start_ctx_from_session(sess)
         ctx = sess["build_ctx"]
         # Run forward until reaching target

--- a/code/web/routes/configs.py
+++ b/code/web/routes/configs.py
@@ -14,18 +14,33 @@ from ..services import orchestrator as orch
 router = APIRouter(prefix="/configs")
 
 
-def _config_dir() -> Path:
-    # Prefer explicit env var if provided, else default to ./config
+def _user_id(request) -> str:
+    """Return the scoped directory name for the current user."""
+    u = getattr(getattr(request, "state", None), "current_user", None)
+    if u and not u.get("is_guest") and u.get("id"):
+        return str(u["id"])
+    return "guest"
+
+
+def _deck_dir(user_id: str = "guest") -> Path:
+    p = os.getenv("DECK_EXPORTS")
+    if p:
+        return (Path(p) / user_id).resolve()
+    return (Path.cwd() / "deck_files" / user_id).resolve()
+
+
+def _config_dir(user_id: str = "guest") -> Path:
+    # Prefer explicit env var if provided, else default to ./config/{user_id}
     p = os.getenv("DECK_CONFIG")
     if p:
-        # If env points to a file, use its parent dir; else treat as dir
         pp = Path(p)
-        return (pp.parent if pp.suffix else pp).resolve()
-    return (Path.cwd() / "config").resolve()
+        base = pp.parent if pp.suffix else pp
+        return (base / user_id).resolve()
+    return (Path.cwd() / "config" / user_id).resolve()
 
 
-def _list_configs() -> list[dict]:
-    d = _config_dir()
+def _list_configs(user_id: str = "guest") -> list[dict]:
+    d = _config_dir(user_id)
     try:
         d.mkdir(parents=True, exist_ok=True)
     except Exception:
@@ -48,12 +63,13 @@ def _list_configs() -> list[dict]:
 
 @router.get("/", response_class=HTMLResponse)
 async def configs_index(request: Request) -> HTMLResponse:
-    items = _list_configs()
+    uid = _user_id(request)
+    items = _list_configs(uid)
     # Load example deck.json from the config directory, if present
     example_json = None
     example_name = "deck.json"
     try:
-        example_path = _config_dir() / example_name
+        example_path = _config_dir(uid) / example_name
         if example_path.exists() and example_path.is_file():
             example_json = example_path.read_text(encoding="utf-8")
     except Exception:
@@ -66,7 +82,8 @@ async def configs_index(request: Request) -> HTMLResponse:
 
 @router.get("/view", response_class=HTMLResponse)
 async def configs_view(request: Request, name: str) -> HTMLResponse:
-    base = _config_dir()
+    uid = _user_id(request)
+    base = _config_dir(uid)
     p = (base / name).resolve()
     # Safety: ensure the resolved path is within config dir
     try:
@@ -77,14 +94,14 @@ async def configs_view(request: Request, name: str) -> HTMLResponse:
     if not (p.exists() and p.is_file() and p.suffix.lower() == ".json"):
         return templates.TemplateResponse(
             "configs/index.html",
-            {"request": request, "items": _list_configs(), "error": "Config not found."},
+            {"request": request, "items": _list_configs(uid), "error": "Config not found."},
         )
     try:
         data = json.loads(p.read_text(encoding="utf-8"))
     except Exception as e:
         return templates.TemplateResponse(
             "configs/index.html",
-            {"request": request, "items": _list_configs(), "error": f"Failed to read JSON: {e}"},
+            {"request": request, "items": _list_configs(uid), "error": f"Failed to read JSON: {e}"},
         )
     return templates.TemplateResponse(
         "configs/view.html",
@@ -94,7 +111,8 @@ async def configs_view(request: Request, name: str) -> HTMLResponse:
 
 @router.post("/run", response_class=HTMLResponse)
 async def configs_run(request: Request, name: str = Form(...), use_owned_only: str | None = Form(None)) -> HTMLResponse:
-    base = _config_dir()
+    uid = _user_id(request)
+    base = _config_dir(uid)
     p = (base / name).resolve()
     try:
         if base not in p.parents and p != base:
@@ -104,14 +122,14 @@ async def configs_run(request: Request, name: str = Form(...), use_owned_only: s
     if not (p.exists() and p.is_file() and p.suffix.lower() == ".json"):
         return templates.TemplateResponse(
             "configs/index.html",
-            {"request": request, "items": _list_configs(), "error": "Config not found."},
+            {"request": request, "items": _list_configs(uid), "error": "Config not found."},
         )
     try:
         cfg = json.loads(p.read_text(encoding="utf-8"))
     except Exception as e:
         return templates.TemplateResponse(
             "configs/index.html",
-            {"request": request, "items": _list_configs(), "error": f"Failed to read JSON: {e}"},
+            {"request": request, "items": _list_configs(uid), "error": f"Failed to read JSON: {e}"},
         )
 
     commander = cfg.get("commander", "")
@@ -177,13 +195,15 @@ async def configs_run(request: Request, name: str = Form(...), use_owned_only: s
         bracket=bracket,
         ideals=ideals,
         tag_mode=tag_mode,
-    use_owned_only=owned_flag,
+        use_owned_only=owned_flag,
         owned_names=owned_names,
         # Thread combo prefs through staged headless run
         prefer_combos=prefer_combos,
         combo_target_count=combo_target_count,
         combo_balance=combo_balance,
+        deck_dir=str(_deck_dir(uid)),
     )
+
     if not res.get("ok"):
         return templates.TemplateResponse(
             "configs/run_result.html",
@@ -228,10 +248,11 @@ async def configs_upload(request: Request, file: UploadFile = File(...)) -> HTML
     except Exception as e:
         return templates.TemplateResponse(
             "configs/index.html",
-            {"request": request, "items": _list_configs(), "error": f"Invalid JSON: {e}"},
+            {"request": request, "items": _list_configs(_user_id(request)), "error": f"Invalid JSON: {e}"},
         )
     # Save to config dir with original filename (or unique)
-    d = _config_dir()
+    uid = _user_id(request)
+    d = _config_dir(uid)
     d.mkdir(parents=True, exist_ok=True)
     fname = file.filename or "config.json"
     out = d / fname
@@ -243,5 +264,5 @@ async def configs_upload(request: Request, file: UploadFile = File(...)) -> HTML
     out.write_text(json.dumps(data, indent=2), encoding="utf-8")
     return templates.TemplateResponse(
         "configs/index.html",
-        {"request": request, "items": _list_configs(), "notice": f"Uploaded {out.name}"},
+        {"request": request, "items": _list_configs(uid), "notice": f"Uploaded {out.name}"},
     )

--- a/code/web/routes/decks.py
+++ b/code/web/routes/decks.py
@@ -17,30 +17,39 @@ from ..app import ENABLE_BUDGET_MODE, ENABLE_PREFETCH
 router = APIRouter(prefix="/decks")
 
 
-def _deck_dir() -> Path:
-    # Prefer explicit env var if provided, else default to ./deck_files
+def _user_id(request: Request) -> str:
+    """Return the scoped directory name for the current user.
+
+    Authenticated users get their UUID; everyone else (including guest) uses 'guest'.
+    """
+    u = getattr(request.state, "current_user", None)
+    if u and not u.get("is_guest") and u.get("id"):
+        return str(u["id"])
+    return "guest"
+
+
+def _deck_dir(user_id: str = "guest") -> Path:
+    # Prefer explicit env var if provided, else default to ./deck_files/{user_id}
     p = os.getenv("DECK_EXPORTS")
     if p:
-        return Path(p).resolve()
-    return (Path.cwd() / "deck_files").resolve()
+        return (Path(p) / user_id).resolve()
+    return (Path.cwd() / "deck_files" / user_id).resolve()
 
 
-def _list_decks() -> list[dict]:
-    d = _deck_dir()
+def _list_from_dir(d: Path) -> list[dict]:
+    """Read CSV deck entries from a single directory."""
     try:
         d.mkdir(parents=True, exist_ok=True)
     except Exception:
         pass
     items: list[dict] = []
-    # Prefer CSV entries and pair with matching TXT if present
     for p in sorted(d.glob("*.csv"), key=lambda x: x.stat().st_mtime, reverse=True):
-        meta = {"name": p.name, "path": str(p), "mtime": p.stat().st_mtime}
+        meta: dict = {"name": p.name, "path": str(p), "mtime": p.stat().st_mtime}
         stem = p.stem
         txt = p.with_suffix('.txt')
         if txt.exists():
             meta["txt_name"] = txt.name
             meta["txt_path"] = str(txt)
-        # Prefer sidecar summary meta if present
         sidecar = p.with_suffix('.summary.json')
         if sidecar.exists():
             try:
@@ -55,7 +64,6 @@ def _list_decks() -> list[dict]:
                     meta["source"] = _m.get('source')
             except Exception:
                 pass
-        # Fallback to parsing commander/themes from filename convention Commander_Themes_YYYYMMDD
         if not meta.get("commander"):
             parts = stem.split('_')
             if len(parts) >= 3:
@@ -66,6 +74,78 @@ def _list_decks() -> list[dict]:
                 meta["tags"] = []
         items.append(meta)
     return items
+
+
+def _list_decks(user_id: str = "guest") -> list[dict]:
+    """Return decks from the user-scoped directory."""
+    return _list_from_dir(_deck_dir(user_id))
+
+
+def _list_guest_decks() -> list[dict]:
+    """Return decks from the shared guest directory (visible to all users)."""
+    return _list_from_dir(_deck_dir("guest"))
+
+
+def _list_legacy_decks() -> list[dict]:
+    """Return CSV files sitting directly in the root deck_files/ directory.
+
+    These are pre-auth builds that landed in the root before user accounts
+    were introduced.  They are visible to everyone.
+    """
+    root = Path(os.getenv("DECK_EXPORTS") or "deck_files").resolve()
+    if not root.exists():
+        return []
+    # Only files directly in root (not in sub-dirs like guest/ or uuid/)
+    return _list_from_dir(root)
+
+
+def _deck_base_for_section(uid: str, section: str) -> Path:
+    """Return the validated base directory for a given section key."""
+    if section == "guest":
+        return _deck_dir("guest")
+    if section == "legacy":
+        return Path(os.getenv("DECK_EXPORTS") or "deck_files").resolve()
+    return _deck_dir(uid)  # "mine" or unrecognised → user's own dir
+
+
+def _index_sections(uid: str) -> list[dict]:
+    """Build the ordered sections list for the deck index page."""
+    is_guest = uid == "guest"
+    sections = []
+
+    my_decks = _list_decks(uid)
+    sections.append({
+        "id": "mine",
+        "label": "Decks" if is_guest else "My Decks",
+        "subtitle": None if is_guest else "Decks built with your account.",
+        "decks": my_decks,
+    })
+
+    if not is_guest:
+        guest_decks = _list_guest_decks()
+        if guest_decks:
+            sections.append({
+                "id": "guest",
+                "label": "Community Builds",
+                "subtitle": "Decks built while not logged in — visible to everyone.",
+                "decks": guest_decks,
+            })
+
+    legacy_decks = _list_legacy_decks()
+    if legacy_decks:
+        # For legacy, exclude any files that are already the user's own deck (same filename)
+        my_names = {d["name"] for d in my_decks}
+        guest_names = {d["name"] for sec in sections if sec["id"] == "guest" for d in sec["decks"]}
+        filtered = [d for d in legacy_decks if d["name"] not in my_names and d["name"] not in guest_names]
+        if filtered:
+            sections.append({
+                "id": "legacy",
+                "label": "Legacy Decks",
+                "subtitle": "Decks from before user accounts were added — visible to everyone.",
+                "decks": filtered,
+            })
+
+    return sections
 
 
 def _safe_within(base: Path, target: Path) -> bool:
@@ -260,16 +340,17 @@ def _read_deck_counts(csv_path: Path) -> Dict[str, int]:
 
 @router.get("/", response_class=HTMLResponse)
 async def decks_index(request: Request) -> HTMLResponse:
-    items = _list_decks()
-    return templates.TemplateResponse("decks/index.html", {"request": request, "items": items})
+    uid = _user_id(request)
+    return templates.TemplateResponse("decks/index.html", {"request": request, "sections": _index_sections(uid)})
 
 
 @router.get("/view", response_class=HTMLResponse)
-async def decks_view(request: Request, name: str) -> HTMLResponse:
-    base = _deck_dir()
+async def decks_view(request: Request, name: str, section: str = "mine") -> HTMLResponse:
+    uid = _user_id(request)
+    base = _deck_base_for_section(uid, section)
     p = (base / name).resolve()
     if not _safe_within(base, p) or not (p.exists() and p.is_file() and p.suffix.lower() == ".csv"):
-        return templates.TemplateResponse("decks/index.html", {"request": request, "items": _list_decks(), "error": "Deck not found."})
+        return templates.TemplateResponse("decks/index.html", {"request": request, "sections": _index_sections(uid), "error": "Deck not found."})
 
     # Try to load sidecar summary JSON first
     summary = None
@@ -455,14 +536,16 @@ async def decks_view(request: Request, name: str) -> HTMLResponse:
 
 @router.get("/compare", response_class=HTMLResponse)
 async def decks_compare(request: Request, A: Optional[str] = None, B: Optional[str] = None) -> HTMLResponse:
-    """Compare two finished deck CSVs and show diffs.
+    """
+    Compare two finished deck CSVs and show diffs.
 
     Query params:
       - A: filename of first deck (e.g., Alena_..._20250827.csv)
       - B: filename of second deck
     """
-    base = _deck_dir()
-    items = _list_decks()
+    uid = _user_id(request)
+    base = _deck_dir(uid)
+    items = _list_decks(uid)
     # Build select options with friendly display labels
     options: List[Dict[str, str]] = []
     for it in items:
@@ -539,12 +622,13 @@ async def decks_compare(request: Request, A: Optional[str] = None, B: Optional[s
 @router.get("/pickups", response_class=HTMLResponse)
 async def decks_pickups(request: Request, name: str) -> HTMLResponse:
     """Show the pickups list for a deck that was built with budget mode enabled."""
-    base = _deck_dir()
+    uid = _user_id(request)
+    base = _deck_dir(uid)
     p = (base / name).resolve()
     if not _safe_within(base, p) or not (p.exists() and p.is_file() and p.suffix.lower() == ".csv"):
         return templates.TemplateResponse(
             "decks/index.html",
-            {"request": request, "items": _list_decks(), "error": "Deck not found."},
+            {"request": request, "sections": _index_sections(uid), "error": "Deck not found."},
         )
 
     meta_info: Dict[str, Any] = {}
@@ -627,9 +711,10 @@ async def decks_pickups(request: Request, name: str) -> HTMLResponse:
 
 
 @router.get("/download-csv")
-async def decks_download_csv(name: str) -> Response:
+async def decks_download_csv(request: Request, name: str, section: str = "mine") -> Response:
     """Serve a CSV export with live prices fetched at download time."""
-    base = _deck_dir()
+    uid = _user_id(request)
+    base = _deck_base_for_section(uid, section)
     p = (base / name).resolve()
     if not _safe_within(base, p) or not (p.exists() and p.is_file() and p.suffix.lower() == ".csv"):
         return HTMLResponse("File not found", status_code=404)
@@ -683,3 +768,43 @@ async def decks_download_csv(name: str) -> Response:
         media_type="text/csv",
         headers={"Content-Disposition": f'attachment; filename="{p.name}"'},
     )
+
+
+@router.post("/delete")
+async def decks_delete(request: Request, name: str, section: str = "mine") -> Response:
+    """Delete a finished deck and its sidecars.
+
+    - 'mine' section: any authenticated (non-guest) user may delete their own decks.
+    - 'guest' / 'legacy' sections: admin only.
+    """
+    uid = _user_id(request)
+    user = getattr(request.state, "current_user", None)
+    is_admin = bool(user and user.get("is_admin"))
+    is_guest_user = not user or bool(user.get("is_guest"))
+
+    # Permission check
+    if section in ("guest", "legacy"):
+        if not is_admin:
+            return Response("Forbidden", status_code=403)
+    else:
+        # 'mine'
+        if is_guest_user:
+            return Response("Forbidden", status_code=403)
+
+    base = _deck_base_for_section(uid, section)
+    p = (base / name).resolve()
+    if not _safe_within(base, p) or not (p.exists() and p.is_file() and p.suffix.lower() == ".csv"):
+        return Response("Not found", status_code=404)
+
+    # Delete CSV + known sidecars
+    stem = p.stem
+    for suffix in (".csv", ".txt", ".summary.json", "_compliance.json"):
+        candidate = p.parent / (stem + suffix)
+        try:
+            if candidate.exists():
+                candidate.unlink()
+        except Exception:
+            pass
+
+    # Return empty 200 — HTMX will swap the panel out of the DOM
+    return Response("", status_code=200)

--- a/code/web/routes/owned.py
+++ b/code/web/routes/owned.py
@@ -4,10 +4,17 @@ from fastapi import APIRouter, Request, UploadFile, File, Query
 from fastapi.responses import HTMLResponse, Response
 from ..app import templates
 from ..services import owned_store as store
-# Session helpers are not required for owned routes
 
 
 router = APIRouter(prefix="/owned")
+
+
+def _user_id(request: Request) -> str:
+    """Return the store key for the current user (UUID or 'guest')."""
+    u = getattr(request.state, "current_user", None)
+    if u and not u.get("is_guest") and u.get("id"):
+        return str(u["id"])
+    return "guest"
 
 
 def _canon_color_code(seq: list[str] | tuple[str, ...]) -> str:
@@ -71,12 +78,10 @@ def _build_color_combos(names_sorted: list[str], colors_by_name: dict[str, list[
 
 
 def _build_owned_context(request: Request, notice: str | None = None, error: str | None = None) -> dict:
-    """Build the template context for the Owned Library page, including
-    enrichment from csv_files and filter option lists.
-    """
-    # Read enriched data from the store (fast path; avoids per-request CSV parsing)
-    names, tags_by_name, type_by_name, colors_by_name = store.get_enriched()
-    added_at_map = store.get_added_at_map()
+    """Build the template context for the Owned Library page."""
+    uid = _user_id(request)
+    names, tags_by_name, type_by_name, colors_by_name = store.get_enriched(uid)
+    added_at_map = store.get_added_at_map(uid)
     # Default sort by name (case-insensitive)
     names_sorted = sorted(names, key=lambda s: s.lower())
     # Build filter option sets
@@ -151,7 +156,7 @@ async def owned_index(
 
     # CMC / Power / Toughness range filters
     if cmc_min or cmc_max or power_min or power_max or tough_min or tough_max:
-        stats_map = store.get_stats_map()
+        stats_map = store.get_stats_map(_user_id(request))
 
         def _to_float(s: str) -> float | None:
             try:
@@ -227,7 +232,7 @@ async def owned_upload(request: Request, file: UploadFile = File(...)) -> HTMLRe
         else:
             names = store.parse_txt_bytes(content)
         # Add and enrich immediately so the page doesn't need to parse CSVs
-        added, total = store.add_and_enrich(names)
+        added, total = store.add_and_enrich(names, _user_id(request))
         notice = f"Added {added} new name(s). Total: {total}."
         ctx = _build_owned_context(request, notice=notice)
         return templates.TemplateResponse("owned/index.html", ctx)
@@ -239,7 +244,7 @@ async def owned_upload(request: Request, file: UploadFile = File(...)) -> HTMLRe
 @router.post("/clear", response_class=HTMLResponse)
 async def owned_clear(request: Request) -> HTMLResponse:
     try:
-        store.clear()
+        store.clear(_user_id(request))
         ctx = _build_owned_context(request, notice="Library cleared.")
         return templates.TemplateResponse("owned/index.html", ctx)
     except Exception as e:
@@ -265,7 +270,7 @@ async def owned_remove(request: Request) -> HTMLResponse:
             raw = form.get("names") or ""
             if raw:
                 names = [s.strip() for s in str(raw).split(',') if s.strip()]
-        removed, total = store.remove_names(names)
+        removed, total = store.remove_names(names, _user_id(request))
         notice = f"Removed {removed} name(s). Total: {total}."
         ctx = _build_owned_context(request, notice=notice)
         return templates.TemplateResponse("owned/index.html", ctx)
@@ -279,11 +284,12 @@ async def owned_remove(request: Request) -> HTMLResponse:
 
 @router.get("/search-autocomplete", response_class=HTMLResponse)
 async def owned_search_autocomplete(
+    request: Request,
     q: str = Query(..., min_length=2),
     limit: int = Query(10, ge=1, le=20),
 ) -> HTMLResponse:
     """Return card name suggestions from the owned library for the search autocomplete."""
-    names, _, _, _ = store.get_enriched()
+    names, _, _, _ = store.get_enriched(_user_id(request))
     ql = q.strip().lower()
     matches = [n for n in names if ql in n.lower()][:limit]
     if not matches:
@@ -304,9 +310,9 @@ Note: Per request, all user tag add/remove endpoints have been removed.
 
 
 @router.get("/export")
-async def owned_export_txt() -> Response:
+async def owned_export_txt(request: Request) -> Response:
     """Download the owned library as a simple TXT (one name per line)."""
-    names, _, _, _ = store.get_enriched()
+    names, _, _, _ = store.get_enriched(_user_id(request))
     # Stable case-insensitive sort
     lines = "\n".join(sorted((names or []), key=lambda s: s.lower()))
     return Response(
@@ -317,9 +323,9 @@ async def owned_export_txt() -> Response:
 
 
 @router.get("/export.csv")
-async def owned_export_csv() -> Response:
+async def owned_export_csv(request: Request) -> Response:
     """Download the owned library with enrichment as CSV (Name,Type,Colors,Tags)."""
-    names, tags_by_name, type_by_name, colors_by_name = store.get_enriched()
+    names, tags_by_name, type_by_name, colors_by_name = store.get_enriched(_user_id(request))
     # Prepare CSV content
     import csv
     from io import StringIO
@@ -385,7 +391,7 @@ async def owned_export_visible_csv(request: Request) -> Response:
             if raw:
                 names = [s.strip() for s in str(raw).split(',') if s.strip()]
         # Build CSV using current enrichment
-        all_names, tags_by_name, type_by_name, colors_by_name = store.get_enriched()
+        all_names, tags_by_name, type_by_name, colors_by_name = store.get_enriched(_user_id(request))
         import csv
         from io import StringIO
         buf = StringIO()

--- a/code/web/routes/setup.py
+++ b/code/web/routes/setup.py
@@ -3,13 +3,18 @@ from __future__ import annotations
 import threading
 from typing import Optional
 from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse
 from pathlib import Path
 import json as _json
-from fastapi.responses import HTMLResponse, JSONResponse
 from ..app import templates
 from ..services.orchestrator import _ensure_setup_ready
 
 router = APIRouter(prefix="/setup")
+
+
+def _require_admin(request: Request) -> bool:
+    user = getattr(request.state, "current_user", None)
+    return bool(user and user.get("is_admin"))
 
 
 def _kickoff_setup_async(force: bool = False):
@@ -37,7 +42,8 @@ def _kickoff_setup_async(force: bool = False):
 
 @router.get("/running", response_class=HTMLResponse)
 async def setup_running(request: Request, start: Optional[int] = 0, next: Optional[str] = None, force: Optional[bool] = None) -> HTMLResponse:
-    # Optionally start the setup/tagging in the background if requested
+    if not _require_admin(request):
+        return RedirectResponse("/auth/login", status_code=303)
     try:
         if start and int(start) != 0:
             # honor optional force flag from query
@@ -60,6 +66,8 @@ async def setup_running(request: Request, start: Optional[int] = 0, next: Option
 @router.post("/start")
 async def setup_start(request: Request):
     """POST endpoint for setup/tagging. Accepts JSON body {"force": true/false} or query string ?force=1"""
+    if not _require_admin(request):
+        return JSONResponse({"ok": False, "error": "Admin required"}, status_code=403)
     force = False
     try:
         # Try to parse JSON body first
@@ -96,28 +104,26 @@ async def setup_start_get(request: Request):
 
     Useful as a fallback from clients that cannot POST JSON.
     """
+    if not _require_admin(request):
+        return JSONResponse({"ok": False, "error": "Admin required"}, status_code=403)
+    force = False
     try:
-        # Determine force from query params
-        force = False
-        try:
-            q_force = request.query_params.get('force')
-            if q_force is not None:
-                force = q_force.strip().lower() in {"1", "true", "yes", "on"}
-        except Exception:
-            pass
-        # Write immediate status so UI reflects the start
-        try:
-            p = Path("csv_files")
-            p.mkdir(parents=True, exist_ok=True)
-            status = {"running": True, "phase": "setup", "message": "Starting setup/tagging...", "color": None}
-            with (p / ".setup_status.json").open('w', encoding='utf-8') as f:
-                _json.dump(status, f)
-        except Exception:
-            pass
-        _kickoff_setup_async(force=bool(force))
-        return JSONResponse({"ok": True, "started": True, "force": bool(force)}, status_code=202)
+        q_force = request.query_params.get('force')
+        if q_force is not None:
+            force = q_force.strip().lower() in {"1", "true", "yes", "on"}
     except Exception:
-        return JSONResponse({"ok": False}, status_code=500)
+        pass
+    # Write immediate status so UI reflects the start
+    try:
+        p = Path("csv_files")
+        p.mkdir(parents=True, exist_ok=True)
+        status = {"running": True, "phase": "setup", "message": "Starting setup/tagging...", "color": None}
+        with (p / ".setup_status.json").open('w', encoding='utf-8') as f:
+            _json.dump(status, f)
+    except Exception:
+        pass
+    _kickoff_setup_async(force=bool(force))
+    return JSONResponse({"ok": True, "started": True, "force": bool(force)}, status_code=202)
 
 
 @router.post("/download-github")
@@ -244,6 +250,8 @@ async def refresh_rulings():
 
 @router.get("/", response_class=HTMLResponse)
 async def setup_index(request: Request) -> HTMLResponse:
+    if not _require_admin(request):
+        return RedirectResponse("/auth/login", status_code=303)
     import code.settings as settings
     from code.file_setup.image_cache import ImageCache
     from code.web.services.price_service import get_price_service

--- a/code/web/services/audit_db.py
+++ b/code/web/services/audit_db.py
@@ -1,0 +1,87 @@
+"""Audit log for auth/admin events — stored in the same users.db as the user table.
+
+Events are append-only. The table is pruned to a rolling 10 000-row cap
+on each insert to prevent unbounded growth.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_DATA_DIR = Path(__file__).resolve().parents[3] / "data"
+_DB_PATH = _DATA_DIR / "users.db"
+
+_CREATE_TABLE = """
+CREATE TABLE IF NOT EXISTS auth_events (
+    id          TEXT PRIMARY KEY,
+    event_type  TEXT NOT NULL,
+    user_id     TEXT,
+    username    TEXT,
+    ip          TEXT,
+    detail      TEXT,
+    created_at  REAL NOT NULL
+);
+"""
+_MAX_ROWS = 10_000
+
+
+def _connect() -> sqlite3.Connection:
+    conn = sqlite3.connect(str(_DB_PATH), check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_audit_db() -> None:
+    """Create the auth_events table if it doesn't exist."""
+    _DATA_DIR.mkdir(parents=True, exist_ok=True)
+    with _connect() as conn:
+        conn.execute(_CREATE_TABLE)
+        conn.commit()
+    logger.info("audit_db: initialised at %s", _DB_PATH)
+
+
+def log_event(
+    event_type: str,
+    *,
+    user_id: str | None = None,
+    username: str | None = None,
+    ip: str | None = None,
+    detail: str | None = None,
+) -> None:
+    """Append an audit event. Silently swallows errors so callers are never blocked."""
+    try:
+        with _connect() as conn:
+            conn.execute(
+                "INSERT INTO auth_events (id, event_type, user_id, username, ip, detail, created_at)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (str(uuid.uuid4()), event_type, user_id, username, ip, detail, time.time()),
+            )
+            # Prune oldest rows if over cap
+            conn.execute(
+                "DELETE FROM auth_events WHERE id IN ("
+                "  SELECT id FROM auth_events ORDER BY created_at ASC"
+                f"  LIMIT MAX(0, (SELECT COUNT(*) FROM auth_events) - {_MAX_ROWS})"
+                ")"
+            )
+            conn.commit()
+    except Exception:
+        logger.exception("audit_db: failed to log event %s", event_type)
+
+
+def get_recent_events(limit: int = 200) -> list[dict[str, Any]]:
+    """Return the most recent *limit* events, newest first."""
+    try:
+        with _connect() as conn:
+            rows = conn.execute(
+                "SELECT * FROM auth_events ORDER BY created_at DESC LIMIT ?", (limit,)
+            ).fetchall()
+        return [dict(r) for r in rows]
+    except Exception:
+        logger.exception("audit_db: failed to fetch events")
+        return []

--- a/code/web/services/auth.py
+++ b/code/web/services/auth.py
@@ -1,0 +1,274 @@
+"""Session cookie + token auth helpers for MTG Deckbuilder.
+
+Cookie design:
+  - Name: ``mtg_session``
+  - HTTP-only, SameSite=Lax, Secure when ``SESSION_SECURE_COOKIES=1``
+  - Value: URLSafeTimedSerializer-signed payload containing ``user_id``
+  - TTL: 8 hours (SESSION_TTL_SECONDS from tasks.py)
+
+Password-reset tokens:
+  - Separate salt ("pwd-reset")
+  - Max age: 3600 s (1 hour)
+  - One-time use enforced at the route level (see auth route handler)
+
+Environment:
+  ``SESSION_SECRET`` — required in production; if unset, a random key is
+  generated at startup with a WARN log. Rotating it invalidates all sessions.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import secrets
+import time
+import warnings
+from collections import defaultdict, deque
+from threading import Lock
+
+from fastapi import Request, Response, HTTPException
+from itsdangerous import URLSafeTimedSerializer, BadSignature, SignatureExpired  # type: ignore[import]
+from starlette.middleware.base import BaseHTTPMiddleware
+from typing import Optional
+
+from code.type_definitions import User
+from .tasks import SESSION_TTL_SECONDS
+from .user_db import get_user_by_id, get_guest_user
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Login rate limiter (in-memory, per-IP)
+# ---------------------------------------------------------------------------
+
+_RATE_WINDOW = 600   # 10 minutes
+_RATE_MAX = 5        # max failed attempts before IP lockout
+
+# Per-username lockout (more lenient window to reduce intentional DoS risk)
+_UNAME_RATE_WINDOW = 900   # 15 minutes
+_UNAME_RATE_MAX = 10
+
+_failed_attempts: dict[str, deque[float]] = defaultdict(deque)
+_failed_by_username: dict[str, deque[float]] = defaultdict(deque)
+_rate_lock = Lock()
+
+
+def _get_client_ip(request: Request) -> str:
+    """Extract real client IP, respecting X-Forwarded-For if present."""
+    forwarded = request.headers.get("X-Forwarded-For", "").strip()
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def check_rate_limit(ip: str) -> bool:
+    """Return True if this IP has exceeded the failed-login threshold."""
+    now = time.monotonic()
+    with _rate_lock:
+        q = _failed_attempts[ip]
+        while q and now - q[0] > _RATE_WINDOW:
+            q.popleft()
+        return len(q) >= _RATE_MAX
+
+
+def record_failed_login(ip: str) -> None:
+    """Record a failed login attempt for this IP."""
+    with _rate_lock:
+        _failed_attempts[ip].append(time.monotonic())
+
+
+def clear_failed_logins(ip: str) -> None:
+    """Clear the failure counter after a successful login."""
+    with _rate_lock:
+        _failed_attempts.pop(ip, None)
+
+
+def check_username_rate_limit(username: str) -> bool:
+    """Return True if this username has exceeded the failed-login threshold."""
+    now = time.monotonic()
+    key = username.strip().lower()
+    with _rate_lock:
+        q = _failed_by_username[key]
+        while q and now - q[0] > _UNAME_RATE_WINDOW:
+            q.popleft()
+        return len(q) >= _UNAME_RATE_MAX
+
+
+def record_failed_username(username: str) -> None:
+    """Record a failed login attempt for this username."""
+    with _rate_lock:
+        _failed_by_username[username.strip().lower()].append(time.monotonic())
+
+
+def clear_failed_username(username: str) -> None:
+    """Clear the username failure counter after a successful login."""
+    with _rate_lock:
+        _failed_by_username.pop(username.strip().lower(), None)
+
+
+# ---------------------------------------------------------------------------
+# Admin synthetic user
+# ---------------------------------------------------------------------------
+
+_ADMIN_ID = "__admin__"
+
+
+def get_admin_synthetic_user() -> Optional[User]:
+    """Build a synthetic admin User from env vars. Returns None if not configured."""
+    username = os.getenv("ADMIN_USERNAME", "").strip()
+    password = os.getenv("ADMIN_PASSWORD", "").strip()
+    if not username or not password:
+        return None
+    return User(
+        id=_ADMIN_ID,
+        username=username,
+        email="",
+        password_hash="",
+        is_guest=False,
+        is_active=True,
+        is_admin=True,
+        created_at=0.0,
+        updated_at=0.0,
+    )
+
+
+def is_admin_login(login: str, password: str) -> bool:
+    """Return True if the supplied credentials match the configured admin account.
+
+    Returns False immediately if ADMIN_ENABLED=0 (allows disabling the default
+    env-based admin once a DB admin account has been created).
+    """
+    if os.getenv("ADMIN_ENABLED", "1").strip().lower() in {"0", "false", "no", "off"}:
+        return False
+    admin_username = os.getenv("ADMIN_USERNAME", "").strip()
+    admin_password = os.getenv("ADMIN_PASSWORD", "").strip()
+    if not admin_username or not admin_password:
+        return False
+    return login.strip().lower() == admin_username.lower() and password == admin_password
+
+# ---------------------------------------------------------------------------
+# Secret key
+# ---------------------------------------------------------------------------
+
+_SESSION_SECRET: str = os.getenv("SESSION_SECRET", "")
+if not _SESSION_SECRET:
+    _SESSION_SECRET = secrets.token_hex(32)
+    logger.warning(
+        "SESSION_SECRET is not set — using a random key. "
+        "All sessions will be invalidated on restart. "
+        "Set SESSION_SECRET in production."
+    )
+
+_COOKIE_NAME = "mtg_session"
+_SESSION_SALT = "mtg-session"
+_RESET_SALT = "pwd-reset"
+_RESET_MAX_AGE = 3600  # 1 hour
+
+_USE_SECURE = os.getenv("SESSION_SECURE_COOKIES", "").strip().lower() in {"1", "true", "yes"}
+
+_serializer = URLSafeTimedSerializer(_SESSION_SECRET)
+
+
+# ---------------------------------------------------------------------------
+# Session cookie helpers
+# ---------------------------------------------------------------------------
+
+def create_session_cookie(response: Response, user_id: str) -> None:
+    """Sign and set the session cookie on *response*."""
+    token = _serializer.dumps(user_id, salt=_SESSION_SALT)
+    response.set_cookie(
+        key=_COOKIE_NAME,
+        value=token,
+        max_age=SESSION_TTL_SECONDS,
+        httponly=True,
+        samesite="lax",
+        secure=_USE_SECURE,
+    )
+
+
+def clear_session_cookie(response: Response) -> None:
+    """Expire the session cookie."""
+    response.delete_cookie(key=_COOKIE_NAME, httponly=True, samesite="lax")
+
+
+def _decode_session_token(token: str) -> Optional[str]:
+    """Return user_id from a valid, unexpired token; else None."""
+    try:
+        user_id: str = _serializer.loads(
+            token, salt=_SESSION_SALT, max_age=SESSION_TTL_SECONDS
+        )
+        return user_id
+    except (BadSignature, SignatureExpired):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# FastAPI dependencies
+# ---------------------------------------------------------------------------
+
+async def get_current_user(request: Request) -> User:
+    """FastAPI dependency — returns authenticated User or falls back to guest.
+
+    Never raises; always returns a User object.
+    """
+    token = request.cookies.get(_COOKIE_NAME)
+    if token:
+        user_id = _decode_session_token(token)
+        if user_id:
+            if user_id == _ADMIN_ID:
+                admin = get_admin_synthetic_user()
+                if admin:
+                    return admin
+            else:
+                user = get_user_by_id(user_id)
+                if user and user["is_active"]:
+                    return user
+    # Fall back to guest
+    guest = get_guest_user()
+    if guest:
+        return guest
+    # Last resort: anonymous stub (should never happen post-init_db)
+    raise HTTPException(status_code=503, detail="Auth service not initialised.")
+
+
+async def get_required_user(request: Request) -> User:
+    """FastAPI dependency — raises 401 if the user is not authenticated (guest counts as unauthenticated)."""
+    user = await get_current_user(request)
+    if user["is_guest"]:
+        raise HTTPException(status_code=401, detail="Login required.")
+    return user
+
+
+# ---------------------------------------------------------------------------
+# Password-reset tokens
+# ---------------------------------------------------------------------------
+
+def create_reset_token(email: str) -> str:
+    """Return a signed, time-limited reset token encoding *email*."""
+    return _serializer.dumps(email.strip().lower(), salt=_RESET_SALT)
+
+
+def verify_reset_token(token: str) -> Optional[str]:
+    """Return the email from a valid, unexpired reset token; else None."""
+    try:
+        email: str = _serializer.loads(token, salt=_RESET_SALT, max_age=_RESET_MAX_AGE)
+        return email
+    except (BadSignature, SignatureExpired):
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Middleware
+# ---------------------------------------------------------------------------
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    """Inject ``request.state.current_user`` on every request.
+
+    Falls back to guest (or None on error) so templates always have a user
+    object to render the nav without crashing.
+    """
+    async def dispatch(self, request: Request, call_next):
+        try:
+            request.state.current_user = await get_current_user(request)
+        except Exception:
+            request.state.current_user = None
+        return await call_next(request)

--- a/code/web/services/build_utils.py
+++ b/code/web/services/build_utils.py
@@ -147,7 +147,7 @@ def owned_names() -> list[str]:
         return []
 
 
-def start_ctx_from_session(sess: dict, *, set_on_session: bool = True) -> Dict[str, Any]:
+def start_ctx_from_session(sess: dict, *, set_on_session: bool = True, deck_dir: str | None = None) -> Dict[str, Any]:
     """Create a staged build context from the current session selections.
 
     Pulls commander, tags, bracket, ideals, tag_mode, ownership flags, locks, custom name,
@@ -167,6 +167,7 @@ def start_ctx_from_session(sess: dict, *, set_on_session: bool = True) -> Dict[s
     partner_enabled = bool(sess.get("partner_enabled")) and _app_bool("ENABLE_PARTNER_MECHANICS", True)
     secondary_commander = sess.get("secondary_commander") if partner_enabled else None
     background_choice = sess.get("background") if partner_enabled else None
+    resolved_deck_dir = deck_dir or str(sess.get("deck_dir") or "deck_files")
     ctx = orch.start_build_ctx(
         commander=sess.get("commander"),
         tags=sess.get("tags", []),
@@ -178,6 +179,7 @@ def start_ctx_from_session(sess: dict, *, set_on_session: bool = True) -> Dict[s
         owned_names=owned_names_list,
         locks=list(sess.get("locks", [])),
         custom_export_base=sess.get("custom_export_base"),
+        deck_dir=resolved_deck_dir,
         multi_copy=sess.get("multi_copy"),
         prefer_combos=bool(sess.get("prefer_combos")),
         combo_target_count=int(sess.get("combo_target_count", 2)),

--- a/code/web/services/email.py
+++ b/code/web/services/email.py
@@ -1,0 +1,260 @@
+"""Async SMTP email service for transactional auth emails.
+
+Configuration via environment variables:
+  SMTP_HOST      — SMTP server hostname (required; if unset, logs URL at WARN)
+  SMTP_PORT      — port (default 587)
+  SMTP_USERNAME  — SMTP auth username (optional)
+  SMTP_PASSWORD  — SMTP auth password (optional)
+  SMTP_FROM      — From address (default noreply@localhost)
+  SMTP_TLS       — set to 1 to use STARTTLS on connect (default: 1)
+  SMTP_SSL       — set to 1 for implicit TLS on port 465 (overrides SMTP_TLS)
+"""
+from __future__ import annotations
+
+import logging
+import os
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+import aiosmtplib  # type: ignore[import]
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Config from env
+# ---------------------------------------------------------------------------
+
+_SMTP_HOST = os.getenv("SMTP_HOST", "").strip()
+_SMTP_PORT = int(os.getenv("SMTP_PORT", "587") or "587")
+_SMTP_USERNAME = os.getenv("SMTP_USERNAME", "").strip()
+_SMTP_PASSWORD = os.getenv("SMTP_PASSWORD", "").strip()
+_SMTP_FROM = os.getenv("SMTP_FROM", "noreply@localhost").strip()
+_SMTP_TLS = os.getenv("SMTP_TLS", "1").strip().lower() in {"1", "true", "yes"}
+_SMTP_SSL = os.getenv("SMTP_SSL", "").strip().lower() in {"1", "true", "yes"}
+_SMTP_ENABLED = os.getenv("ENABLE_SMTP", "1").strip().lower() not in {"0", "false", "no", "off"}
+
+
+def is_smtp_configured() -> bool:
+    """Return True if SMTP is enabled and SMTP_HOST is set."""
+    return bool(_SMTP_HOST) and _SMTP_ENABLED
+
+
+# ---------------------------------------------------------------------------
+# Email builder
+# ---------------------------------------------------------------------------
+
+def _build_reset_email(to_email: str, reset_url: str) -> MIMEMultipart:
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = "MTG Deckbuilder — Reset your password"
+    msg["From"] = _SMTP_FROM
+    msg["To"] = to_email
+
+    plain = (
+        "You requested a password reset for your MTG Deckbuilder account.\n\n"
+        f"Reset your password here (link expires in 1 hour):\n{reset_url}\n\n"
+        "If you did not request this, you can ignore this email.\n"
+        "Your password will not change.\n"
+    )
+
+    html = (
+        "<!DOCTYPE html><html><body"
+        ' style="font-family:sans-serif;max-width:520px;margin:0 auto;padding:1rem;">\n'
+        "  <h2 style=\"margin-bottom:.5rem;\">Reset your password</h2>\n"
+        "  <p>You requested a password reset for your <strong>MTG Deckbuilder</strong> account.</p>\n"
+        '  <p style="margin:1.5rem 0;">\n'
+        f'    <a href="{reset_url}"\n'
+        '       style="display:inline-block;background:#2563eb;color:#fff;text-decoration:none;'
+        'padding:.65rem 1.25rem;border-radius:6px;font-weight:500;">\n'
+        "      Reset Password\n"
+        "    </a>\n"
+        "  </p>\n"
+        '  <p style="font-size:.85rem;color:#6b7280;">\n'
+        "    This link expires in <strong>1 hour</strong>. "
+        "If you did not request this, you can safely ignore this email.\n"
+        "  </p>\n"
+        '  <hr style="border:none;border-top:1px solid #e5e7eb;margin:1.5rem 0;">\n'
+        '  <p style="font-size:.75rem;color:#9ca3af;">\n'
+        "    If the button above does not work, copy and paste this URL into your browser:<br>\n"
+        f'    <a href="{reset_url}" style="color:#6b7280;">{reset_url}</a>\n'
+        "  </p>\n"
+        "</body></html>\n"
+    )
+
+    msg.attach(MIMEText(plain, "plain"))
+    msg.attach(MIMEText(html, "html"))
+    return msg
+
+
+def _build_welcome_email(to_email: str, username: str, login_url: str) -> MIMEMultipart:
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = f"Welcome to MTG Deckbuilder, {username}!"
+    msg["From"] = _SMTP_FROM
+    msg["To"] = to_email
+
+    plain = (
+        f"Hi {username},\n\n"
+        "Your MTG Deckbuilder account has been created successfully.\n\n"
+        f"Log in here:\n{login_url}\n\n"
+        "If you ever need to reset your password, use the \"Forgot password?\" "
+        "link on the login page.\n\n"
+        "Happy deck building!\n"
+    )
+
+    html = (
+        "<!DOCTYPE html><html><body"
+        ' style="font-family:sans-serif;max-width:520px;margin:0 auto;padding:1rem;">\n'
+        f"  <h2 style=\"margin-bottom:.5rem;\">Welcome, {username}!</h2>\n"
+        "  <p>Your <strong>MTG Deckbuilder</strong> account has been created successfully.</p>\n"
+        '  <p style="margin:1.5rem 0;">\n'
+        f'    <a href="{login_url}"\n'
+        '       style="display:inline-block;background:#2563eb;color:#fff;text-decoration:none;'
+        'padding:.65rem 1.25rem;border-radius:6px;font-weight:500;">\n'
+        "      Log In\n"
+        "    </a>\n"
+        "  </p>\n"
+        '  <p style="font-size:.85rem;color:#6b7280;">\n'
+        "    If you ever need to reset your password, use the "
+        '    <a href="' + login_url.rstrip('/').rsplit('/', 1)[0] + '/auth/forgot" style="color:#2563eb;">Forgot password?</a>'
+        " link on the login page.\n"
+        "  </p>\n"
+        '</body></html>\n'
+    )
+
+    msg.attach(MIMEText(plain, "plain"))
+    msg.attach(MIMEText(html, "html"))
+    return msg
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+async def send_welcome_email(to_email: str, username: str, login_url: str) -> None:
+    """Send a welcome email after successful registration.
+
+    Silently skips (with an INFO log) if SMTP is not configured.
+    Logs errors but never raises — registration must not fail due to email.
+    """
+    if not is_smtp_configured():
+        logger.info("SMTP not configured — skipping welcome email for %s", username)
+        return
+
+    msg = _build_welcome_email(to_email, username, login_url)
+    smtp = aiosmtplib.SMTP(
+        hostname=_SMTP_HOST,
+        port=_SMTP_PORT,
+        use_tls=_SMTP_SSL,
+    )
+    try:
+        await smtp.connect()
+        if _SMTP_TLS and not _SMTP_SSL:
+            await smtp.starttls()
+        if _SMTP_USERNAME and _SMTP_PASSWORD:
+            await smtp.login(_SMTP_USERNAME, _SMTP_PASSWORD)
+        await smtp.send_message(msg)
+        logger.info("Welcome email sent to %s", to_email)
+    except Exception:
+        logger.exception("Failed to send welcome email to %s", to_email)
+    finally:
+        try:
+            await smtp.quit()
+        except Exception:
+            pass
+
+
+async def send_account_created_email(to_email: str, username: str, set_password_url: str) -> None:
+    """Send an 'account created by admin' email with a one-time set-password link.
+
+    Silently skips if SMTP is not configured.
+    Logs errors but never raises.
+    """
+    if not is_smtp_configured():
+        logger.info("SMTP not configured — skipping account-created email for %s", username)
+        return
+
+    msg = MIMEMultipart("alternative")
+    msg["Subject"] = "Your MTG Deckbuilder account is ready"
+    msg["From"] = _SMTP_FROM
+    msg["To"] = to_email
+
+    plain = (
+        f"Hi {username},\n\n"
+        "An administrator has created an MTG Deckbuilder account for you.\n\n"
+        f"Set your password here (link expires in 1 hour):\n{set_password_url}\n\n"
+        "If you were not expecting this, you can safely ignore this email.\n"
+    )
+    html = (
+        "<!DOCTYPE html><html><body"
+        ' style="font-family:sans-serif;max-width:520px;margin:0 auto;padding:1rem;">\n'
+        f"  <h2 style=\"margin-bottom:.5rem;\">Welcome, {username}!</h2>\n"
+        "  <p>An administrator has created an <strong>MTG Deckbuilder</strong> account for you.</p>\n"
+        '  <p style="margin:1.5rem 0;">\n'
+        f'    <a href="{set_password_url}"\n'
+        '       style="display:inline-block;background:#2563eb;color:#fff;text-decoration:none;'
+        'padding:.65rem 1.25rem;border-radius:6px;font-weight:500;">\n'
+        "      Set Your Password\n"
+        "    </a>\n"
+        "  </p>\n"
+        '  <p style="font-size:.85rem;color:#6b7280;">This link expires in <strong>1 hour</strong>.</p>\n'
+        '  <hr style="border:none;border-top:1px solid #e5e7eb;margin:1.5rem 0;">\n'
+        '  <p style="font-size:.75rem;color:#9ca3af;">\n'
+        "    If you were not expecting this, you can safely ignore this email.\n"
+        "  </p>\n"
+        "</body></html>\n"
+    )
+    msg.attach(MIMEText(plain, "plain"))
+    msg.attach(MIMEText(html, "html"))
+
+    smtp = aiosmtplib.SMTP(hostname=_SMTP_HOST, port=_SMTP_PORT, use_tls=_SMTP_SSL)
+    try:
+        await smtp.connect()
+        if _SMTP_TLS and not _SMTP_SSL:
+            await smtp.starttls()
+        if _SMTP_USERNAME and _SMTP_PASSWORD:
+            await smtp.login(_SMTP_USERNAME, _SMTP_PASSWORD)
+        await smtp.send_message(msg)
+        logger.info("Account-created email sent to %s", to_email)
+    except Exception:
+        logger.exception("Failed to send account-created email to %s", to_email)
+    finally:
+        try:
+            await smtp.quit()
+        except Exception:
+            pass
+
+
+async def send_password_reset(to_email: str, reset_url: str) -> None:
+    """Send a password-reset email to *to_email*.
+
+    If ``SMTP_HOST`` is not configured, the reset URL is logged at WARN level
+    so development environments work without an SMTP server. No exception is
+    raised in that case.
+
+    Raises on SMTP delivery failure so callers can decide whether to surface
+    the error or swallow it.
+    """
+    if not _SMTP_HOST:
+        logger.warning(
+            "SMTP_HOST not configured — password reset URL (dev only): %s", reset_url
+        )
+        return
+
+    msg = _build_reset_email(to_email, reset_url)
+    smtp = aiosmtplib.SMTP(
+        hostname=_SMTP_HOST,
+        port=_SMTP_PORT,
+        use_tls=_SMTP_SSL,
+    )
+    await smtp.connect()
+    try:
+        if _SMTP_TLS and not _SMTP_SSL:
+            await smtp.starttls()
+        if _SMTP_USERNAME and _SMTP_PASSWORD:
+            await smtp.login(_SMTP_USERNAME, _SMTP_PASSWORD)
+        await smtp.send_message(msg)
+        logger.info("password reset email sent to %s", to_email)
+    finally:
+        try:
+            await smtp.quit()
+        except Exception:
+            pass

--- a/code/web/services/multi_build_orchestrator.py
+++ b/code/web/services/multi_build_orchestrator.py
@@ -151,7 +151,9 @@ class MultiBuildOrchestrator:
             "locks": set(config.get("locks", [])),
             "replace_mode": True,
             # Add build index to context for debugging
-            "batch_build_index": build_index
+            "batch_build_index": build_index,
+            # Thread per-user deck export directory through to the build context
+            "deck_dir": config.get("deck_dir") or "deck_files",
         }
         
         # Handle partner mechanics if present

--- a/code/web/services/orchestrator.py
+++ b/code/web/services/orchestrator.py
@@ -1704,7 +1704,7 @@ def _ensure_setup_ready(out, force: bool = False) -> None:
             pass
 
 
-def run_build(commander: str, tags: List[str], bracket: int, ideals: Dict[str, int], tag_mode: str | None = None, *, use_owned_only: bool | None = None, prefer_owned: bool | None = None, owned_names: List[str] | None = None, prefer_combos: bool | None = None, combo_target_count: int | None = None, combo_balance: str | None = None) -> Dict[str, Any]:
+def run_build(commander: str, tags: List[str], bracket: int, ideals: Dict[str, int], tag_mode: str | None = None, *, use_owned_only: bool | None = None, prefer_owned: bool | None = None, owned_names: List[str] | None = None, prefer_combos: bool | None = None, combo_target_count: int | None = None, combo_balance: str | None = None, deck_dir: str = "deck_files") -> Dict[str, Any]:
     """Run the deck build end-to-end with provided selections and capture logs.
 
     Returns: { ok: bool, log: str, csv_path: Optional[str], txt_path: Optional[str], error: Optional[str] }
@@ -1981,7 +1981,7 @@ def run_build(commander: str, tags: List[str], bracket: int, ideals: Dict[str, i
             except Exception:
                 pass
             if hasattr(b, 'export_decklist_csv'):
-                csv_path = b.export_decklist_csv()
+                csv_path = b.export_decklist_csv(directory=deck_dir)
         except Exception as e:
             out(f"CSV export failed: {e}")
         try:
@@ -1989,7 +1989,7 @@ def run_build(commander: str, tags: List[str], bracket: int, ideals: Dict[str, i
                 # Try to mirror build_deck_full behavior by displaying the contents
                 import os as _os
                 base, _ext = _os.path.splitext(_os.path.basename(csv_path)) if csv_path else (f"deck_{b.timestamp}", "")
-                txt_path = b.export_decklist_text(filename=base + '.txt')
+                txt_path = b.export_decklist_text(directory=deck_dir, filename=base + '.txt')
                 try:
                     b._display_txt_contents(txt_path)
                 except Exception:
@@ -2009,19 +2009,7 @@ def run_build(commander: str, tags: List[str], bracket: int, ideals: Dict[str, i
                             b.enforce_and_reexport(base_stem=base, mode='auto')
                 except Exception:
                     pass
-                # Load compliance JSON for UI consumption
-                try:
-                    # Prefer the in-memory report (with enforcement plan) when available
-                    if rep0 is not None:
-                        compliance_obj = rep0
-                    else:
-                        import json as _json
-                        comp_path = _os.path.join('deck_files', f"{base}_compliance.json")
-                        if _os.path.exists(comp_path):
-                            with open(comp_path, 'r', encoding='utf-8') as _cf:
-                                compliance_obj = _json.load(_cf)
-                except Exception:
-                    compliance_obj = None
+                # Load compliance JSON for UI consumption\n                try:\n                    # Prefer the in-memory report (with enforcement plan) when available\n                    if rep0 is not None:\n                        compliance_obj = rep0\n                    else:\n                        import json as _json\n                        comp_path = _os.path.join(deck_dir, f\"{base}_compliance.json\")\n                        if _os.path.exists(comp_path):\n                            with open(comp_path, 'r', encoding='utf-8') as _cf:\n                                compliance_obj = _json.load(_cf)\n                except Exception:\n                    compliance_obj = None
         except Exception as e:
             out(f"Text export failed: {e}")
 
@@ -2549,6 +2537,7 @@ def start_build_ctx(
     owned_names: List[str] | None = None,
     locks: List[str] | None = None,
     custom_export_base: str | None = None,
+    deck_dir: str = "deck_files",
     multi_copy: Dict[str, Any] | None = None,
     prefer_combos: bool | None = None,
     combo_target_count: int | None = None,
@@ -2741,6 +2730,7 @@ def start_build_ctx(
     "history": [],  # list of {i, key, label, snapshot}
         "locks": {str(n).strip().lower() for n in (locks or []) if str(n).strip()},
     "custom_export_base": str(custom_export_base).strip() if isinstance(custom_export_base, str) and custom_export_base.strip() else None,
+        "deck_dir": str(deck_dir) if deck_dir else "deck_files",
         "swap_mdfc_basics": bool(swap_mdfc_basics),
     }
     return ctx
@@ -2797,6 +2787,7 @@ def run_stage(ctx: Dict[str, Any], rerun: bool = False, show_skipped: bool = Fal
 
     # If all stages done, finalize exports (interactive/manual build)
     if ctx["idx"] >= len(stages):
+        deck_dir = str(ctx.get("deck_dir") or "deck_files")
         # Apply custom export base if present in context
         try:
             custom_base = ctx.get("custom_export_base")
@@ -2806,14 +2797,14 @@ def run_stage(ctx: Dict[str, Any], rerun: bool = False, show_skipped: bool = Fal
             pass
         if not ctx.get("txt_path") and hasattr(b, 'export_decklist_text'):
             try:
-                ctx["csv_path"] = b.export_decklist_csv()
+                ctx["csv_path"] = b.export_decklist_csv(directory=deck_dir)
             except Exception as e:
                 logs.append(f"CSV export failed: {e}")
         if not ctx.get("txt_path") and hasattr(b, 'export_decklist_text'):
             try:
                 import os as _os
                 base, _ext = _os.path.splitext(_os.path.basename(ctx.get("csv_path") or f"deck_{b.timestamp}.csv"))
-                ctx["txt_path"] = b.export_decklist_text(filename=base + '.txt')
+                ctx["txt_path"] = b.export_decklist_text(directory=deck_dir, filename=base + '.txt')
                 # Export the run configuration JSON for manual builds
                 try:
                     b.export_run_config_json(directory='config', filename=base + '.json')
@@ -2840,7 +2831,7 @@ def run_stage(ctx: Dict[str, Any], rerun: bool = False, show_skipped: bool = Fal
                         ctx["compliance"] = rep0
                     else:
                         import json as _json
-                        comp_path = _os.path.join('deck_files', f"{base}_compliance.json")
+                        comp_path = _os.path.join(deck_dir, f"{base}_compliance.json")
                         if _os.path.exists(comp_path):
                             with open(comp_path, 'r', encoding='utf-8') as _cf:
                                 ctx["compliance"] = _json.load(_cf)
@@ -3685,6 +3676,7 @@ def run_stage(ctx: Dict[str, Any], rerun: bool = False, show_skipped: bool = Fal
 
     # If we reached here, all remaining stages were no-ops; finalize exports
     ctx["idx"] = len(stages)
+    deck_dir = str(ctx.get("deck_dir") or "deck_files")
     # Apply custom export base if present
     try:
         custom_base = ctx.get("custom_export_base")
@@ -3694,14 +3686,14 @@ def run_stage(ctx: Dict[str, Any], rerun: bool = False, show_skipped: bool = Fal
         pass
     if not ctx.get("csv_path") and hasattr(b, 'export_decklist_csv'):
         try:
-            ctx["csv_path"] = b.export_decklist_csv()
+            ctx["csv_path"] = b.export_decklist_csv(directory=deck_dir)
         except Exception as e:
             logs.append(f"CSV export failed: {e}")
     if not ctx.get("txt_path") and hasattr(b, 'export_decklist_text'):
         try:
             import os as _os
             base, _ext = _os.path.splitext(_os.path.basename(ctx.get("csv_path") or f"deck_{b.timestamp}.csv"))
-            ctx["txt_path"] = b.export_decklist_text(filename=base + '.txt')
+            ctx["txt_path"] = b.export_decklist_text(directory=deck_dir, filename=base + '.txt')
             # Export the run configuration JSON for manual builds
             try:
                 b.export_run_config_json(directory='config', filename=base + '.json')
@@ -3727,7 +3719,7 @@ def run_stage(ctx: Dict[str, Any], rerun: bool = False, show_skipped: bool = Fal
                     ctx["compliance"] = rep0
                 else:
                     import json as _json
-                    comp_path = _os.path.join('deck_files', f"{base}_compliance.json")
+                    comp_path = _os.path.join(deck_dir, f"{base}_compliance.json")
                     if _os.path.exists(comp_path):
                         with open(comp_path, 'r', encoding='utf-8') as _cf:
                             ctx["compliance"] = _json.load(_cf)

--- a/code/web/services/owned_store.py
+++ b/code/web/services/owned_store.py
@@ -7,10 +7,14 @@ import os
 import time
 
 
-def _owned_dir() -> Path:
-    """Resolve the owned cards directory (shared with CLI) for persistence.
+def _owned_dir(user_id: str | None = None) -> Path:
+    """Resolve the owned cards directory.
 
-    Precedence:
+    When *user_id* is provided the directory is scoped:
+      ``<base>/guest/``   for the shared guest account
+      ``<base>/{user_id}/`` for authenticated users
+
+    Precedence for the base path:
     - OWNED_CARDS_DIR env var
     - CARD_LIBRARY_DIR env var (back-compat)
     - ./owned_cards (if exists)
@@ -18,6 +22,9 @@ def _owned_dir() -> Path:
     - default ./owned_cards
     """
     env_dir = os.getenv("OWNED_CARDS_DIR") or os.getenv("CARD_LIBRARY_DIR")
+    if user_id:
+        base = Path(env_dir).resolve() if env_dir else Path("owned_cards").resolve()
+        return base / user_id
     if env_dir:
         return Path(env_dir).resolve()
     for name in ("owned_cards", "card_library"):
@@ -27,8 +34,8 @@ def _owned_dir() -> Path:
     return Path("owned_cards").resolve()
 
 
-def _db_path() -> Path:
-    d = _owned_dir()
+def _db_path(user_id: str | None = None) -> Path:
+    d = _owned_dir(user_id)
     try:
         d.mkdir(parents=True, exist_ok=True)
     except Exception:
@@ -36,8 +43,8 @@ def _db_path() -> Path:
     return (d / ".web_owned_db.json").resolve()
 
 
-def _load_raw() -> dict:
-    p = _db_path()
+def _load_raw(user_id: str | None = None) -> dict:
+    p = _db_path(user_id)
     if p.exists():
         try:
             with p.open("r", encoding="utf-8") as f:
@@ -54,8 +61,8 @@ def _load_raw() -> dict:
     return {"names": [], "meta": {}}
 
 
-def _save_raw(data: dict) -> None:
-    p = _db_path()
+def _save_raw(data: dict, user_id: str | None = None) -> None:
+    p = _db_path(user_id)
     try:
         with p.open("w", encoding="utf-8") as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
@@ -63,8 +70,8 @@ def _save_raw(data: dict) -> None:
         pass
 
 
-def get_names() -> List[str]:
-    data = _load_raw()
+def get_names(user_id: str | None = None) -> List[str]:
+    data = _load_raw(user_id)
     names = data.get("names") or []
     if not isinstance(names, list):
         return []
@@ -83,13 +90,13 @@ def get_names() -> List[str]:
     return out
 
 
-def clear() -> None:
-    _save_raw({"names": [], "meta": {}})
+def clear(user_id: str | None = None) -> None:
+    _save_raw({"names": [], "meta": {}}, user_id)
 
 
-def add_names(names: Iterable[str]) -> Tuple[int, int]:
+def add_names(names: Iterable[str], user_id: str | None = None) -> Tuple[int, int]:
     """Add a batch of names; returns (added_count, total_after)."""
-    data = _load_raw()
+    data = _load_raw(user_id)
     cur = [str(x).strip() for x in (data.get("names") or []) if str(x).strip()]
     cur_set = {n.lower() for n in cur}
     added = 0
@@ -119,7 +126,7 @@ def add_names(names: Iterable[str]) -> Tuple[int, int]:
         else:
             if "added_at" not in info:
                 info["added_at"] = now
-    _save_raw(data)
+    _save_raw(data, user_id)
     return added, len(cur)
 
 
@@ -206,11 +213,11 @@ def _enrich_from_csvs(target_names: Iterable[str]) -> Dict[str, Dict[str, object
     return meta
 
 
-def add_and_enrich(names: Iterable[str]) -> Tuple[int, int]:
+def add_and_enrich(names: Iterable[str], user_id: str | None = None) -> Tuple[int, int]:
     """Add names and enrich their metadata from Parquet (M4).
     Returns (added_count, total_after).
     """
-    data = _load_raw()
+    data = _load_raw(user_id)
     current_names = [str(x).strip() for x in (data.get("names") or []) if str(x).strip()]
     cur_set = {n.lower() for n in current_names}
     new_names: List[str] = []
@@ -241,15 +248,15 @@ def add_and_enrich(names: Iterable[str]) -> Tuple[int, int]:
                 entry["added_at"] = now
     data["names"] = current_names
     data["meta"] = meta
-    _save_raw(data)
+    _save_raw(data, user_id)
     return len(new_names), len(current_names)
 
 
-def get_enriched() -> Tuple[List[str], Dict[str, List[str]], Dict[str, str], Dict[str, List[str]]]:
+def get_enriched(user_id: str | None = None) -> Tuple[List[str], Dict[str, List[str]], Dict[str, str], Dict[str, List[str]]]:
     """Return names and metadata dicts (tags_by_name, type_by_name, colors_by_name).
     If metadata missing, returns empty for those entries.
     """
-    data = _load_raw()
+    data = _load_raw(user_id)
     names = [str(x).strip() for x in (data.get("names") or []) if str(x).strip()]
     meta: Dict[str, Dict[str, object]] = data.get("meta") or {}
     tags_by_name: Dict[str, List[str]] = {}
@@ -270,11 +277,11 @@ def get_enriched() -> Tuple[List[str], Dict[str, List[str]], Dict[str, str], Dic
     return names, tags_by_name, type_by_name, colors_by_name
 
 
-def get_stats_map() -> Dict[str, Dict[str, object]]:
+def get_stats_map(user_id: str | None = None) -> Dict[str, Dict[str, object]]:
     """Return {name: {manaValue, power, toughness}} for all owned names.
     Falls back to a parquet lookup for any entries missing numeric stats.
     """
-    data = _load_raw()
+    data = _load_raw(user_id)
     names: List[str] = [str(x).strip() for x in (data.get("names") or []) if str(x).strip()]
     meta: Dict[str, Dict[str, object]] = data.get("meta") or {}
 
@@ -323,9 +330,9 @@ def get_stats_map() -> Dict[str, Dict[str, object]]:
 # add_user_tag/remove_user_tag removed; user-defined tags are not persisted anymore
 
 
-def get_added_at_map() -> Dict[str, int]:
+def get_added_at_map(user_id: str | None = None) -> Dict[str, int]:
     """Return a mapping of name -> added_at unix timestamp (if known)."""
-    data = _load_raw()
+    data = _load_raw(user_id)
     meta: Dict[str, Dict[str, object]] = data.get("meta") or {}
     out: Dict[str, int] = {}
     for n, info in meta.items():
@@ -338,12 +345,12 @@ def get_added_at_map() -> Dict[str, int]:
     return out
 
 
-def remove_names(names: Iterable[str]) -> Tuple[int, int]:
+def remove_names(names: Iterable[str], user_id: str | None = None) -> Tuple[int, int]:
     """Remove a batch of names; returns (removed_count, total_after)."""
     target = {str(n).strip().lower() for n in (names or []) if str(n).strip()}
     if not target:
-        return 0, len(get_names())
-    data = _load_raw()
+        return 0, len(get_names(user_id))
+    data = _load_raw(user_id)
     cur = [str(x).strip() for x in (data.get("names") or []) if str(x).strip()]
     before = len(cur)
     cur_kept: List[str] = []
@@ -362,7 +369,7 @@ def remove_names(names: Iterable[str]) -> Tuple[int, int]:
         except Exception:
             continue
     data["meta"] = meta
-    _save_raw(data)
+    _save_raw(data, user_id)
     return removed, len(cur_kept)
 
 

--- a/code/web/services/user_db.py
+++ b/code/web/services/user_db.py
@@ -1,0 +1,274 @@
+"""SQLite-backed user store for MTG Deckbuilder auth.
+
+Uses WAL mode for light concurrent access. Passwords are bcrypt-hashed via
+passlib; plain-text passwords are never stored.
+
+The `data/` directory (and `users.db` inside it) are gitignored and
+Docker-volume-mounted so they persist across container restarts.
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+import bcrypt as _bcrypt  # type: ignore[import]
+
+from code.type_definitions import User
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+_DATA_DIR = Path(__file__).resolve().parents[3] / "data"
+_DB_PATH = _DATA_DIR / "users.db"
+
+# ---------------------------------------------------------------------------
+# Password hashing
+# ---------------------------------------------------------------------------
+
+def hash_password(plain: str) -> str:
+    return _bcrypt.hashpw(plain.encode(), _bcrypt.gensalt()).decode()
+
+
+def verify_password(plain: str, hashed: str) -> bool:
+    return _bcrypt.checkpw(plain.encode(), hashed.encode())
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+def _connect() -> sqlite3.Connection:
+    conn = sqlite3.connect(str(_DB_PATH), check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA foreign_keys=ON")
+    return conn
+
+
+_CREATE_USERS_TABLE = """
+CREATE TABLE IF NOT EXISTS users (
+    id            TEXT PRIMARY KEY,
+    username      TEXT UNIQUE NOT NULL,
+    email         TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    is_guest      INTEGER NOT NULL DEFAULT 0,
+    is_active     INTEGER NOT NULL DEFAULT 1,
+    created_at    REAL    NOT NULL,
+    updated_at    REAL    NOT NULL
+);
+"""
+
+_GUEST_EMAIL = "guest@localhost"
+_GUEST_USERNAME = "guest"
+
+
+def init_db() -> None:
+    """Create the data directory, users.db, and schema if they don't exist."""
+    _DATA_DIR.mkdir(parents=True, exist_ok=True)
+    with _connect() as conn:
+        conn.execute(_CREATE_USERS_TABLE)
+        # Migration: add reset_token_hash column if not already present
+        try:
+            conn.execute("ALTER TABLE users ADD COLUMN reset_token_hash TEXT DEFAULT NULL")
+        except sqlite3.OperationalError:
+            pass  # column already exists
+        # Migration: add is_admin column if not already present
+        try:
+            conn.execute("ALTER TABLE users ADD COLUMN is_admin INTEGER NOT NULL DEFAULT 0")
+        except sqlite3.OperationalError:
+            pass  # column already exists
+        conn.commit()
+    logger.info("user_db: initialised at %s", _DB_PATH)
+
+
+def ensure_guest_user() -> None:
+    """Idempotently create the shared guest account."""
+    with _connect() as conn:
+        existing = conn.execute(
+            "SELECT id FROM users WHERE email = ?", (_GUEST_EMAIL,)
+        ).fetchone()
+        if existing:
+            return
+        now = time.time()
+        conn.execute(
+            "INSERT INTO users (id, username, email, password_hash, is_guest, is_active, created_at, updated_at)"
+            " VALUES (?, ?, ?, ?, 1, 1, ?, ?)",
+            (str(uuid.uuid4()), _GUEST_USERNAME, _GUEST_EMAIL, hash_password(str(uuid.uuid4())), now, now),
+        )
+        conn.commit()
+    logger.info("user_db: guest account ensured")
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+def _row_to_user(row: sqlite3.Row) -> User:
+    keys = row.keys()
+    return User(
+        id=row["id"],
+        username=row["username"],
+        email=row["email"],
+        password_hash=row["password_hash"],
+        is_guest=bool(row["is_guest"]),
+        is_active=bool(row["is_active"]),
+        is_admin=bool(row["is_admin"]) if "is_admin" in keys else False,
+        created_at=float(row["created_at"]),
+        updated_at=float(row["updated_at"]),
+    )
+
+
+def create_user(username: str, email: str, password: str) -> User:
+    """Hash and persist a new user. Raises ValueError on duplicate username/email."""
+    user_id = str(uuid.uuid4())
+    now = time.time()
+    pw_hash = hash_password(password)
+    try:
+        with _connect() as conn:
+            conn.execute(
+                "INSERT INTO users (id, username, email, password_hash, is_guest, is_active, created_at, updated_at)"
+                " VALUES (?, ?, ?, ?, 0, 1, ?, ?)",
+                (user_id, username.strip(), email.strip().lower(), pw_hash, now, now),
+            )
+            conn.commit()
+    except sqlite3.IntegrityError as exc:
+        raise ValueError("Username or email already registered.") from exc
+    return get_user_by_id(user_id)  # type: ignore[return-value]
+
+
+def get_user_by_email(email: str) -> Optional[User]:
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT * FROM users WHERE email = ?", (email.strip().lower(),)
+        ).fetchone()
+    return _row_to_user(row) if row else None
+
+
+def get_user_by_username(username: str) -> Optional[User]:
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT * FROM users WHERE LOWER(username) = LOWER(?)", (username.strip(),)
+        ).fetchone()
+    return _row_to_user(row) if row else None
+
+
+def get_user_by_login(login: str) -> Optional[User]:
+    """Look up a user by email or username (whichever matches)."""
+    return get_user_by_email(login) or get_user_by_username(login)
+
+
+def get_user_by_id(user_id: str) -> Optional[User]:
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT * FROM users WHERE id = ?", (user_id,)
+        ).fetchone()
+    return _row_to_user(row) if row else None
+
+
+def get_guest_user() -> Optional[User]:
+    return get_user_by_email(_GUEST_EMAIL)
+
+
+def list_all_users() -> list[User]:
+    """Return all non-guest, non-admin DB users ordered by creation time."""
+    with _connect() as conn:
+        rows = conn.execute(
+            "SELECT * FROM users WHERE is_guest = 0 ORDER BY created_at ASC"
+        ).fetchall()
+    return [_row_to_user(r) for r in rows]
+
+
+def set_user_admin(user_id: str, is_admin_flag: bool) -> None:
+    """Grant or revoke admin role for a DB user. Raises ValueError for protected accounts."""
+    with _connect() as conn:
+        row = conn.execute("SELECT username, is_guest FROM users WHERE id = ?", (user_id,)).fetchone()
+        if not row:
+            raise ValueError("User not found.")
+        if bool(row["is_guest"]):
+            raise ValueError("Cannot grant admin to the guest account.")
+        conn.execute(
+            "UPDATE users SET is_admin = ?, updated_at = ? WHERE id = ?",
+            (1 if is_admin_flag else 0, time.time(), user_id),
+        )
+        conn.commit()
+    logger.info("user_db: set is_admin=%s for user %s", is_admin_flag, user_id)
+
+
+def set_user_active(user_id: str, active: bool) -> None:
+    """Activate or deactivate a DB user. Raises ValueError for protected accounts."""
+    with _connect() as conn:
+        row = conn.execute("SELECT username, is_guest FROM users WHERE id = ?", (user_id,)).fetchone()
+        if not row:
+            raise ValueError("User not found.")
+        if bool(row["is_guest"]):
+            raise ValueError("Cannot deactivate the guest account.")
+        conn.execute(
+            "UPDATE users SET is_active = ?, updated_at = ? WHERE id = ?",
+            (1 if active else 0, time.time(), user_id),
+        )
+        conn.commit()
+    logger.info("user_db: set is_active=%s for user %s", active, user_id)
+
+
+def delete_user(user_id: str) -> None:
+    import os as _os
+    admin_username = _os.getenv("ADMIN_USERNAME", "").strip().lower()
+    with _connect() as conn:
+        row = conn.execute("SELECT username, is_guest FROM users WHERE id = ?", (user_id,)).fetchone()
+        if not row:
+            raise ValueError("User not found.")
+        if bool(row["is_guest"]):
+            raise ValueError("Cannot delete the guest account.")
+        if admin_username and row["username"].lower() == admin_username:
+            raise ValueError("Cannot delete the admin account.")
+        conn.execute("DELETE FROM users WHERE id = ?", (user_id,))
+        conn.commit()
+    logger.info("user_db: deleted user %s", user_id)
+
+
+def update_password(user_id: str, new_password: str) -> None:
+    import os as _os
+    if user_id == "__admin__":
+        raise ValueError("Admin password cannot be changed through the application.")
+    now = time.time()
+    new_hash = hash_password(new_password)
+    with _connect() as conn:
+        conn.execute(
+            "UPDATE users SET password_hash = ?, updated_at = ? WHERE id = ?",
+            (new_hash, now, user_id),
+        )
+        conn.commit()
+
+
+def set_reset_token_hash(user_id: str, token_hash: str) -> None:
+    """Store a hashed reset token so it can be verified and consumed once."""
+    now = time.time()
+    with _connect() as conn:
+        conn.execute(
+            "UPDATE users SET reset_token_hash = ?, updated_at = ? WHERE id = ?",
+            (token_hash, now, user_id),
+        )
+        conn.commit()
+
+
+def consume_reset_token(user_id: str, token_hash: str) -> bool:
+    """Return True and clear the stored hash if it matches; False otherwise."""
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT reset_token_hash FROM users WHERE id = ?", (user_id,)
+        ).fetchone()
+        if not row or row["reset_token_hash"] != token_hash:
+            return False
+        conn.execute(
+            "UPDATE users SET reset_token_hash = NULL, updated_at = ? WHERE id = ?",
+            (time.time(), user_id),
+        )
+        conn.commit()
+    return True

--- a/code/web/static/styles.css
+++ b/code/web/static/styles.css
@@ -1334,6 +1334,24 @@ body {
   flex-shrink: 0 !important;
 }
 
+/* User auth nav — right side of banner */
+
+.banner-right{
+  display:flex;
+  align-items:center;
+  gap:.5rem;
+  margin-left:auto;
+  flex-shrink:0;
+}
+
+.banner-username{
+  font-size:.85rem;
+  color:var(--surface-banner-text);
+  opacity:.85;
+  padding:0 .25rem;
+  white-space:nowrap;
+}
+
 /* Hide elements on all screen sizes */
 
 #btn-open-permalink{
@@ -4121,6 +4139,22 @@ img.lqip.loaded {
   color: #fff;
 }
 
+.btn-danger-sm {
+  display: inline-block;
+  background: var(--err, #c0392b);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 0.25rem 0.6rem;
+  font-size: 0.8rem;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.btn-danger-sm:hover {
+  filter: brightness(1.1);
+}
+
 /* Button Sizes */
 
 .btn-sm {
@@ -4512,6 +4546,97 @@ img.lqip.loaded {
 .form-field-error .form-textarea,
 .form-field-error .form-select {
   border-color: var(--err);
+}
+
+/* === AUTH PAGES === */
+
+.auth-page{
+  display:flex;
+  justify-content:center;
+  align-items:flex-start;
+  padding:3rem 1rem;
+  min-height:60vh;
+}
+
+.auth-card{
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:10px;
+  padding:2rem;
+  width:100%;
+  max-width:400px;
+  display:flex;
+  flex-direction:column;
+  gap:1.25rem;
+}
+
+.auth-card h2{
+  margin:0;
+  font-size:1.4rem;
+  color:var(--text);
+}
+
+.auth-error{
+  background:rgba(239,68,68,.1);
+  border:1px solid rgba(239,68,68,.3);
+  color:var(--err);
+  border-radius:6px;
+  padding:.6rem .85rem;
+  font-size:.875rem;
+}
+
+.auth-success{
+  background:rgba(34,197,94,.1);
+  border:1px solid rgba(34,197,94,.3);
+  color:#16a34a;
+  border-radius:6px;
+  padding:.6rem .85rem;
+  font-size:.875rem;
+}
+
+.auth-field{
+  display:flex;
+  flex-direction:column;
+  gap:.35rem;
+}
+
+.auth-field label{
+  font-size:.875rem;
+  font-weight:500;
+  color:var(--text);
+}
+
+.auth-actions{
+  display:flex;
+  align-items:center;
+  gap:1rem;
+  margin-top:.5rem;
+}
+
+.auth-link{
+  font-size:.875rem;
+  color:var(--ring);
+  text-decoration:none;
+}
+
+.auth-link:hover{
+  text-decoration:underline;
+}
+
+.auth-alt{
+  margin:0;
+  font-size:.875rem;
+  color:var(--muted);
+  text-align:center;
+}
+
+.auth-alt a{
+  color:var(--ring);
+  text-decoration:none;
+}
+
+.auth-alt a:hover{
+  text-decoration:underline;
 }
 
 /* === CARD DISPLAY COMPONENTS === */

--- a/code/web/static/tailwind.css
+++ b/code/web/static/tailwind.css
@@ -100,6 +100,9 @@ body {
 .top-banner h1{ font-size: 1.1rem; margin:0; margin-left: 25px; }
 .flex-row{ display: flex; align-items: center; gap: 25px; }
 .top-banner .banner-left{ width: 260px !important; flex-shrink: 0 !important; }
+/* User auth nav — right side of banner */
+.banner-right{ display:flex; align-items:center; gap:.5rem; margin-left:auto; flex-shrink:0; }
+.banner-username{ font-size:.85rem; color:var(--surface-banner-text); opacity:.85; padding:0 .25rem; white-space:nowrap; }
 /* Hide elements on all screen sizes */
 #btn-open-permalink{ display:none !important; }
 #banner-status{ display:none !important; }
@@ -1825,6 +1828,19 @@ img.lqip.loaded { filter: blur(0); opacity: 1; }
 	color: #fff;
 }
 
+.btn-danger-sm {
+	display: inline-block;
+	background: var(--err, #c0392b);
+	color: #fff;
+	border: none;
+	border-radius: 6px;
+	padding: 0.25rem 0.6rem;
+	font-size: 0.8rem;
+	cursor: pointer;
+	line-height: 1;
+}
+.btn-danger-sm:hover { filter: brightness(1.1); }
+
 /* Button Sizes */
 .btn-sm {
 	padding: 0.25rem 0.75rem;
@@ -2202,6 +2218,21 @@ img.lqip.loaded { filter: blur(0); opacity: 1; }
 .form-field-error .form-select {
 	border-color: var(--err);
 }
+
+/* === AUTH PAGES === */
+.auth-page{ display:flex; justify-content:center; align-items:flex-start; padding:3rem 1rem; min-height:60vh; }
+.auth-card{ background:var(--panel); border:1px solid var(--border); border-radius:10px; padding:2rem; width:100%; max-width:400px; display:flex; flex-direction:column; gap:1.25rem; }
+.auth-card h2{ margin:0; font-size:1.4rem; color:var(--text); }
+.auth-error{ background:rgba(239,68,68,.1); border:1px solid rgba(239,68,68,.3); color:var(--err); border-radius:6px; padding:.6rem .85rem; font-size:.875rem; }
+.auth-success{ background:rgba(34,197,94,.1); border:1px solid rgba(34,197,94,.3); color:#16a34a; border-radius:6px; padding:.6rem .85rem; font-size:.875rem; }
+.auth-field{ display:flex; flex-direction:column; gap:.35rem; }
+.auth-field label{ font-size:.875rem; font-weight:500; color:var(--text); }
+.auth-actions{ display:flex; align-items:center; gap:1rem; margin-top:.5rem; }
+.auth-link{ font-size:.875rem; color:var(--ring); text-decoration:none; }
+.auth-link:hover{ text-decoration:underline; }
+.auth-alt{ margin:0; font-size:.875rem; color:var(--muted); text-align:center; }
+.auth-alt a{ color:var(--ring); text-decoration:none; }
+.auth-alt a:hover{ text-decoration:underline; }
 
 /* === CARD DISPLAY COMPONENTS === */
 /* Card Thumbnail Container */

--- a/code/web/templates/admin/audit.html
+++ b/code/web/templates/admin/audit.html
@@ -1,0 +1,42 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="page-content">
+  <div style="display:flex; align-items:center; gap:1rem; margin-bottom:1rem;">
+    <h2 style="margin:0;">Audit Log</h2>
+    <a href="/admin/" class="btn btn-sm btn-ghost">&#8592; Users</a>
+  </div>
+
+  {% if not events %}
+  <p style="color:var(--text-muted);">No events recorded yet.</p>
+  {% else %}
+  <div style="overflow-x:auto;">
+    <table style="width:100%; border-collapse:collapse; font-size:0.85rem;">
+      <thead>
+        <tr style="border-bottom:1px solid var(--border); text-align:left;">
+          <th style="padding:0.4rem 0.75rem; white-space:nowrap;">Time</th>
+          <th style="padding:0.4rem 0.75rem;">Event</th>
+          <th style="padding:0.4rem 0.75rem;">User</th>
+          <th style="padding:0.4rem 0.75rem;">IP</th>
+          <th style="padding:0.4rem 0.75rem;">Detail</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for e in events %}
+        {% set _severity = "var(--danger, #c0392b)" if "failed" in e.event_type or "rate_limited" in e.event_type or "delete" in e.event_type else ("var(--blue-main)" if "login" == e.event_type or "register" == e.event_type else "var(--text-muted)") %}
+        <tr style="border-bottom:1px solid var(--border-subtle, var(--border));">
+          <td style="padding:0.4rem 0.75rem; white-space:nowrap; color:var(--text-muted);">{{ e.created_at_fmt }}</td>
+          <td style="padding:0.4rem 0.75rem;">
+            <span style="color:{{ _severity }}; font-weight:500;">{{ e.event_type }}</span>
+          </td>
+          <td style="padding:0.4rem 0.75rem;">{{ e.username or "—" }}</td>
+          <td style="padding:0.4rem 0.75rem; color:var(--text-muted);">{{ e.ip or "—" }}</td>
+          <td style="padding:0.4rem 0.75rem; color:var(--text-muted);">{{ e.detail or "" }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  <p style="font-size:.8rem; color:var(--text-muted); margin-top:.75rem;">Showing up to 200 most recent events. Log is capped at 10 000 rows total.</p>
+  {% endif %}
+</div>
+{% endblock %}

--- a/code/web/templates/admin/index.html
+++ b/code/web/templates/admin/index.html
@@ -1,0 +1,104 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="page-content">
+  <div style="display:flex; align-items:center; gap:1rem; margin-bottom:1rem;">
+    <h2 style="margin:0;">Admin — User Management</h2>
+    <a href="/admin/audit" class="btn btn-sm btn-ghost">Audit Log</a>
+  </div>
+
+  {% if error %}
+  <div class="auth-error" style="margin-bottom:1rem;">{{ error }}</div>
+  {% endif %}
+  {% if success %}
+  <div class="auth-success" style="margin-bottom:1rem;">{{ success }}</div>
+  {% endif %}
+
+  <!-- Create user -->
+  <section class="card" style="margin-bottom:1.5rem; padding:1.25rem;">
+    <h3 style="margin-top:0;">Create User</h3>
+    <form method="post" action="/admin/users/create" style="display:flex; flex-wrap:wrap; gap:0.75rem; align-items:flex-end;">
+      <div class="auth-field" style="flex:1; min-width:140px;">
+        <label for="new-username">Username</label>
+        <input class="form-input" type="text" id="new-username" name="username" required autocomplete="off">
+      </div>
+      <div class="auth-field" style="flex:1; min-width:180px;">
+        <label for="new-email">Email</label>
+        <input class="form-input" type="email" id="new-email" name="email" required autocomplete="off">
+      </div>
+      <div class="auth-field" style="flex:1; min-width:160px;">
+        <label for="new-password">Password</label>
+        <input class="form-input" type="password" id="new-password" name="password" required minlength="8" autocomplete="new-password">
+      </div>
+      <div>
+        <button type="submit" class="btn">Create</button>
+      </div>
+    </form>
+  </section>
+
+  <!-- User list -->
+  <section class="card" style="padding:1.25rem;">
+    <h3 style="margin-top:0;">Users ({{ users | length }})</h3>
+    {% if not users %}
+    <p style="color:var(--text-muted);">No non-guest accounts registered yet.</p>
+    {% else %}
+    {% set _me = request.state.current_user.id %}
+    <table style="width:100%; border-collapse:collapse; font-size:0.9rem;">
+      <thead>
+        <tr style="border-bottom:1px solid var(--border); text-align:left;">
+          <th style="padding:0.5rem 0.75rem;">Username</th>
+          <th style="padding:0.5rem 0.75rem;">Status</th>
+          <th style="padding:0.5rem 0.75rem; text-align:right;">Actions</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for u in users %}
+        {% set _is_self = (u.id == _me) %}
+        <tr style="border-bottom:1px solid var(--border-subtle, var(--border));{% if not u.is_active %} opacity:0.55;{% endif %}">
+          <td style="padding:0.5rem 0.75rem;">
+            {{ u.username }}
+            {% if u.is_admin %}<span style="margin-left:.4rem; padding:1px 6px; border-radius:999px; font-size:11px; font-weight:600; background:var(--blue-main); color:#fff;">Admin</span>{% endif %}
+            {% if _is_self %}<span style="margin-left:.4rem; padding:1px 6px; border-radius:999px; font-size:11px; color:var(--text-muted);">(you)</span>{% endif %}
+          </td>
+          <td style="padding:0.5rem 0.75rem; color:var(--text-muted);">{{ "Active" if u.is_active else "Inactive" }}</td>
+          <td style="padding:0.5rem 0.75rem; text-align:right; display:flex; gap:0.5rem; justify-content:flex-end; flex-wrap:wrap;">
+            <!-- Grant / revoke admin -->
+            {% if u.is_admin %}
+            <form method="post" action="/admin/users/{{ u.id }}/revoke-admin" onsubmit="return confirm('Revoke admin from {{ u.username }}?');">
+              <button type="submit" class="btn btn-sm btn-ghost" {% if _is_self %}disabled title="Cannot revoke your own admin access"{% endif %}>Revoke Admin</button>
+            </form>
+            {% else %}
+            <form method="post" action="/admin/users/{{ u.id }}/grant-admin" onsubmit="return confirm('Grant admin to {{ u.username }}?');">
+              <button type="submit" class="btn btn-sm btn-ghost">Grant Admin</button>
+            </form>
+            {% endif %}
+            <!-- Activate / deactivate -->
+            <form method="post" action="/admin/users/{{ u.id }}/toggle-active" onsubmit="return confirm('{% if u.is_active %}Deactivate{% else %}Activate{% endif %} user {{ u.username }}?');">
+              <button type="submit" class="btn btn-sm btn-ghost" {% if _is_self %}disabled title="Cannot deactivate your own account"{% endif %}>
+                {{ "Deactivate" if u.is_active else "Activate" }}
+              </button>
+            </form>
+            <!-- Change password (only when SMTP is not configured; otherwise users self-serve) -->
+            {% if not smtp_configured %}
+            <details style="display:inline-block; position:relative;">
+              <summary class="btn btn-sm btn-ghost" style="cursor:pointer; list-style:none;">Change Password</summary>
+              <div style="position:absolute; right:0; z-index:10; background:var(--surface); border:1px solid var(--border); border-radius:6px; padding:0.75rem; min-width:220px; top:2rem;">
+                <form method="post" action="/admin/users/{{ u.id }}/password" style="display:flex; flex-direction:column; gap:0.5rem;">
+                  <input class="form-input" type="password" name="new_password" placeholder="New password (8+ chars)" required minlength="8" autocomplete="new-password">
+                  <button type="submit" class="btn btn-sm">Set Password</button>
+                </form>
+              </div>
+            </details>
+            {% endif %}
+            <!-- Delete -->
+            <form method="post" action="/admin/users/{{ u.id }}/delete" onsubmit="return confirm('Delete user {{ u.username }}? This cannot be undone.');">
+              <button type="submit" class="btn btn-sm" style="background:var(--danger, #c0392b); color:#fff; border-color:var(--danger, #c0392b);">Delete</button>
+            </form>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    {% endif %}
+  </section>
+</div>
+{% endblock %}

--- a/code/web/templates/auth/forgot.html
+++ b/code/web/templates/auth/forgot.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="auth-page">
+  <div class="auth-card">
+    <h2>Forgot Password</h2>
+
+    {% if submitted %}
+    <div class="auth-success">
+      If that email is registered, you'll receive a reset link shortly.
+      {% if not error %}Check your inbox (or server logs if SMTP isn't configured).{% endif %}
+    </div>
+    <p class="auth-alt"><a href="/auth/login">Back to Log In</a></p>
+
+    {% elif not smtp_configured %}
+    <div class="auth-error">
+      Password reset by email is not configured on this server.<br>
+      Please contact an administrator to have your password reset.
+    </div>
+    <p class="auth-alt"><a href="/auth/login">Back to Log In</a></p>
+
+    {% else %}
+
+    {% if error %}
+    <div class="auth-error">{{ error }}</div>
+    {% endif %}
+
+    <p style="margin:0; font-size:.9rem; color:var(--muted);">Enter your email address and we'll send you a link to reset your password.</p>
+
+    <form method="post" action="/auth/forgot">
+      <div style="display:flex; flex-direction:column; gap:1rem;">
+        <div class="auth-field">
+          <label for="email">Email</label>
+          <input class="form-input" type="email" id="email" name="email" required autocomplete="email" autofocus>
+        </div>
+        <div class="auth-actions">
+          <button type="submit" class="btn">Send Reset Link</button>
+          <a href="/auth/login" class="auth-link">Back to Log In</a>
+        </div>
+      </div>
+    </form>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/code/web/templates/auth/login.html
+++ b/code/web/templates/auth/login.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="auth-page">
+  <div class="auth-card">
+    <h2>Log In</h2>
+
+    {% if reset_success %}
+    <div class="auth-success">Your password has been reset. Please log in.</div>
+    {% endif %}
+
+    {% if error %}
+    <div class="auth-error">{{ error }}</div>
+    {% endif %}
+
+    <form method="post" action="/auth/login" autocomplete="on">
+      <div style="display:flex; flex-direction:column; gap:1rem;">
+        <div class="auth-field">
+          <label for="login">Username or Email</label>
+          <input class="form-input" type="text" id="login" name="login" required autocomplete="username" autofocus>
+        </div>
+        <div class="auth-field">
+          <label for="password">Password</label>
+          <input class="form-input" type="password" id="password" name="password" required autocomplete="current-password">
+        </div>
+        <div class="auth-actions">
+          <button type="submit" class="btn">Log In</button>
+          <a href="/auth/forgot" class="auth-link">Forgot password?</a>
+        </div>
+      </div>
+    </form>
+
+    <p class="auth-alt">Don't have an account? <a href="/auth/register">Sign Up</a></p>
+  </div>
+</div>
+{% endblock %}

--- a/code/web/templates/auth/profile.html
+++ b/code/web/templates/auth/profile.html
@@ -1,0 +1,54 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="auth-page">
+  <div class="auth-card">
+    <h2>Your Profile</h2>
+
+    <div style="margin-bottom:1.25rem; font-size:.9rem; color:var(--text-muted);">
+      <strong>Username:</strong> {{ request.state.current_user.username }}
+    </div>
+
+    {% if request.state.current_user.id == "__admin__" %}
+    <div class="auth-error">
+      The admin account password is managed via environment variables and cannot be changed here.
+    </div>
+    <p class="auth-alt"><a href="/">Back to Home</a></p>
+
+    {% else %}
+
+    <h3 style="margin-top:0; margin-bottom:1rem;">Change Password</h3>
+
+    {% if success %}
+    <div class="auth-success">{{ success }}</div>
+    {% endif %}
+    {% if error %}
+    <div class="auth-error">{{ error }}</div>
+    {% endif %}
+
+    <form method="post" action="/auth/profile/password" autocomplete="on">
+      <div style="display:flex; flex-direction:column; gap:1rem;">
+        <div class="auth-field">
+          <label for="current_password">Current Password</label>
+          <input class="form-input" type="password" id="current_password" name="current_password"
+                 required autocomplete="current-password" autofocus>
+        </div>
+        <div class="auth-field">
+          <label for="new_password">New Password</label>
+          <input class="form-input" type="password" id="new_password" name="new_password"
+                 required minlength="8" autocomplete="new-password">
+        </div>
+        <div class="auth-field">
+          <label for="confirm">Confirm New Password</label>
+          <input class="form-input" type="password" id="confirm" name="confirm"
+                 required minlength="8" autocomplete="new-password">
+        </div>
+        <div class="auth-actions">
+          <button type="submit" class="btn">Update Password</button>
+          <a href="/" class="auth-link">Cancel</a>
+        </div>
+      </div>
+    </form>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/code/web/templates/auth/register.html
+++ b/code/web/templates/auth/register.html
@@ -1,0 +1,38 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="auth-page">
+  <div class="auth-card">
+    <h2>Create Account</h2>
+
+    {% if error %}
+    <div class="auth-error">{{ error }}</div>
+    {% endif %}
+
+    <form method="post" action="/auth/register" autocomplete="on">
+      <div style="display:flex; flex-direction:column; gap:1rem;">
+        <div class="auth-field">
+          <label for="username">Username</label>
+          <input class="form-input" type="text" id="username" name="username" required autocomplete="username" autofocus maxlength="64">
+        </div>
+        <div class="auth-field">
+          <label for="email">Email</label>
+          <input class="form-input" type="email" id="email" name="email" required autocomplete="email">
+        </div>
+        <div class="auth-field">
+          <label for="password">Password <span style="font-weight:normal; color:var(--muted);">(min 8 characters)</span></label>
+          <input class="form-input" type="password" id="password" name="password" required autocomplete="new-password" minlength="8">
+        </div>
+        <div class="auth-field">
+          <label for="confirm">Confirm Password</label>
+          <input class="form-input" type="password" id="confirm" name="confirm" required autocomplete="new-password" minlength="8">
+        </div>
+        <div class="auth-actions">
+          <button type="submit" class="btn">Sign Up</button>
+        </div>
+      </div>
+    </form>
+
+    <p class="auth-alt">Already have an account? <a href="/auth/login">Log In</a></p>
+  </div>
+</div>
+{% endblock %}

--- a/code/web/templates/auth/reset.html
+++ b/code/web/templates/auth/reset.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+{% block content %}
+<div class="auth-page">
+  <div class="auth-card">
+    <h2>Reset Password</h2>
+
+    {% if expired %}
+    <div class="auth-error">{{ error }}</div>
+    <p class="auth-alt"><a href="/auth/forgot">Request a new link</a></p>
+
+    {% else %}
+
+    {% if error %}
+    <div class="auth-error">{{ error }}</div>
+    {% endif %}
+
+    <form method="post" action="/auth/reset/{{ token }}">
+      <div style="display:flex; flex-direction:column; gap:1rem;">
+        <div class="auth-field">
+          <label for="password">New Password <span style="font-weight:normal; color:var(--muted);">(min 8 characters)</span></label>
+          <input class="form-input" type="password" id="password" name="password" required autocomplete="new-password" minlength="8" autofocus>
+        </div>
+        <div class="auth-field">
+          <label for="confirm">Confirm New Password</label>
+          <input class="form-input" type="password" id="confirm" name="confirm" required autocomplete="new-password" minlength="8">
+        </div>
+        <div class="auth-actions">
+          <button type="submit" class="btn">Set New Password</button>
+        </div>
+      </div>
+    </form>
+    {% endif %}
+  </div>
+</div>
+{% endblock %}

--- a/code/web/templates/base.html
+++ b/code/web/templates/base.html
@@ -67,6 +67,21 @@
           <h1 style="margin:0; white-space: nowrap;">MTG Deckbuilder</h1>
         </div>
         <div id="banner-status" class="banner-status" role="status" aria-live="polite"></div>
+        <div class="banner-right">
+          {% if request.state.current_user and not request.state.current_user.is_guest %}
+            <span class="banner-username">{{ request.state.current_user.username }}</span>
+            <a href="/auth/profile" class="btn btn-ghost btn-sm" style="color:var(--surface-banner-text); border-color:var(--border);">Profile</a>
+            {% if request.state.current_user.is_admin %}
+              <a href="/admin/" class="btn btn-ghost btn-sm" style="color:var(--surface-banner-text); border-color:var(--border);">Admin</a>
+            {% endif %}
+            <form method="post" action="/auth/logout" style="display:contents;">
+              <button type="submit" class="btn btn-ghost btn-sm" style="color:var(--surface-banner-text); border-color:var(--border);">Log Out</button>
+            </form>
+          {% else %}
+            <a href="/auth/login" class="btn btn-ghost btn-sm" style="color:var(--surface-banner-text); border-color:var(--border);">Log In</a>
+            <a href="/auth/register" class="btn btn-sm">Sign Up</a>
+          {% endif %}
+        </div>
       </div>
     </header>
     <div class="layout">
@@ -84,7 +99,8 @@
           <a href="/">Home</a>
           <a href="/build">Build</a>
           <a href="/decks/import">Import Deck</a>
-          {% if show_setup %}<a href="/setup">Setup/Tag</a>{% endif %}
+          {% set _is_admin = request.state.current_user and request.state.current_user.is_admin %}
+          {% if show_setup and _is_admin %}<a href="/setup">Setup/Tag</a>{% endif %}
           <a href="/owned">Owned Library</a>
           <a href="/cards">All Cards</a>
           {% if show_commanders %}<a href="/commanders">Commanders</a>{% endif %}
@@ -92,8 +108,8 @@
           <a href="/themes/">Themes</a>
           {% if random_ui %}<a href="/random">Random</a>{% endif %}
           <a href="/help">Help</a>
-          {% if show_diagnostics %}<a href="/diagnostics">Diagnostics</a>{% endif %}
-          {% if show_logs %}<a href="/logs">Logs</a>{% endif %}
+          {% if show_diagnostics and _is_admin %}<a href="/diagnostics">Diagnostics</a>{% endif %}
+          {% if show_logs and _is_admin %}<a href="/logs">Logs</a>{% endif %}
         </nav>
         {% if enable_themes %}
         <div class="sidebar-theme" role="group" aria-label="Theme">

--- a/code/web/templates/decks/index.html
+++ b/code/web/templates/decks/index.html
@@ -36,10 +36,26 @@
 </div>
 
 
-{% if items %}
-  <div id="deck-list" role="list" aria-labelledby="decks-heading" style="list-style:none; padding:0; margin:0; display:block;">
-    {% for it in items %}
-      <div class="panel" role="listitem" tabindex="0" data-name="{{ it.name }}" data-commander="{{ it.commander }}" data-tags="{{ (it.tags|join(' ')) if it.tags else '' }}" data-tags-pipe="{{ (it.tags|join('|')) if it.tags else '' }}" data-mtime="{{ it.mtime if it.mtime is defined else 0 }}" data-txt="{{ '1' if it.txt_path else '0' }}" style="margin:0 0 .5rem 0;">
+{% set has_any = sections and sections | selectattr('decks') | list | length > 0 %}
+{% if has_any %}
+  <div id="deck-list" style="list-style:none; padding:0; margin:0; display:block;">
+    {% for sec in sections %}
+    {% if sec.decks %}
+    <div class="deck-section" data-section="{{ sec.id }}">
+      <div class="deck-section-header" style="margin:.75rem 0 .4rem 0; padding-bottom:.3rem; border-bottom:1px solid var(--border,#374151);">
+        <strong style="font-size:1rem;">{{ sec.label }}</strong>
+        {% if sec.subtitle %}<span class="muted" style="font-size:12px; margin-left:.5rem;">{{ sec.subtitle }}</span>{% endif %}
+      </div>
+      {% for it in sec.decks %}
+      <div class="panel" role="listitem" tabindex="0"
+           data-name="{{ it.name }}"
+           data-commander="{{ it.commander }}"
+           data-tags="{{ (it.tags|join(' ')) if it.tags else '' }}"
+           data-tags-pipe="{{ (it.tags|join('|')) if it.tags else '' }}"
+           data-mtime="{{ it.mtime if it.mtime is defined else 0 }}"
+           data-txt="{{ '1' if it.txt_path else '0' }}"
+           data-section="{{ sec.id }}"
+           style="margin:0 0 .5rem 0;">
         <div style="display:flex; justify-content:space-between; align-items:center; gap:.5rem;">
           <div>
             <div>
@@ -69,6 +85,7 @@
             </label>
             <form action="/decks/download-csv" method="get" style="display:inline; margin:0;">
               <input type="hidden" name="name" value="{{ it.name }}" />
+              <input type="hidden" name="section" value="{{ sec.id }}" />
               <button type="submit" title="Download CSV" aria-label="Download CSV for {{ it.commander }}">CSV</button>
             </form>
             {% if it.txt_path %}
@@ -79,11 +96,27 @@
             {% endif %}
             <form action="/decks/view" method="get" style="display:inline; margin:0;">
               <input type="hidden" name="name" value="{{ it.name }}" />
-              <button type="submit" aria-label="Open deck {{ it.commander }}"{% if prefetch_enabled %} data-prefetch="1" data-prefetch-url="/decks/view?name={{ it.name|urlencode }}"{% endif %}>Open</button>
+              <input type="hidden" name="section" value="{{ sec.id }}" />
+              <button type="submit" aria-label="Open deck {{ it.commander }}"{% if prefetch_enabled %} data-prefetch="1" data-prefetch-url="/decks/view?name={{ it.name|urlencode }}&section={{ sec.id }}"{% endif %}>Open</button>
             </form>
+            {% set _u = request.state.current_user %}
+            {% set _can_delete = (_u and not _u.is_guest and sec.id == 'mine') or (_u and _u.is_admin) %}
+            {% if _can_delete %}
+            <form method="post" action="/decks/delete?name={{ it.name|urlencode }}&section={{ sec.id }}"
+                  hx-post="/decks/delete?name={{ it.name|urlencode }}&section={{ sec.id }}"
+                  hx-target="closest .panel"
+                  hx-swap="outerHTML"
+                  hx-confirm="Delete '{{ it.name }}'? This cannot be undone."
+                  style="display:inline; margin:0;">
+              <button type="submit" class="btn-danger-sm" title="Delete this deck" aria-label="Delete {{ it.commander }}">Delete</button>
+            </form>
+            {% endif %}
           </div>
         </div>
       </div>
+      {% endfor %}
+    </div>
+    {% endif %}
     {% endfor %}
   </div>
   <div id="deck-empty" class="muted" style="display:none; margin-top:.5rem;">No decks match your filters.</div>
@@ -102,7 +135,7 @@
           <li><kbd>Arrow ↑/↓</kbd>, <kbd>Home</kbd>, <kbd>End</kbd> navigate rows</li>
           <li><kbd>Esc</kbd> clears the filter (when focused)</li>
           <li><kbd>R</kbd> resets all filters, sort, and theme</li>
-          <li>Use “TXT only” to show only decks that have a TXT export</li>
+          <li>Use "TXT only" to show only decks that have a TXT export</li>
           <li>Share copies a link with your current filters</li>
         </ul>
       </div>
@@ -246,6 +279,13 @@
     try { if (txtOnlyCb && txtOnlyCb.checked) { txtOk = (row.dataset.txt === '1'); } } catch(_){ }
     row.style.display = (textMatch && tagMatch && txtOk) ? '' : 'none';
       });
+      // Hide section headers when all their panels are filtered out
+      Array.prototype.forEach.call(list.querySelectorAll('.deck-section'), function(sec){
+        var hasVisible = Array.prototype.some.call(sec.querySelectorAll('.panel'), function(p){
+          return p.style.display !== 'none';
+        });
+        sec.style.display = hasVisible ? '' : 'none';
+      });
     }
 
     function highlightMatches(){
@@ -290,8 +330,7 @@
 
   function applySort(){
       var mode = (sortSel && sortSel.value) || 'newest';
-      var rows = panels.slice();
-      rows.sort(function(a,b){
+      function sortFn(a, b){
         if (mode === 'newest' || mode === 'oldest'){
           var am = parseFloat(a.dataset.mtime || '0');
           var bm = parseFloat(b.dataset.mtime || '0');
@@ -303,9 +342,21 @@
           return (mode === 'name-asc') ? cmp : -cmp;
         }
         return 0;
-      });
-      // Re-append in new order
-  rows.forEach(function(r){ list.appendChild(r); });
+      }
+      // Sort within each section to preserve grouping
+      var deckSections = Array.prototype.slice.call(list.querySelectorAll('.deck-section'));
+      if (deckSections.length > 1) {
+        deckSections.forEach(function(sec){
+          var sRows = Array.prototype.slice.call(sec.querySelectorAll('.panel'));
+          sRows.sort(sortFn);
+          sRows.forEach(function(r){ sec.appendChild(r); });
+        });
+      } else {
+        // Single section or flat list: sort globally
+        var rows = panels.slice();
+        rows.sort(sortFn);
+        rows.forEach(function(r){ list.appendChild(r); });
+      }
   refreshPanels();
     }
 
@@ -502,13 +553,18 @@
     // Open deck: keyboard and mouse helpers on panels
     function getPanelUrl(p){
       try {
-        var name = p.getAttribute('data-name') || '';
-        if (name) return '/decks/view?name=' + encodeURIComponent(name);
         var form = p.querySelector('form[action="/decks/view"]');
         if (form) {
           var nameInput = form.querySelector('input[name="name"]');
-          if (nameInput && nameInput.value) return '/decks/view?name=' + encodeURIComponent(nameInput.value);
+          var secInput = form.querySelector('input[name="section"]');
+          if (nameInput && nameInput.value) {
+            var url = '/decks/view?name=' + encodeURIComponent(nameInput.value);
+            if (secInput && secInput.value && secInput.value !== 'mine') url += '&section=' + encodeURIComponent(secInput.value);
+            return url;
+          }
         }
+        var name = p.getAttribute('data-name') || '';
+        if (name) return '/decks/view?name=' + encodeURIComponent(name);
       } catch(_){ }
       return '/decks/view';
     }
@@ -645,3 +701,4 @@
     #deck-list .panel.selected { box-shadow: 0 0 0 2px #10b981 inset; border-color: #10b981; }
 </style>
 {% endblock %}
+

--- a/code/web/templates/home.html
+++ b/code/web/templates/home.html
@@ -7,7 +7,13 @@
     {{ button('Build a Deck', variant='secondary', href='/build', classes='action-button home-button', attrs='style="background:#0d47a1;color:#fff;border-color:#0d47a1;" onmouseover="this.style.background=\'#0a3472\';this.style.borderColor=\'#0a3472\';" onmouseout="this.style.background=\'#0d47a1\';this.style.borderColor=\'#0d47a1\';"') }}
     {{ button('Import a Deck', variant='primary', href='/decks/import', classes='action-button home-button') }}
     {{ button('Run a JSON Config', variant='secondary', href='/configs', classes='action-button home-button') }}
-    {% if show_setup %}{{ button('Initial Setup', variant='secondary', href='/setup', classes='action-button home-button') }}{% endif %}
+    {% set _is_admin = request.state.current_user and request.state.current_user.is_admin %}
+    {% if show_setup and _is_admin %}{{ button('Initial Setup', variant='secondary', href='/setup', classes='action-button home-button') }}{% endif %}
+    {% if show_setup and not _is_admin and not setup_ready %}
+    <div style="grid-column:1/-1; padding:.6rem .9rem; border-radius:6px; background:var(--info-bg,#1e3a5f); color:var(--info-text,#93c5fd); border:1px solid var(--info-border,#3b82f6); font-size:.875rem;">
+      Initial setup has not been completed yet. Sign in as an admin to run it.
+    </div>
+    {% endif %}
     {{ button('Owned Library', variant='secondary', href='/owned', classes='action-button home-button') }}
     {{ button('Browse All Cards', variant='secondary', href='/cards', classes='action-button home-button') }}
     {% if show_commanders %}{{ button('Browse Commanders', variant='secondary', href='/commanders', classes='action-button home-button') }}{% endif %}
@@ -15,8 +21,8 @@
     {{ button('Browse Themes', variant='secondary', href='/themes/', classes='action-button home-button') }}
     {{ button('Help & Guides', variant='secondary', href='/help', classes='action-button home-button') }}
     {% if random_ui %}{{ button('Random Build', variant='secondary', href='/random', classes='action-button home-button') }}{% endif %}
-    {% if show_diagnostics %}{{ button('Diagnostics', variant='secondary', href='/diagnostics', classes='action-button home-button') }}{% endif %}
-    {% if show_logs %}{{ button('View Logs', variant='secondary', href='/logs', classes='action-button home-button') }}{% endif %}
+    {% if show_diagnostics and _is_admin %}{{ button('Diagnostics', variant='secondary', href='/diagnostics', classes='action-button home-button') }}{% endif %}
+    {% if show_logs and _is_admin %}{{ button('View Logs', variant='secondary', href='/logs', classes='action-button home-button') }}{% endif %}
   </div>
   <div id="themes-quick" style="margin-top:1rem; font-size:.85rem; color:var(--text-muted);">
     <span id="themes-quick-status">Themes: …</span>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -267,7 +267,35 @@ services:
       # Redis backend (optional)
       # THEME_PREVIEW_REDIS_URL: "redis://redis:6379/0"
       # THEME_PREVIEW_REDIS_DISABLE: "0"        # 1=force disable redis even if URL is set
+
+      # ------------------------------------------------------------------
+      # User Authentication
+      # SESSION_SECRET: required in production — set to a random 32-byte hex string.
+      #   Generate one with: openssl rand -hex 32
+      #   If unset, a random key is used each restart (all sessions invalidated).
+      # SESSION_SECURE_COOKIES: set to 1 when serving over HTTPS.
+      # SMTP_*: credentials go in secrets.env only — never in docker-compose.yml.
+      #   ENABLE_SMTP: 0 disables email even when credentials are present in secrets.env.
+      # ------------------------------------------------------------------
+
+      # Auth / Session
+      # SESSION_SECRET and ADMIN_* credentials are loaded from secrets.env (see that file).
+      # SESSION_SECURE_COOKIES: "0"   # 1=Secure flag on session cookie (requires HTTPS)
+
+      # Admin account (credentials loaded from secrets.env — never commit secrets.env)
+      # Create secrets.env alongside docker-compose.yml with:
+      #   ADMIN_USERNAME=admin
+      #   ADMIN_PASSWORD=<strong-password>
+      # The admin account is never stored in the database; it is synthesised at
+      # runtime from these env vars. Leave both unset to disable the admin account.
+
+      # SMTP (credentials in secrets.env)
+      ENABLE_SMTP: "0"              # 1=enable email (requires SMTP_HOST in secrets.env); 0=disable
+    env_file:
+      - path: secrets.env
+        required: false
     volumes:
+      - ${PWD}/data:/app/data
       - ${PWD}/deck_files:/app/deck_files
       - ${PWD}/logs:/app/logs
       - ${PWD}/csv_files:/app/csv_files

--- a/dockerhub-docker-compose.yml
+++ b/dockerhub-docker-compose.yml
@@ -268,7 +268,25 @@ services:
       # Redis backend (optional)
       # THEME_PREVIEW_REDIS_URL: "redis://redis:6379/0"
       # THEME_PREVIEW_REDIS_DISABLE: "0"        # 1=force disable redis even if URL is set
+
+      # ------------------------------------------------------------------
+      # User Authentication
+      # SESSION_SECRET: required in production — set to a random 32-byte hex string.
+      #   Generate one with: openssl rand -hex 32
+      #   If unset, a random key is used each restart (all sessions invalidated).
+      # SESSION_SECURE_COOKIES: set to 1 when serving over HTTPS.
+      # SMTP_*: credentials go in secrets.env only — never in docker-compose.yml.
+      #   ENABLE_SMTP: 0 disables email even when credentials are present in secrets.env.
+      # ------------------------------------------------------------------
+
+      # Auth / Session
+      # SESSION_SECRET: "paste-64-char-hex-from-secrets-token-hex-32-here"  # Required in production
+      # SESSION_SECURE_COOKIES: "0"   # 1=Secure flag on session cookie (requires HTTPS)
+
+      # SMTP (credentials in secrets.env)
+      ENABLE_SMTP: "0"              # 1=enable email (requires SMTP_HOST in secrets.env); 0=disable
     volumes:
+      - ${PWD}/data:/app/data
       - ${PWD}/deck_files:/app/deck_files
       - ${PWD}/logs:/app/logs
       - ${PWD}/csv_files:/app/csv_files

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,9 @@ PyYAML>=6.0
 # Markdown rendering for web-accessible documentation
 markdown>=3.5.0
 
+# Auth / user accounts
+bcrypt>=4.0.0
+itsdangerous>=2.1.0
+aiosmtplib>=3.0.0
+
 # Development dependencies are in requirements-dev.txt

--- a/secrets.env.example
+++ b/secrets.env.example
@@ -1,0 +1,44 @@
+# secrets.env.example — copy this to secrets.env and fill in your values.
+# secrets.env is gitignored and will never be committed.
+#
+# Usage:
+#   cp secrets.env.example secrets.env
+#   # edit secrets.env with your values
+#   docker compose up --build -d
+
+# ---------------------------------------------------------------------------
+# Session secret
+# ---------------------------------------------------------------------------
+# Required in production. All active sessions are invalidated if this changes.
+# Generate with: openssl rand -hex 32
+# If unset, a random key is generated each restart (fine for development only).
+SESSION_SECRET=
+
+# ---------------------------------------------------------------------------
+# Admin account
+# ---------------------------------------------------------------------------
+# The admin account is synthetic — credentials are checked against these env
+# vars and the account is never stored in the database.
+# Set both USERNAME and PASSWORD to enable; leave either blank to disable.
+#
+# Once you have promoted a real DB user to admin via /admin/, you can disable
+# this default account by uncommenting ADMIN_ENABLED=0 (recommended for
+# production deployments).
+ADMIN_USERNAME=
+ADMIN_PASSWORD=
+# ADMIN_ENABLED=0
+
+# ---------------------------------------------------------------------------
+# SMTP (password reset emails) — optional
+# ---------------------------------------------------------------------------
+# If SMTP_HOST is unset, password reset emails are disabled and the admin must
+# reset passwords manually via the admin panel.
+#
+# SMTP_HOST=smtp.example.com
+# SMTP_PORT=587
+# SMTP_USERNAME=
+# SMTP_PASSWORD=
+# SMTP_FROM=noreply@example.com
+# SMTP_TLS=1       # STARTTLS (default). Set SMTP_SSL=1 for implicit TLS (port 465).
+# SMTP_SSL=0
+# ENABLE_SMTP=0    # uncomment to disable email even if credentials are set above


### PR DESCRIPTION
Adds a full user account system to the web UI.

## What's included

- **User accounts**: register, login, logout, per-user file isolation (`deck_files/{user_id}/`, `owned_cards/{user_id}/`, `config/{user_id}/`)
- **Admin panel** (`/admin/`): create, deactivate, delete accounts; grant/revoke admin role; change passwords when SMTP is not configured
- **Env-based admin account**: configured via `ADMIN_USERNAME`/`ADMIN_PASSWORD` in `secrets.env`; disable with `ADMIN_ENABLED=0` after promoting a DB user to admin
- **Profile page** (`/auth/profile`): self-service password changes for authenticated users
- **Audit log** (`/admin/audit`): all auth and admin events recorded, capped at 10,000 rows
- **SMTP email**: welcome email on registration, account-created email (with set-password link) for admin-created users, forgot-password flow; gated by `ENABLE_SMTP` toggle
- **Login rate limiting**: per-IP (5/10 min) and per-username (10/15 min) lockout
- **`secrets.env` / `secrets.env.example`**: gitignored credential file for `SESSION_SECRET`, admin credentials, and SMTP settings
- **Admin-restricted pages**: Setup, Diagnostics, and Logs restricted to admin accounts

See `CHANGELOG.md` for full details.