### PR TITLE
chore: bump postcss to 8.5.10 (fixes GHSA-qx2v-qp2m-jg93)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "devDependencies": {
         "autoprefixer": "^10.4.21",
-        "postcss": "^8.5.6",
+        "postcss": "^8.5.10",
         "tailwindcss": "^3.4.18",
         "typescript": "^5.9.3"
       }
@@ -257,9 +257,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+      "integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -984,9 +984,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "ISC",
   "devDependencies": {
     "autoprefixer": "^10.4.21",
-    "postcss": "^8.5.6",
+    "postcss": "^8.5.10",
     "tailwindcss": "^3.4.18",
     "typescript": "^5.9.3"
   }


### PR DESCRIPTION
Bumps the postcss devDependency from 8.5.6 to 8.5.10, resolving Dependabot alert #8 (CVE-2026-41305 / GHSA-qx2v-qp2m-jg93), an XSS-via-unescaped-\</style>\ issue in PostCSS's CSS stringify output.

Also ran \
pm audit fix\ to clear a moderate \race-expansion\ ReDoS finding (Dependabot alert #7, already auto-dismissed) along the way.

- postcss: 8.5.6 -> 8.5.10
- \
pm audit\: 0 vulnerabilities remaining

Dev-only dependency used for our Tailwind build; no runtime CSS from untrusted/user input is ever passed through PostCSS, so actual exposure was low, but no reason not to patch.