### PR TITLE
fix: deck path scoping (upgrades, import, synergy export) and /files security

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,18 @@ This format follows Keep a Changelog principles and aims for Semantic Versioning
 _No unreleased changes yet_
 
 ### Changed
-_No unreleased changes yet_
+- "Popular in your past builds" theme recommendations now consider every past build across all accounts, not just the shared pre-accounts folder; a deck's visibility (private/unlisted/public) has no bearing on this signal
 
 ### Fixed
-_No unreleased changes yet_
+- **Potential Upgrades page** (`/decks/upgrades`) returned "Page Not Found" for any logged-in user because it always looked for decks in the shared guest folder instead of the account's own folder; viewing upgrade suggestions on another account's public deck now also works, while applying a swap remains restricted to the deck's owner (or an admin)
+- **Imported decks** (via Deck Import & Analysis) were always saved to the shared root folder instead of the importing account's own folder; also fixed the saved sidecar file's format so imported decks display correctly and respect your default visibility preference
+- **Synergy deck export** (Batch Build & Compare) had the same shared-root-folder and sidecar-format issue as imported decks; fixed the same way
 
 ### Removed
 _No unreleased changes yet_
 
 ### Security
-_No unreleased changes yet_
+- **File download endpoint hardening**: the internal file-download link used by CSV/TXT export buttons validated access with a loose check on the file path that could be manipulated to read another account's deck files. It now only serves files that resolve to the current account's own deck folder or the public pre-accounts folder
 
 ## [4.9.1] - 2026-07-17
 ### Added

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -5,14 +5,16 @@
 _No unreleased changes yet_
 
 ### Changed
-_No unreleased changes yet_
+- "Popular in your past builds" theme recommendations now consider every past build across all accounts, not just the shared pre-accounts folder; a deck's visibility (private/unlisted/public) has no bearing on this signal
 
 ### Fixed
-_No unreleased changes yet_
+- **Potential Upgrades page** (`/decks/upgrades`) returned "Page Not Found" for any logged-in user because it always looked for decks in the shared guest folder instead of the account's own folder; viewing upgrade suggestions on another account's public deck now also works, while applying a swap remains restricted to the deck's owner (or an admin)
+- **Imported decks** (via Deck Import & Analysis) were always saved to the shared root folder instead of the importing account's own folder; also fixed the saved sidecar file's format so imported decks display correctly and respect your default visibility preference
+- **Synergy deck export** (Batch Build & Compare) had the same shared-root-folder and sidecar-format issue as imported decks; fixed the same way
 
 ### Removed
 _No unreleased changes yet_
 
 ### Security
-_No unreleased changes yet_
+- **File download endpoint hardening**: the internal file-download link used by CSV/TXT export buttons validated access with a loose check on the file path that could be manipulated to read another account's deck files. It now only serves files that resolve to the current account's own deck folder or the public pre-accounts folder
 

--- a/code/web/app.py
+++ b/code/web/app.py
@@ -2432,6 +2432,7 @@ from .routes import build_compliance as build_compliance_routes  # noqa: E402
 from .routes import build_permalinks as build_permalinks_routes  # noqa: E402
 from .routes import configs as config_routes  # noqa: E402
 from .routes import decks as decks_routes  # noqa: E402
+from .routes.decks import _deck_dir as _decks_deck_dir, _user_id as _decks_user_id  # noqa: E402
 from .routes import upgrade_suggestions as upgrade_suggestions_routes  # noqa: E402
 from .routes import setup as setup_routes  # noqa: E402
 from .routes import owned as owned_routes  # noqa: E402
@@ -2622,27 +2623,41 @@ async def random_modes_page(request: Request) -> HTMLResponse:
         },
     )
 
-# Lightweight file download endpoint for exports
+# Lightweight file download endpoint for exports.
+#
+# SECURITY: only serves files that resolve to (a) the current requester's own
+# deck-export directory or (b) the shared pre-accounts "legacy" deck_files/
+# root (files directly in the root, always visible to everyone - the same
+# rule the Finished Decks "legacy" section already uses). Anything else is
+# rejected. Do NOT relax this to a substring/"contains deck_files" check -
+# that previously allowed path traversal (e.g. "config/../../secrets.env")
+# and cross-user file disclosure (any user's deck_files/{other_uuid}/... was
+# readable by anyone, private decks included) since the check ran on the
+# raw, unresolved path string instead of a resolved, directory-scoped one.
 @app.get("/files")
-async def get_file(path: str):
+async def get_file(request: Request, path: str):
     try:
-        p = Path(path)
-        if not p.exists() or not p.is_file():
-            return PlainTextResponse("File not found", status_code=404)
-        # Only allow returning files within the workspace directory for safety
-        # (best-effort: require relative to current working directory)
-        try:
-            cwd = Path.cwd().resolve()
-            if cwd not in p.resolve().parents and p.resolve() != cwd:
-                # Still allow if under deck_files or config
-                allowed = any(seg in ("deck_files", "config", "logs") for seg in p.parts)
-                if not allowed:
-                    return PlainTextResponse("Access denied", status_code=403)
-        except Exception:
-            pass
-        return FileResponse(path)
+        target = Path(path).resolve()
     except Exception:
-        return PlainTextResponse("Error serving file", status_code=500)
+        return PlainTextResponse("Invalid path", status_code=400)
+
+    if target.suffix.lower() not in (".csv", ".txt", ".json"):
+        return PlainTextResponse("Access denied", status_code=403)
+
+    own_dir = _decks_deck_dir(_decks_user_id(request))
+    legacy_root = Path(os.getenv("DECK_EXPORTS") or "deck_files").resolve()
+    # own_dir is allowed at any depth (deck files sit directly in it today,
+    # but this keeps room for future sidecars); legacy_root must match
+    # exactly - not a subdirectory - so other users' per-user folders (which
+    # also live under deck_files/) are never reachable this way.
+    allowed = own_dir in target.parents or target.parent == own_dir or target.parent == legacy_root
+    if not allowed:
+        return PlainTextResponse("Access denied", status_code=403)
+
+    if not target.exists() or not target.is_file():
+        return PlainTextResponse("File not found", status_code=404)
+
+    return FileResponse(str(target))
 
 # Serve /favicon.ico from static (prefer .ico, fallback to .png)
 @app.get("/favicon.ico")

--- a/code/web/routes/compare.py
+++ b/code/web/routes/compare.py
@@ -525,9 +525,9 @@ async def export_synergy_deck(request: Request, batch_id: str):
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     base_filename = f"{commander_name}_Synergy_{timestamp}"
     
-    # Prepare deck_files directory
+    # Prepare deck_files directory (per-user, matching how the batch itself was built)
     from pathlib import Path
-    deck_files_dir = Path("deck_files")
+    deck_files_dir = Path(config.get("deck_dir") or "deck_files")
     deck_files_dir.mkdir(parents=True, exist_ok=True)
     
     # Create CSV content
@@ -601,9 +601,12 @@ async def export_synergy_deck(request: Request, batch_id: str):
         csv_path.write_text(csv_content, encoding='utf-8')
         txt_path.write_text(txt_content, encoding='utf-8')
         
-        # Create summary JSON (similar to individual builds)
-        summary_data = {
+        # Create summary JSON (similar to individual builds).  Nested under
+        # "meta" to match the schema every other saved-deck view expects.
+        from ..services.deck_visibility import resolve_visibility_for_write
+        meta_data = {
             "commander": config.get("commander", "Unknown"),
+            "name": config.get("commander", "Unknown"),
             "tags": config.get("tags", []),
             "colors": config.get("colors", []),
             "bracket_level": config.get("bracket"),
@@ -617,9 +620,10 @@ async def export_synergy_deck(request: Request, batch_id: str):
                 "high_frequency_count": synergy_deck["high_frequency_count"],
                 "source_builds": len(builds)
             },
-            "exported_at": timestamp
+            "exported_at": timestamp,
+            "visibility": resolve_visibility_for_write(csv_path, deck_dir=deck_files_dir),
         }
-        summary_path.write_text(json.dumps(summary_data, indent=2), encoding='utf-8')
+        summary_path.write_text(json.dumps({"meta": meta_data, "summary": {}}, indent=2), encoding='utf-8')
         
         # Create compliance JSON (basic compliance for synergy deck)
         compliance_data = {

--- a/code/web/routes/deck_import.py
+++ b/code/web/routes/deck_import.py
@@ -31,6 +31,7 @@ from ..services.deck_import_service import (
     write_temp_session,
 )
 from ..services.tasks import get_session_value, new_sid, set_session_value
+from .decks import _deck_dir, _user_id
 
 router = APIRouter(prefix="/decks", tags=["import"])
 
@@ -357,7 +358,11 @@ async def post_import_save(
     request: Request,
     token: str = Form(...),
 ) -> HTMLResponse:
-    """Save an imported deck to deck_files/ as permanent CSV + TXT + summary.json.
+    """Save an imported deck as permanent CSV + TXT + summary.json.
+
+    Saves into the current user's own deck directory (``deck_files/{user_id}/``,
+    or ``deck_files/guest/`` for guests) so imported decks are scoped the same
+    way as built decks.
 
     Reads enriched/analysis from session (primary) or temp file (fallback).
     On success, redirects to the new deck's view page.
@@ -374,7 +379,8 @@ async def post_import_save(
         enriched, analysis, _ = temp_result
 
     try:
-        csv_name, _txt_name, _summary_name = save_imported_deck(token, enriched, analysis)
+        deck_dir = str(_deck_dir(_user_id(request)))
+        csv_name, _txt_name, _summary_name = save_imported_deck(token, enriched, analysis, deck_dir=deck_dir)
     except Exception as exc:
         ctx = {
             "request": request,

--- a/code/web/routes/decks.py
+++ b/code/web/routes/decks.py
@@ -585,6 +585,7 @@ def _render_deck_view(
         "tags": tags,
         "display_name": display_name,
         "is_owner": is_owner,
+        "owner_user_id": owner_user_id,
         "deck_visibility": _get_deck_visibility_by_path(p),
         "visibility_options": VALID_VISIBILITIES,
         "share_url": f"/decks/{owner_username}/{p.name}" if owner_username else None,

--- a/code/web/routes/upgrade_suggestions.py
+++ b/code/web/routes/upgrade_suggestions.py
@@ -32,7 +32,8 @@ from ..services.upgrade_suggestions_service import (
     UpgradeSuggestionsService,
     _DEFAULT_IDEAL_ROLE_TAGS,
 )
-from .decks import _deck_dir, _safe_within
+from .decks import _deck_dir, _safe_within, _user_id, _check_deck_access
+from ..services.user_db import get_user_by_id
 
 router = APIRouter(prefix="/decks", tags=["upgrades"])
 
@@ -53,7 +54,7 @@ def _get_svc() -> UpgradeSuggestionsService:
 # Deck loading helpers
 # ---------------------------------------------------------------------------
 
-def _load_deck(name: str) -> tuple[Path, dict, list[DeckCard], list[str], list[str]]:
+def _load_deck(name: str, owner_user_id: str) -> tuple[Path, dict, list[DeckCard], list[str], list[str]]:
     """Load a deck CSV and return (csv_path, meta, deck_cards, themes, color_identity).
 
     Parses the CSV directly to capture proper CMC values.  Skips the trailing
@@ -64,7 +65,7 @@ def _load_deck(name: str) -> tuple[Path, dict, list[DeckCard], list[str], list[s
     import csv as _csv
     import json as _json
 
-    deck_dir = _deck_dir()
+    deck_dir = _deck_dir(owner_user_id)
     target = (deck_dir / name).resolve()
     if not _safe_within(deck_dir, target):
         raise HTTPException(status_code=404, detail="Deck not found")
@@ -485,12 +486,19 @@ async def deck_upgrades(
     name: str = Query(..., description="Deck CSV filename"),
     section: str = Query("new"),
     page: int = Query(1, ge=1),
+    owner: Optional[str] = Query(None, description="Owner's user id; defaults to the current user"),
 ) -> HTMLResponse:
     if not ENABLE_UPGRADE_SUGGESTIONS:
         raise HTTPException(status_code=404, detail="Upgrade suggestions disabled")
 
+    uid = _user_id(request)
+    owner_user_id = owner or uid
+    if not _check_deck_access(request, owner_user_id, name):
+        raise HTTPException(status_code=404, detail="Deck not found")
+    is_owner = owner_user_id == uid
+
     per_page = max(5, min(50, int(UPGRADE_PAGE_SIZE)))
-    csv_path, meta, deck_cards, themes, color_identity = _load_deck(name)
+    csv_path, meta, deck_cards, themes, color_identity = _load_deck(name, owner_user_id)
     excluded_names: set[str] = meta.get("excluded_names") or set()
     card_ceiling: Optional[float] = meta.get("card_ceiling")
 
@@ -505,6 +513,9 @@ async def deck_upgrades(
     ctx = {
         "request": request,
         "name": name,
+        "owner": owner_user_id,
+        "is_owner": is_owner,
+        "owner_username": None if is_owner else (get_user_by_id(owner_user_id) or {}).get("username"),
         "commander": meta.get("commander", ""),
         "color_identity": color_identity,
         "section": section,
@@ -520,12 +531,19 @@ async def deck_upgrades_cards(
     name: str = Query(...),
     section: str = Query("new"),
     page: int = Query(1, ge=1),
+    owner: Optional[str] = Query(None, description="Owner's user id; defaults to the current user"),
 ) -> HTMLResponse:
     if not ENABLE_UPGRADE_SUGGESTIONS:
         raise HTTPException(status_code=404, detail="Upgrade suggestions disabled")
 
+    uid = _user_id(request)
+    owner_user_id = owner or uid
+    if not _check_deck_access(request, owner_user_id, name):
+        raise HTTPException(status_code=404, detail="Deck not found")
+    is_owner = owner_user_id == uid
+
     per_page = max(5, min(50, int(UPGRADE_PAGE_SIZE)))
-    csv_path, meta, deck_cards, themes, color_identity = _load_deck(name)
+    csv_path, meta, deck_cards, themes, color_identity = _load_deck(name, owner_user_id)
     excluded_names: set[str] = meta.get("excluded_names") or set()
     card_ceiling: Optional[float] = meta.get("card_ceiling")
 
@@ -540,6 +558,8 @@ async def deck_upgrades_cards(
     ctx = {
         "request": request,
         "name": name,
+        "owner": owner_user_id,
+        "is_owner": is_owner,
         "commander": meta.get("commander", ""),
         "color_identity": color_identity,
         "section": section,
@@ -554,11 +574,16 @@ async def deck_upgrades_swaps(
     request: Request,
     name: str = Query(...),
     card: str = Query(...),
+    owner: Optional[str] = Query(None, description="Owner's user id; defaults to the current user"),
 ) -> HTMLResponse:
     if not ENABLE_UPGRADE_SUGGESTIONS:
         raise HTTPException(status_code=404, detail="Upgrade suggestions disabled")
 
-    csv_path, meta, deck_cards, themes, color_identity = _load_deck(name)
+    owner_user_id = owner or _user_id(request)
+    if not _check_deck_access(request, owner_user_id, name):
+        raise HTTPException(status_code=404, detail="Deck not found")
+
+    csv_path, meta, deck_cards, themes, color_identity = _load_deck(name, owner_user_id)
 
     # Look up the card's roles from the parquet to build a proper UpgradeCandidate.
     roles: list[str] = []
@@ -934,8 +959,12 @@ async def deck_upgrades_apply_swap(
     name: str = Form(...),
     remove: str = Form(...),
     add: str = Form(...),
+    owner: Optional[str] = Form(None, description="Owner's user id; defaults to the current user"),
 ) -> HTMLResponse:
     """Apply a card swap: remove `remove` from the deck and insert `add`.
+
+    Only the deck's owner (or an admin) may apply a swap; other viewers may
+    see suggestions but cannot modify the deck.
 
     Returns a small HTMX fragment replacing the swap-item row:
     - Success: a green "Swapped" confirmation chip
@@ -944,8 +973,17 @@ async def deck_upgrades_apply_swap(
     if not ENABLE_UPGRADE_SUGGESTIONS:
         raise HTTPException(status_code=404, detail="Upgrade suggestions disabled")
 
+    uid = _user_id(request)
+    owner_user_id = owner or uid
+    user = getattr(request.state, "current_user", None)
+    is_admin = bool(user and user.get("is_admin"))
+    if owner_user_id != uid and not is_admin:
+        return HTMLResponse(
+            '<span class="upgrade-swap-error">Only the deck owner can apply upgrades.</span>'
+        )
+
     # --- Resolve and validate deck path ---
-    deck_dir = _deck_dir()
+    deck_dir = _deck_dir(owner_user_id)
     csv_path = (deck_dir / name).resolve()
     if not _safe_within(deck_dir, csv_path):
         raise HTTPException(status_code=403, detail="Invalid deck path")
@@ -953,7 +991,7 @@ async def deck_upgrades_apply_swap(
         raise HTTPException(status_code=404, detail="Deck not found")
 
     # --- Load deck to validate remove/add ---
-    _, meta, deck_cards, _, _ = _load_deck(name)
+    _, meta, deck_cards, _, _ = _load_deck(name, owner_user_id)
 
     deck_names_lower = {c.name.lower() for c in deck_cards}
     commanders_lower = {c.name.lower() for c in deck_cards if c.is_commander}

--- a/code/web/services/deck_import_service.py
+++ b/code/web/services/deck_import_service.py
@@ -1987,10 +1987,13 @@ def save_imported_deck(
     token: str,
     enriched: "EnrichedDeck",
     analysis: "DeckAnalysis",
+    deck_dir: Optional[str] = None,
 ) -> tuple[str, str, str]:
     """Write permanent deck files for an imported deck.
 
-    Creates three files atomically in ``deck_files/``:
+    Creates three files atomically in ``deck_dir`` (defaults to the shared
+    ``deck_files/`` root when omitted; callers should pass the importing
+    user's own per-user directory, e.g. ``deck_files/{user_id}/``):
       - ``{slug}_{date}.csv``   - full card list in built-deck CSV schema
       - ``{slug}_{date}.txt``   - one-line-per-card plain text list
       - ``{slug}_{date}.summary.json`` - metadata sidecar (source="imported")
@@ -2001,26 +2004,27 @@ def save_imported_deck(
     """
     import os  # noqa: PLC0415
 
+    deck_dir = deck_dir or _DECK_FILES_DIR
     commander_name = analysis.commander_name or "Unknown"
     slug = _safe_slug(commander_name)
     today = _date.today().strftime("%Y%m%d")
     base = f"{slug}_{today}"
 
     # Avoid clobbering an existing file for same commander on same day
-    os.makedirs(_DECK_FILES_DIR, exist_ok=True)
+    os.makedirs(deck_dir, exist_ok=True)
     counter = 0
     while True:
         suffix = f"_{counter}" if counter else ""
         csv_name = f"{base}{suffix}.csv"
-        csv_path = os.path.join(_DECK_FILES_DIR, csv_name)
+        csv_path = os.path.join(deck_dir, csv_name)
         if not os.path.exists(csv_path):
             break
         counter += 1
 
     txt_name = csv_name.replace(".csv", ".txt")
     summary_name = csv_name.replace(".csv", ".summary.json")
-    txt_path = os.path.join(_DECK_FILES_DIR, txt_name)
-    summary_path = os.path.join(_DECK_FILES_DIR, summary_name)
+    txt_path = os.path.join(deck_dir, txt_name)
+    summary_path = os.path.join(deck_dir, summary_name)
 
     themes = (
         analysis.themes.user_confirmed
@@ -2092,6 +2096,8 @@ def save_imported_deck(
 
     # --- Summary JSON ---
     try:
+        from .deck_visibility import resolve_visibility_for_write  # noqa: PLC0415
+
         meta = {
             "commander": commander_name,
             "commander_names": [commander_name],
@@ -2102,6 +2108,7 @@ def save_imported_deck(
             "csv": csv_name,
             "txt": txt_name,
             "import_token": token,
+            "visibility": resolve_visibility_for_write(csv_path, deck_dir=deck_dir),
         }
         with open(summary_path, "w", encoding="utf-8") as fh:
             json.dump({"meta": meta, "summary": {}}, fh, ensure_ascii=False, indent=2)

--- a/code/web/services/orchestrator.py
+++ b/code/web/services/orchestrator.py
@@ -716,27 +716,48 @@ def _get_cached_commander_df():
 
 
 def _get_past_builds_index() -> Dict[str, List[Dict[str, Any]]]:
-    """M7: Return cached index of past builds: commander_name -> list of {tags, age_days}."""
+    """M7: Return cached index of past builds: commander_name -> list of {tags, age_days}.
+
+    Scans every user's deck directory (not just the shared root/legacy area),
+    since this theme-popularity signal should reflect all past builds
+    regardless of who built them. Deck visibility controls who can *view* a
+    deck, not whether it contributes to this recommendation.
+    """
     global _PAST_BUILDS_CACHE
-    
-    deck_files_dir = 'deck_files'
+
+    deck_files_dir = os.getenv("DECK_EXPORTS") or 'deck_files'
     need_rebuild = _PAST_BUILDS_CACHE["index"] is None
-    
-    if not need_rebuild:
-        # Check if deck_files directory has changed
+
+    def _current_signature() -> float:
+        """Max mtime across the root dir and every immediate subdirectory (per-user folders)."""
+        latest = 0.0
         try:
             if os.path.exists(deck_files_dir):
-                current_mtime = os.path.getmtime(deck_files_dir)
-                cached_mtime = _PAST_BUILDS_CACHE.get("mtime")
-                if cached_mtime is None or current_mtime > cached_mtime:
-                    need_rebuild = True
+                latest = os.path.getmtime(deck_files_dir)
+                for entry in os.scandir(deck_files_dir):
+                    if entry.is_dir():
+                        try:
+                            latest = max(latest, entry.stat().st_mtime)
+                        except OSError:
+                            continue
         except Exception:
             pass
-    
+        return latest
+
+    if not need_rebuild:
+        try:
+            current_mtime = _current_signature()
+            cached_mtime = _PAST_BUILDS_CACHE.get("mtime")
+            if cached_mtime is None or current_mtime > cached_mtime:
+                need_rebuild = True
+        except Exception:
+            pass
+
     if need_rebuild:
         index: Dict[str, List[Dict[str, Any]]] = {}
         try:
-            for path in glob(os.path.join(deck_files_dir, '*.summary.json')):
+            pattern = os.path.join(deck_files_dir, '**', '*.summary.json')
+            for path in glob(pattern, recursive=True):
                 try:
                     st = os.stat(path)
                     age_days = max(0, (time.time() - st.st_mtime) / 86400.0)
@@ -760,8 +781,7 @@ def _get_past_builds_index() -> Dict[str, List[Dict[str, Any]]]:
                     continue
             
             _PAST_BUILDS_CACHE["index"] = index
-            if os.path.exists(deck_files_dir):
-                _PAST_BUILDS_CACHE["mtime"] = os.path.getmtime(deck_files_dir)
+            _PAST_BUILDS_CACHE["mtime"] = _current_signature()
         except Exception:
             _PAST_BUILDS_CACHE["index"] = {}
             _PAST_BUILDS_CACHE["mtime"] = None

--- a/code/web/templates/decks/_upgrade_card.html
+++ b/code/web/templates/decks/_upgrade_card.html
@@ -63,15 +63,19 @@
         {% set _rs = [(swap.swap_score / 2.0)|round(1), 10.0]|min %}
         <span class="upgrade-swap-score-pill" title="Replaceability score (1-10): how upgradable this card is">{{ _rs }}</span>
         {% endif %}
+        {% set _can_apply = is_owner or (request.state.current_user and request.state.current_user.is_admin) %}
+        {% if _can_apply %}
         <form hx-post="/decks/upgrades/apply-swap"
               hx-target="this"
               hx-swap="outerHTML"
               style="display:inline; margin:0;">
           <input type="hidden" name="name" value="{{ name }}">
+          <input type="hidden" name="owner" value="{{ owner }}">
           <input type="hidden" name="remove" value="{{ swap.name }}">
           <input type="hidden" name="add" value="{{ upgrade_card.name }}">
           <button type="submit" class="upgrade-swap-btn" hx-disabled-elt="this" title="Remove {{ swap.name }} and add {{ upgrade_card.name }} to your deck">Apply</button>
         </form>
+        {% endif %}
       </div>
       {% endfor %}
     </div>

--- a/code/web/templates/decks/_upgrade_cards_fragment.html
+++ b/code/web/templates/decks/_upgrade_cards_fragment.html
@@ -48,21 +48,21 @@
     {% if page > 1 %}
     <a class="btn btn-sm"
        role="button"
-       href="/decks/upgrades?name={{ name|urlencode }}&section={{ section }}&page={{ page - 1 }}"
-       hx-get="/decks/upgrades/cards?name={{ name|urlencode }}&section={{ section }}&page={{ page - 1 }}"
+       href="/decks/upgrades?name={{ name|urlencode }}&section={{ section }}&page={{ page - 1 }}&owner={{ owner|urlencode }}"
+       hx-get="/decks/upgrades/cards?name={{ name|urlencode }}&section={{ section }}&page={{ page - 1 }}&owner={{ owner|urlencode }}"
        hx-target="#upgrade-card-list"
        hx-swap="outerHTML"
-       hx-push-url="/decks/upgrades?name={{ name|urlencode }}&section={{ section }}&page={{ page - 1 }}">&laquo; Prev</a>
+       hx-push-url="/decks/upgrades?name={{ name|urlencode }}&section={{ section }}&page={{ page - 1 }}&owner={{ owner|urlencode }}">&laquo; Prev</a>
     {% endif %}
     <span class="muted text-sm">Page {{ page }} of {{ total_pages }}</span>
     {% if page < total_pages %}
     <a class="btn btn-sm"
        role="button"
-       href="/decks/upgrades?name={{ name|urlencode }}&section={{ section }}&page={{ page + 1 }}"
-       hx-get="/decks/upgrades/cards?name={{ name|urlencode }}&section={{ section }}&page={{ page + 1 }}"
+       href="/decks/upgrades?name={{ name|urlencode }}&section={{ section }}&page={{ page + 1 }}&owner={{ owner|urlencode }}"
+       hx-get="/decks/upgrades/cards?name={{ name|urlencode }}&section={{ section }}&page={{ page + 1 }}&owner={{ owner|urlencode }}"
        hx-target="#upgrade-card-list"
        hx-swap="outerHTML"
-       hx-push-url="/decks/upgrades?name={{ name|urlencode }}&section={{ section }}&page={{ page + 1 }}">Next &raquo;</a>
+       hx-push-url="/decks/upgrades?name={{ name|urlencode }}&section={{ section }}&page={{ page + 1 }}&owner={{ owner|urlencode }}">Next &raquo;</a>
     {% endif %}
   </div>
   {% endif %}

--- a/code/web/templates/decks/upgrade_suggestions.html
+++ b/code/web/templates/decks/upgrade_suggestions.html
@@ -12,16 +12,22 @@
 </div>
 
 <div style="display:flex; gap:.5rem; flex-wrap:wrap; margin-bottom:1rem;">
-  <a href="/decks/upgrades?name={{ name|urlencode }}&section=new&page=1"
+  <a href="/decks/upgrades?name={{ name|urlencode }}&section=new&page=1&owner={{ owner|urlencode }}"
      class="btn{% if section == 'new' %} btn-active{% endif %}"
      role="button">New Cards{% if section == "new" and total_cards %} ({{ total_cards }}){% endif %}</a>
-  <a href="/decks/upgrades?name={{ name|urlencode }}&section=general&page=1"
+  <a href="/decks/upgrades?name={{ name|urlencode }}&section=general&page=1&owner={{ owner|urlencode }}"
      class="btn{% if section == 'general' %} btn-active{% endif %}"
      role="button">General Upgrades{% if section == "general" and total_cards %} ({{ total_cards }}){% endif %}</a>
-  <a href="/decks/upgrades?name={{ name|urlencode }}&section=possible&page=1"
+  <a href="/decks/upgrades?name={{ name|urlencode }}&section=possible&page=1&owner={{ owner|urlencode }}"
      class="btn{% if section == 'possible' %} btn-active{% endif %}"
      role="button">Possible Upgrades{% if section == "possible" and total_cards %} ({{ total_cards }}){% endif %}</a>
+  {% if is_owner %}
   <a href="/decks/view?name={{ name|urlencode }}" class="btn" role="button">Back to Deck</a>
+  {% elif owner_username %}
+  <a href="/decks/{{ owner_username }}/{{ name|urlencode }}" class="btn" role="button">Back to Deck</a>
+  {% else %}
+  <a href="/decks" class="btn" role="button">Back to Finished Decks</a>
+  {% endif %}
   {% if back_url is defined and back_url %}
   <a href="{{ back_url }}" class="btn" role="button">Back to Import</a>
   {% endif %}

--- a/code/web/templates/decks/view.html
+++ b/code/web/templates/decks/view.html
@@ -73,7 +73,7 @@
       <a href="/decks/compare?A={{ name|urlencode }}" class="btn" role="button" title="Compare this deck with another">Compare…</a>
 
       {% if enable_upgrade_suggestions %}
-      <a href="/decks/upgrades?name={{ name|urlencode }}" class="btn" role="button" title="View potential card upgrades">Potential Upgrades</a>
+      <a href="/decks/upgrades?name={{ name|urlencode }}&owner={{ owner_user_id|urlencode }}" class="btn" role="button" title="View potential card upgrades">Potential Upgrades</a>
       {% endif %}
       <form method="get" action="/decks" style="display:inline; margin:0;">
         <button type="submit">Back to Finished Decks</button>

--- a/docs/user_guides/suggested_upgrades.md
+++ b/docs/user_guides/suggested_upgrades.md
@@ -8,6 +8,8 @@ The **Potential Upgrades** page surfaces card suggestions for any saved deck, or
 
 From any finished deck's view page, click **Potential Upgrades**. The button only appears for saved decks (not mid-build previews).
 
+Anyone who can view a deck (its owner, or anyone if the deck is Unlisted/Public) can browse suggestions here. Only the deck's owner (or an admin) can click **Apply** to actually swap a card into the saved deck; other viewers see the same suggestions without the Apply button.
+
 ---
 
 ## Two Upgrade Sections


### PR DESCRIPTION
Fixes several places that predated per-user deck accounts and never got updated to use each account's own deck folder, plus hardens a file-download endpoint.

## What's included

- **Potential Upgrades page fix**: `/decks/upgrades` returned "Page Not Found" for any logged-in user because it always looked in the shared guest folder instead of the account's own folder. Viewing upgrade suggestions on another account's public deck now also works; applying a swap remains restricted to the deck's owner (or an admin).
- **Deck Import fix**: imported decks were always saved to the shared root folder instead of the importing account's own folder. Also fixed the saved sidecar file's format so imported decks display correctly and respect your default visibility preference.
- **Synergy deck export fix** (Batch Build & Compare): same shared-root-folder and sidecar-format issue as imported decks, fixed the same way.
- **Recommendation fix**: "Popular in your past builds" now considers every past build across all accounts, not just the shared pre-accounts folder; a deck's visibility has no bearing on this signal.
- **Security**: hardened the internal file-download endpoint (used by CSV/TXT export buttons), which validated access with a loose check on the file path that could be manipulated to read another account's deck files. It now only serves files that resolve to the current account's own deck folder or the public pre-accounts folder.

See `CHANGELOG.md` for full details.
