### PR TITLE
feat: public REST API at /api/v1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -222,6 +222,11 @@ DEBIAN_FRONTEND=noninteractive      # Suppress apt UI in Docker builds.
 # SMTP_SSL=0                        # 1=SSL (use with port 465)
 
 ############################
+# Public REST API (/api/v1)
+############################
+API_DOCS_ENABLED=1                  # dockerhub: API_DOCS_ENABLED="1" (1=serve Swagger UI at /api/v1/docs and Redoc at /api/v1/redoc; 0=disable in production)
+
+############################
 # Editorial / Theme Catalog (Phase D) – Advanced
 ############################
 # The following variables control automated theme catalog generation,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ This format follows Keep a Changelog principles and aims for Semantic Versioning
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- **Public REST API** (`/api/v1`): a full JSON API for third-party tools and the upcoming mobile app
+  - Deck building (start a build, poll progress, fetch the finished deck) plus deck management (list, view, export, delete, upgrade suggestions)
+  - Card, commander, and theme browsing/search; owned-card list management; live TCGPlayer/Card Kingdom price checks; saved headless configs
+  - Account registration/login/logout and API key management, authenticated with per-account API keys instead of the website's login cookie
+  - Interactive documentation at `/api/v1/docs` (Swagger) and `/api/v1/redoc`; disable both in production with `API_DOCS_ENABLED=0`
 
 ### Changed
 _No unreleased changes yet_

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -308,6 +308,7 @@ See `.env.example` for the full catalog. Common knobs:
 | `SHOW_NEW_BADGE` | `1` | Show the "New" badge on recently released cards across the site. Set to `0` to suppress the badge without disabling upgrade suggestions. |
 | `UPGRADE_WINDOW_MONTHS` | `6` | Rolling-months window used to identify New Cards (cards released within the last N months). |
 | `UPGRADE_PAGE_SIZE` | `16` | Cards shown per page on the Potential Upgrades page (valid range: 5–50). |
+| `API_DOCS_ENABLED` | `1` | Serve interactive Swagger UI at `/api/v1/docs` and Redoc at `/api/v1/redoc` for the public REST API. Set to `0` to disable both in production. |
 
 ### Random build controls
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,12 @@ Browse all user guides without leaving the browser.
 - Contextual help icons throughout the build wizard link directly to the relevant guide section without interrupting the workflow.
 - Also reachable via the "Help & Guides" button on the home page.
 
+### Public API
+A full JSON REST API mirroring the web UI's core features, for scripting and third-party clients.
+- Base path `/api/v1`; every response is a JSON envelope (`{"ok": true, "data": ...}` or `{"ok": false, "error": ..., "code": ...}`).
+- Covers deck building, deck management, card/commander/theme browsing, owned-card lists, price checks, upgrade suggestions, headless configs, and account auth (register/login/logout), all authenticated with per-account API keys (`Authorization: Bearer <key>`).
+- Interactive docs at `/api/v1/docs` (Swagger UI) and `/api/v1/redoc`; toggle both with `API_DOCS_ENABLED`.
+
 ---
 
 ## User accounts
@@ -469,6 +475,11 @@ Most defaults are defined in `docker-compose.yml` and documented in `.env.exampl
 | `ENABLE_UPGRADE_SUGGESTIONS` | `1` | Enable the Potential Upgrades page and surfacing suggestions on saved deck views. |
 | `UPGRADE_PAGE_SIZE` | `16` | Number of upgrade suggestions shown per page. |
 | `UPGRADE_WINDOW_MONTHS` | `6` | Months of release history considered for the New Cards tab. |
+
+### Public API
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `API_DOCS_ENABLED` | `1` | Serve Swagger UI (`/api/v1/docs`) and Redoc (`/api/v1/redoc`) for the public REST API. Set to `0` to disable both in production. |
 
 ### Supplemental themes
 | Variable | Default | Purpose |

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -2,7 +2,11 @@
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- **Public REST API** (`/api/v1`): a full JSON API for third-party tools and the upcoming mobile app
+  - Deck building (start a build, poll progress, fetch the finished deck) plus deck management (list, view, export, delete, upgrade suggestions)
+  - Card, commander, and theme browsing/search; owned-card list management; live TCGPlayer/Card Kingdom price checks; saved headless configs
+  - Account registration/login/logout and API key management, authenticated with per-account API keys instead of the website's login cookie
+  - Interactive documentation at `/api/v1/docs` (Swagger) and `/api/v1/redoc`; disable both in production with `API_DOCS_ENABLED=0`
 
 ### Changed
 _No unreleased changes yet_

--- a/code/tests/test_api_v1_builds.py
+++ b/code/tests/test_api_v1_builds.py
@@ -1,0 +1,178 @@
+"""Tests for the public API's deck-build endpoints (Roadmap 28, Milestone 3).
+
+Mocks `orch.start_build_ctx`/`orch.run_stage` (per the existing convention in
+test_build_utils_ctx.py) to avoid the full commander-data integration; the
+build engine itself is already covered elsewhere. Focus here is on the
+API's routing, auth, background execution, and store lifecycle.
+"""
+from __future__ import annotations
+
+import time
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    import code.web.services.user_db as user_db
+    monkeypatch.setattr(user_db, "_DATA_DIR", tmp_path)
+    monkeypatch.setattr(user_db, "_DB_PATH", tmp_path / "users.db")
+    user_db.init_db()
+    yield
+
+
+@pytest.fixture()
+def client(_isolated_db):
+    from code.web.app import app
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+@pytest.fixture()
+def auth_headers(client):
+    from code.web.services.user_db import create_user, create_api_key
+
+    user = create_user("henry", "henry@example.com", "pw")
+    key_plain, _ = create_api_key(user["id"])
+    return {"Authorization": f"Bearer {key_plain}"}
+
+
+def _fake_orchestrator(monkeypatch, *, stage_count: int = 2, fail: bool = False):
+    """Patch code.web.routes.api_v1.builds.orch with a fake single-stage engine."""
+    import code.web.routes.api_v1.builds as builds_route
+
+    def _fake_start_build_ctx(**kwargs):
+        return {"stages": list(range(stage_count)), "idx": 0}
+
+    def _fake_run_stage(ctx, *args, **kwargs):
+        if fail:
+            raise RuntimeError("boom")
+        ctx["idx"] += 1
+        if ctx["idx"] >= len(ctx["stages"]):
+            return {
+                "done": True,
+                "idx": ctx["idx"],
+                "total": len(ctx["stages"]),
+                "label": "Complete",
+                "csv_path": "deck_files/Test.csv",
+                "txt_path": "deck_files/Test.txt",
+                "summary": {"type_breakdown": {"total": 100}},
+                "compliance": {"overall": "PASS"},
+            }
+        return {"done": False, "idx": ctx["idx"], "total": len(ctx["stages"]), "label": "Stage"}
+
+    monkeypatch.setattr(builds_route.orch, "start_build_ctx", _fake_start_build_ctx)
+    monkeypatch.setattr(builds_route.orch, "run_stage", _fake_run_stage)
+    monkeypatch.setattr(builds_route.orch, "ideal_defaults", lambda: {})
+    monkeypatch.setattr(builds_route.orch, "bracket_options", lambda: [{"level": 1}])
+
+
+def _poll_until_done(client, headers, build_id, timeout=5.0):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        resp = client.get(f"/api/v1/builds/{build_id}", headers=headers)
+        data = resp.json()["data"]
+        if data["status"] in ("done", "error"):
+            return data
+        time.sleep(0.05)
+    raise AssertionError("build did not finish in time")
+
+
+def test_create_build_requires_auth(client):
+    resp = client.post("/api/v1/builds", json={"commander": "Test Commander"})
+    assert resp.status_code == 401
+
+
+def test_create_build_requires_commander(client, auth_headers, monkeypatch):
+    _fake_orchestrator(monkeypatch)
+    resp = client.post("/api/v1/builds", json={"commander": "  "}, headers=auth_headers)
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "INVALID_COMMANDER"
+
+
+def test_full_build_lifecycle(client, auth_headers, monkeypatch):
+    _fake_orchestrator(monkeypatch)
+
+    resp = client.post(
+        "/api/v1/builds", json={"commander": "Test Commander", "themes": ["Aggro"]}, headers=auth_headers
+    )
+    assert resp.status_code == 202
+    build_id = resp.json()["data"]["build_id"]
+    assert resp.json()["data"]["status"] == "queued"
+
+    data = _poll_until_done(client, auth_headers, build_id)
+    assert data["status"] == "done"
+    assert data["progress_pct"] == 100
+
+    resp = client.get(f"/api/v1/builds/{build_id}/deck", headers=auth_headers)
+    assert resp.status_code == 200
+    result = resp.json()["data"]
+    assert result["summary"]["type_breakdown"]["total"] == 100
+    assert result["compliance"]["overall"] == "PASS"
+
+    resp = client.delete(f"/api/v1/builds/{build_id}", headers=auth_headers)
+    assert resp.status_code == 200
+
+    resp = client.get(f"/api/v1/builds/{build_id}", headers=auth_headers)
+    assert resp.status_code == 404
+
+
+def test_build_failure_reported(client, auth_headers, monkeypatch):
+    _fake_orchestrator(monkeypatch, fail=True)
+
+    resp = client.post("/api/v1/builds", json={"commander": "Test Commander"}, headers=auth_headers)
+    build_id = resp.json()["data"]["build_id"]
+
+    data = _poll_until_done(client, auth_headers, build_id)
+    assert data["status"] == "error"
+    assert "boom" in data["error"]
+
+    resp = client.get(f"/api/v1/builds/{build_id}/deck", headers=auth_headers)
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "BUILD_FAILED"
+
+
+def test_deck_not_ready_before_done(client, auth_headers, monkeypatch):
+    import threading
+    import code.web.routes.api_v1.builds as builds_route
+
+    gate = threading.Event()
+
+    def _fake_start_build_ctx(**kwargs):
+        return {"stages": [0], "idx": 0}
+
+    def _fake_run_stage(ctx, *args, **kwargs):
+        gate.wait(timeout=5)  # held open until the test releases it
+        ctx["idx"] += 1
+        return {"done": True, "idx": 1, "total": 1, "label": "Complete", "summary": {}, "compliance": {}}
+
+    monkeypatch.setattr(builds_route.orch, "start_build_ctx", _fake_start_build_ctx)
+    monkeypatch.setattr(builds_route.orch, "run_stage", _fake_run_stage)
+    monkeypatch.setattr(builds_route.orch, "ideal_defaults", lambda: {})
+    monkeypatch.setattr(builds_route.orch, "bracket_options", lambda: [{"level": 1}])
+
+    resp = client.post("/api/v1/builds", json={"commander": "Test Commander"}, headers=auth_headers)
+    build_id = resp.json()["data"]["build_id"]
+
+    try:
+        resp = client.get(f"/api/v1/builds/{build_id}/deck", headers=auth_headers)
+        assert resp.status_code == 409
+        assert resp.json()["code"] == "BUILD_NOT_READY"
+    finally:
+        gate.set()
+
+
+def test_build_not_visible_to_other_user(client, auth_headers, monkeypatch):
+    from code.web.services.user_db import create_user, create_api_key
+
+    _fake_orchestrator(monkeypatch)
+    resp = client.post("/api/v1/builds", json={"commander": "Test Commander"}, headers=auth_headers)
+    build_id = resp.json()["data"]["build_id"]
+
+    other_user = create_user("iris", "iris@example.com", "pw")
+    other_key, _ = create_api_key(other_user["id"])
+    other_headers = {"Authorization": f"Bearer {other_key}"}
+
+    resp = client.get(f"/api/v1/builds/{build_id}", headers=other_headers)
+    assert resp.status_code == 404

--- a/code/tests/test_api_v1_cards.py
+++ b/code/tests/test_api_v1_cards.py
@@ -1,0 +1,144 @@
+"""Tests for the public API's card browser endpoints (Roadmap 28, Milestone 4).
+
+Uses a small fixture DataFrame (written to a temp parquet) instead of the
+real all_cards.parquet -- no auth required, so no user_db fixture is needed.
+"""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def sample_parquet_file(tmp_path):
+    df = pd.DataFrame(
+        {
+            "name": ["Sol Ring", "Lightning Bolt", "Fire // Ice", "Counterspell"],
+            "colorIdentity": ["Colorless", "R", "UR", "U"],
+            "type": ["Artifact", "Instant", "Instant // Instant", "Instant"],
+            "manaValue": [1.0, 1.0, 2.0, 2.0],
+            "rarity": ["uncommon", "common", "uncommon", "common"],
+            "themeTags": [["Ramp"], ["Removal", "Burn"], ["Removal", "Burn"], ["Counterspell"]],
+            "edhrecRank": [1.0, 50.0, 500.0, 20.0],
+            "scryfallID": ["sol-ring-id", "bolt-id", "fire-ice-id", ""],
+            "text": ["Add {C}{C}.", "Deal 3 damage.", "Deal 2 damage. // Tap target.", "Counter target spell."],
+            "power": [None, None, None, None],
+            "toughness": [None, None, None, None],
+            "printings": ["LEA", "LEA", "APC", "LEA"],
+            "layout": ["normal", "normal", "split", "normal"],
+            "isNew": [False, False, False, False],
+        }
+    )
+    path = tmp_path / "all_cards.parquet"
+    df.to_parquet(path, engine="pyarrow")
+    return str(path)
+
+
+@pytest.fixture(autouse=True)
+def _patched_loader(sample_parquet_file, monkeypatch):
+    import code.web.routes.api_v1.cards as cards_route
+    from code.services.all_cards_loader import AllCardsLoader
+
+    cards_route._loader = AllCardsLoader(file_path=sample_parquet_file)
+    cards_route._similarity = None
+    yield
+    cards_route._loader = None
+    cards_route._similarity = None
+
+
+@pytest.fixture()
+def client():
+    from code.web.app import app
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+def test_list_cards_no_filters(client):
+    resp = client.get("/api/v1/cards")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["total_count"] == 4
+    assert len(data["cards"]) == 4
+
+
+def test_list_cards_by_query(client):
+    resp = client.get("/api/v1/cards", params={"q": "bolt"})
+    data = resp.json()["data"]
+    assert data["total_count"] == 1
+    assert data["cards"][0]["name"] == "Lightning Bolt"
+
+
+def test_list_cards_by_colors(client):
+    resp = client.get("/api/v1/cards", params={"colors": "U"})
+    data = resp.json()["data"]
+    names = {c["name"] for c in data["cards"]}
+    assert names == {"Counterspell"}
+
+
+def test_list_cards_by_tags_and_logic(client):
+    resp = client.get("/api/v1/cards", params={"tags": "Removal,Burn"})
+    data = resp.json()["data"]
+    names = {c["name"] for c in data["cards"]}
+    assert names == {"Lightning Bolt", "Fire // Ice"}
+
+
+def test_list_cards_cmc_range(client):
+    resp = client.get("/api/v1/cards", params={"min_cmc": 2, "max_cmc": 2})
+    data = resp.json()["data"]
+    names = {c["name"] for c in data["cards"]}
+    assert names == {"Fire // Ice", "Counterspell"}
+
+
+def test_list_cards_pagination(client):
+    resp = client.get("/api/v1/cards", params={"page": 1, "page_size": 2})
+    data = resp.json()["data"]
+    assert len(data["cards"]) == 2
+    assert data["total_pages"] == 2
+
+
+def test_card_detail_found(client):
+    resp = client.get("/api/v1/cards/Sol Ring")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["name"] == "Sol Ring"
+    assert data["text"] == "Add {C}{C}."
+
+
+def test_card_detail_with_slash_in_name(client):
+    resp = client.get("/api/v1/cards/Fire // Ice")
+    assert resp.status_code == 200
+    assert resp.json()["data"]["name"] == "Fire // Ice"
+
+
+def test_card_detail_not_found(client):
+    resp = client.get("/api/v1/cards/Nonexistent Card")
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "CARD_NOT_FOUND"
+
+
+def test_card_similar(client):
+    resp = client.get("/api/v1/cards/Lightning Bolt/similar")
+    assert resp.status_code == 200
+    similar_names = {c["name"] for c in resp.json()["data"]}
+    assert "Fire // Ice" in similar_names
+
+
+def test_card_rulings_uses_scryfall_id(client, monkeypatch):
+    import code.web.routes.api_v1.cards as cards_route
+
+    async def _fake_get_rulings(scryfall_id):
+        assert scryfall_id == "bolt-id"
+        return [{"published_at": "2020-01-01", "source": "wotc", "comment": "Test ruling."}]
+
+    monkeypatch.setattr(cards_route, "get_rulings", _fake_get_rulings)
+
+    resp = client.get("/api/v1/cards/Lightning Bolt/rulings")
+    assert resp.status_code == 200
+    assert resp.json()["data"][0]["comment"] == "Test ruling."
+
+
+def test_card_rulings_empty_scryfall_id(client):
+    resp = client.get("/api/v1/cards/Counterspell/rulings")
+    assert resp.status_code == 200
+    assert resp.json()["data"] == []

--- a/code/tests/test_api_v1_commanders.py
+++ b/code/tests/test_api_v1_commanders.py
@@ -1,0 +1,76 @@
+"""Tests for the public API's commander catalog endpoints (Roadmap 28, Milestone 6).
+
+Uses the real commander catalog (testdata CSV set) rather than a synthetic
+fixture, matching the existing convention in test_commanders_route.py.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    from code.web.services.commander_catalog_loader import clear_commander_catalog_cache
+
+    csv_dir = Path("csv_files/testdata").resolve()
+    monkeypatch.setenv("CSV_FILES_DIR", str(csv_dir))
+    clear_commander_catalog_cache()
+    from code.web.app import app
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+    clear_commander_catalog_cache()
+
+
+@pytest.fixture()
+def sample_commander():
+    from code.web.services.commander_catalog_loader import load_commander_catalog
+
+    catalog = load_commander_catalog()
+    if not catalog.entries:
+        pytest.skip("No commander catalog available")
+    return catalog.entries[0]
+
+
+def test_list_commanders_no_filters(client, sample_commander):
+    resp = client.get("/api/v1/commanders")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["total_count"] >= 1
+    assert len(data["commanders"]) >= 1
+
+
+def test_list_commanders_by_query(client, sample_commander):
+    resp = client.get("/api/v1/commanders", params={"q": sample_commander.display_name})
+    data = resp.json()["data"]
+    names = {c["name"] for c in data["commanders"]}
+    assert sample_commander.display_name in names
+
+
+def test_commander_detail(client, sample_commander):
+    resp = client.get(f"/api/v1/commanders/{sample_commander.display_name}")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["name"] == sample_commander.display_name
+    assert "oracle_text" in data
+
+
+def test_commander_detail_not_found(client):
+    resp = client.get("/api/v1/commanders/Definitely Not A Real Commander XYZ")
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "COMMANDER_NOT_FOUND"
+
+
+def test_commander_partners(client, sample_commander):
+    resp = client.get(f"/api/v1/commanders/{sample_commander.display_name}/partners")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert "options" in data
+    assert isinstance(data["options"], list)
+
+
+def test_commander_partners_not_found(client):
+    resp = client.get("/api/v1/commanders/Definitely Not A Real Commander XYZ/partners")
+    assert resp.status_code == 404

--- a/code/tests/test_api_v1_configs.py
+++ b/code/tests/test_api_v1_configs.py
@@ -1,0 +1,112 @@
+"""Tests for the public API's config management endpoints (Roadmap 28, Milestone 9).
+
+Uses a temp `DECK_CONFIG` env var (matching configs.py's own env override)
+so no real config/ state is touched.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    import code.web.services.user_db as user_db
+    monkeypatch.setattr(user_db, "_DATA_DIR", tmp_path)
+    monkeypatch.setattr(user_db, "_DB_PATH", tmp_path / "users.db")
+    user_db.init_db()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("DECK_CONFIG", str(tmp_path / "config" / "deck.json"))
+    yield
+
+
+@pytest.fixture()
+def client(_isolated_db, _isolated_config_dir):
+    from code.web.app import app
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+@pytest.fixture()
+def auth(client):
+    from code.web.services.user_db import create_user, create_api_key
+
+    user = create_user("configuser", "configs@example.com", "pw")
+    key_plain, _ = create_api_key(user["id"])
+    return user, {"Authorization": f"Bearer {key_plain}"}
+
+
+def test_configs_require_auth(client):
+    assert client.get("/api/v1/configs").status_code == 401
+    assert client.get("/api/v1/configs/deck.json").status_code == 401
+    assert client.post("/api/v1/configs/deck.json", json={}).status_code == 401
+    assert client.request("DELETE", "/api/v1/configs/deck.json").status_code == 401
+
+
+def test_save_and_get_config(client, auth):
+    _, headers = auth
+    body = {"commander": "Krenko, Mob Boss", "primary_tag": "Goblins"}
+    resp = client.post("/api/v1/configs/goblins.json", headers=headers, json=body)
+    assert resp.status_code == 200
+    assert resp.json()["data"]["saved"] is True
+
+    resp = client.get("/api/v1/configs/goblins.json", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["data"]["config"]["commander"] == "Krenko, Mob Boss"
+
+
+def test_list_configs(client, auth):
+    _, headers = auth
+    client.post("/api/v1/configs/goblins.json", headers=headers, json={"commander": "Krenko"})
+    resp = client.get("/api/v1/configs", headers=headers)
+    assert resp.status_code == 200
+    names = [c["name"] for c in resp.json()["data"]["configs"]]
+    assert "goblins.json" in names
+
+
+def test_get_config_not_found(client, auth):
+    _, headers = auth
+    resp = client.get("/api/v1/configs/nope.json", headers=headers)
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "CONFIG_NOT_FOUND"
+
+
+def test_save_config_requires_json_extension(client, auth):
+    _, headers = auth
+    resp = client.post("/api/v1/configs/goblins.txt", headers=headers, json={"commander": "Krenko"})
+    assert resp.status_code == 400
+
+
+def test_delete_config(client, auth):
+    _, headers = auth
+    client.post("/api/v1/configs/goblins.json", headers=headers, json={"commander": "Krenko"})
+    resp = client.request("DELETE", "/api/v1/configs/goblins.json", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["data"]["deleted"] is True
+
+    resp = client.get("/api/v1/configs/goblins.json", headers=headers)
+    assert resp.status_code == 404
+
+
+def test_configs_cross_user_isolated(client):
+    from code.web.services.user_db import create_user, create_api_key
+
+    a = create_user("cfga", "cfga@example.com", "pw")
+    a_key, _ = create_api_key(a["id"])
+    b = create_user("cfgb", "cfgb@example.com", "pw")
+    b_key, _ = create_api_key(b["id"])
+
+    client.post(
+        "/api/v1/configs/secret.json",
+        headers={"Authorization": f"Bearer {a_key}"},
+        json={"commander": "Krenko"},
+    )
+    resp = client.get(
+        "/api/v1/configs/secret.json",
+        headers={"Authorization": f"Bearer {b_key}"},
+    )
+    assert resp.status_code == 404

--- a/code/tests/test_api_v1_decks.py
+++ b/code/tests/test_api_v1_decks.py
@@ -1,0 +1,172 @@
+"""Tests for the public API's deck management endpoints (Roadmap 28, Milestone 5).
+
+Uses a temp `DECK_EXPORTS` directory (matching decks.py's own env override)
+so no real deck_files/ state is touched.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    import code.web.services.user_db as user_db
+    monkeypatch.setattr(user_db, "_DATA_DIR", tmp_path)
+    monkeypatch.setattr(user_db, "_DB_PATH", tmp_path / "users.db")
+    user_db.init_db()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _isolated_deck_exports(tmp_path, monkeypatch):
+    monkeypatch.setenv("DECK_EXPORTS", str(tmp_path / "deck_files"))
+    yield
+
+
+@pytest.fixture()
+def client(_isolated_db, _isolated_deck_exports):
+    from code.web.app import app
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+@pytest.fixture()
+def auth(client):
+    from code.web.services.user_db import create_user, create_api_key
+
+    user = create_user("iris", "iris@example.com", "pw")
+    key_plain, _ = create_api_key(user["id"])
+    return user, {"Authorization": f"Bearer {key_plain}"}
+
+
+def _write_sample_deck(user_id: str, tmp_path, name: str = "Test Deck.csv"):
+    import os
+
+    deck_dir = tmp_path / "deck_files" / user_id
+    deck_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = deck_dir / name
+    csv_path.write_text(
+        "Name,Count,Type,ManaValue,Colors,Role,Tags\n"
+        "Sol Ring,1,Artifact,1,Colorless,Ramp,Ramp\n"
+        "Lightning Bolt,1,Instant,1,R,Removal,Removal;Burn\n"
+        "Total,2,,,,,\n",
+        encoding="utf-8",
+    )
+    (deck_dir / (csv_path.stem + ".txt")).write_text("1 Sol Ring\n1 Lightning Bolt\n", encoding="utf-8")
+    return csv_path
+
+
+def test_list_decks_requires_auth(client):
+    resp = client.get("/api/v1/decks")
+    assert resp.status_code == 401
+
+
+def test_list_decks(client, auth, tmp_path):
+    user, headers = auth
+    _write_sample_deck(user["id"], tmp_path)
+    resp = client.get("/api/v1/decks", headers=headers)
+    assert resp.status_code == 200
+    names = [d["name"] for d in resp.json()["data"]]
+    assert "Test Deck.csv" in names
+
+
+def test_deck_detail(client, auth, tmp_path):
+    user, headers = auth
+    _write_sample_deck(user["id"], tmp_path)
+    resp = client.get("/api/v1/decks/Test Deck.csv", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["card_count"] == 2
+    names = {c["name"] for c in data["cards"]}
+    assert names == {"Sol Ring", "Lightning Bolt"}
+
+
+def test_deck_detail_not_found(client, auth):
+    _, headers = auth
+    resp = client.get("/api/v1/decks/Nope.csv", headers=headers)
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "DECK_NOT_FOUND"
+
+
+def test_deck_detail_wrong_user_isolated(client, tmp_path):
+    """A deck saved under one user's folder must not be visible to another user."""
+    from code.web.services.user_db import create_user, create_api_key
+
+    owner = create_user("owner", "owner@example.com", "pw")
+    _write_sample_deck(owner["id"], tmp_path)
+
+    other = create_user("other", "other@example.com", "pw")
+    other_key, _ = create_api_key(other["id"])
+
+    resp = client.get(
+        "/api/v1/decks/Test Deck.csv",
+        headers={"Authorization": f"Bearer {other_key}"},
+    )
+    assert resp.status_code == 404
+
+
+def test_export_csv(client, auth, tmp_path):
+    user, headers = auth
+    _write_sample_deck(user["id"], tmp_path)
+    resp = client.get("/api/v1/decks/Test Deck.csv/export", headers=headers, params={"format": "csv"})
+    assert resp.status_code == 200
+    assert "text/csv" in resp.headers["content-type"]
+
+
+def test_export_txt(client, auth, tmp_path):
+    user, headers = auth
+    _write_sample_deck(user["id"], tmp_path)
+    resp = client.get("/api/v1/decks/Test Deck.csv/export", headers=headers, params={"format": "txt"})
+    assert resp.status_code == 200
+    assert "Sol Ring" in resp.text
+
+
+def test_export_json(client, auth, tmp_path):
+    user, headers = auth
+    _write_sample_deck(user["id"], tmp_path)
+    resp = client.get("/api/v1/decks/Test Deck.csv/export", headers=headers, params={"format": "json"})
+    assert resp.status_code == 200
+    payload = json.loads(resp.text)
+    assert payload["card_count"] == 2
+
+
+def test_delete_deck(client, auth, tmp_path):
+    user, headers = auth
+    csv_path = _write_sample_deck(user["id"], tmp_path)
+    resp = client.request("DELETE", "/api/v1/decks/Test Deck.csv", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["data"]["deleted"] is True
+    assert not csv_path.exists()
+    assert not csv_path.with_suffix(".txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# Milestone 8: upgrade suggestions
+# ---------------------------------------------------------------------------
+
+def test_deck_upgrades_requires_auth(client):
+    resp = client.get("/api/v1/decks/Test Deck.csv/upgrades")
+    assert resp.status_code == 401
+
+
+def test_deck_upgrades_not_found(client, auth):
+    _, headers = auth
+    resp = client.get("/api/v1/decks/Nope.csv/upgrades", headers=headers)
+    assert resp.status_code == 404
+
+
+def test_deck_upgrades_general_section(client, auth, tmp_path):
+    user, headers = auth
+    _write_sample_deck(user["id"], tmp_path)
+    resp = client.get(
+        "/api/v1/decks/Test Deck.csv/upgrades",
+        headers=headers,
+        params={"section": "general"},
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["section"] == "general"
+    assert isinstance(data["cards"], list)

--- a/code/tests/test_api_v1_keys.py
+++ b/code/tests/test_api_v1_keys.py
@@ -1,0 +1,132 @@
+"""Tests for the public API's key management (Roadmap 28, Milestones 1-2).
+
+Covers: user_db API key CRUD, and the /api/v1/keys routes via TestClient
+(bearer-token auth, plaintext-once, revoke, 401 on invalid/missing token).
+Uses an isolated user DB so no real data/users.db is touched.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    import code.web.services.user_db as user_db
+    monkeypatch.setattr(user_db, "_DATA_DIR", tmp_path)
+    monkeypatch.setattr(user_db, "_DB_PATH", tmp_path / "users.db")
+    user_db.init_db()
+    yield
+
+
+@pytest.fixture()
+def client(_isolated_db):
+    from code.web.app import app
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+# ---------------------------------------------------------------------------
+# user_db CRUD
+# ---------------------------------------------------------------------------
+
+def test_create_and_verify_api_key():
+    from code.web.services.user_db import create_user, create_api_key, verify_api_key
+
+    user = create_user("alice", "alice@example.com", "hunter2")
+    key_plain, api_key = create_api_key(user["id"], label="laptop")
+    assert api_key["label"] == "laptop"
+    assert api_key["is_active"] is True
+
+    verified = verify_api_key(key_plain)
+    assert verified is not None
+    assert verified["id"] == user["id"]
+
+
+def test_verify_api_key_wrong_or_revoked():
+    from code.web.services.user_db import create_user, create_api_key, verify_api_key, revoke_api_key
+
+    user = create_user("bob", "bob@example.com", "pw")
+    key_plain, api_key = create_api_key(user["id"])
+
+    assert verify_api_key("not-a-real-key") is None
+
+    revoke_api_key(api_key["id"], user["id"])
+    assert verify_api_key(key_plain) is None
+
+
+def test_list_api_keys_never_reveals_plaintext():
+    from code.web.services.user_db import create_user, create_api_key, list_api_keys
+
+    user = create_user("carol", "carol@example.com", "pw")
+    create_api_key(user["id"], label="phone")
+    keys = list_api_keys(user["id"])
+    assert len(keys) == 1
+    assert "key_hash" not in keys[0]
+    assert "key" not in keys[0]
+
+
+def test_revoke_api_key_wrong_owner_raises():
+    from code.web.services.user_db import create_user, create_api_key, revoke_api_key
+
+    owner = create_user("dave", "dave@example.com", "pw")
+    other = create_user("erin", "erin@example.com", "pw")
+    _, api_key = create_api_key(owner["id"])
+    with pytest.raises(ValueError):
+        revoke_api_key(api_key["id"], other["id"])
+
+
+# ---------------------------------------------------------------------------
+# /api/v1/keys routes
+# ---------------------------------------------------------------------------
+
+def test_keys_route_requires_bearer_token(client):
+    resp = client.get("/api/v1/keys")
+    assert resp.status_code == 401
+    body = resp.json()
+    assert body["ok"] is False
+
+
+def test_keys_route_rejects_invalid_token(client):
+    resp = client.get("/api/v1/keys", headers={"Authorization": "Bearer not-a-real-key"})
+    assert resp.status_code == 401
+
+
+def test_create_list_and_revoke_key_via_routes(client):
+    from code.web.services.user_db import create_user, create_api_key
+
+    user = create_user("frank", "frank@example.com", "pw")
+    bootstrap_plain, _ = create_api_key(user["id"], label="bootstrap")
+    headers = {"Authorization": f"Bearer {bootstrap_plain}"}
+
+    resp = client.post("/api/v1/keys", json={"label": "second-device"}, headers=headers)
+    assert resp.status_code == 201
+    created = resp.json()["data"]
+    assert "key" in created and created["key"]
+    new_key_id = created["id"]
+
+    resp = client.get("/api/v1/keys", headers=headers)
+    assert resp.status_code == 200
+    labels = {k["label"] for k in resp.json()["data"]}
+    assert labels == {"bootstrap", "second-device"}
+
+    resp = client.delete(f"/api/v1/keys/{new_key_id}", headers=headers)
+    assert resp.status_code == 200
+
+    resp = client.get("/api/v1/keys", headers=headers)
+    labels = {k["label"] for k in resp.json()["data"]}
+    assert labels == {"bootstrap"}
+
+
+def test_revoke_missing_key_returns_404_envelope(client):
+    from code.web.services.user_db import create_user, create_api_key
+
+    user = create_user("gina", "gina@example.com", "pw")
+    key_plain, _ = create_api_key(user["id"])
+    headers = {"Authorization": f"Bearer {key_plain}"}
+
+    resp = client.delete("/api/v1/keys/does-not-exist", headers=headers)
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["ok"] is False
+    assert body["code"] == "KEY_NOT_FOUND"

--- a/code/tests/test_api_v1_owned.py
+++ b/code/tests/test_api_v1_owned.py
@@ -1,0 +1,97 @@
+"""Tests for the public API's owned-cards endpoints (Roadmap 28, Milestone 7).
+
+Uses a temp `OWNED_CARDS_DIR` (matching owned_store.py's own env override)
+so no real owned_cards/ state is touched.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    import code.web.services.user_db as user_db
+    monkeypatch.setattr(user_db, "_DATA_DIR", tmp_path)
+    monkeypatch.setattr(user_db, "_DB_PATH", tmp_path / "users.db")
+    user_db.init_db()
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _isolated_owned_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("OWNED_CARDS_DIR", str(tmp_path / "owned_cards"))
+    yield
+
+
+@pytest.fixture()
+def client(_isolated_db, _isolated_owned_dir):
+    from code.web.app import app
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+@pytest.fixture()
+def auth(client):
+    from code.web.services.user_db import create_user, create_api_key
+
+    user = create_user("owneduser", "owned@example.com", "pw")
+    key_plain, _ = create_api_key(user["id"])
+    return user, {"Authorization": f"Bearer {key_plain}"}
+
+
+def test_owned_requires_auth(client):
+    assert client.get("/api/v1/owned").status_code == 401
+    assert client.post("/api/v1/owned", content="Sol Ring").status_code == 401
+    assert client.request("DELETE", "/api/v1/owned").status_code == 401
+
+
+def test_get_owned_empty(client, auth):
+    _, headers = auth
+    resp = client.get("/api/v1/owned", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data == {"names": [], "count": 0}
+
+
+def test_upload_replaces_list(client, auth):
+    _, headers = auth
+    resp = client.post("/api/v1/owned", headers=headers, content="Sol Ring\n1x Lightning Bolt\n")
+    assert resp.status_code == 200
+    assert resp.json()["data"]["total"] == 2
+
+    resp = client.get("/api/v1/owned", headers=headers)
+    names = {n.lower() for n in resp.json()["data"]["names"]}
+    assert names == {"sol ring", "lightning bolt"}
+
+    # Second upload should REPLACE, not append.
+    resp = client.post("/api/v1/owned", headers=headers, content="Counterspell\n")
+    assert resp.status_code == 200
+    resp = client.get("/api/v1/owned", headers=headers)
+    names = {n.lower() for n in resp.json()["data"]["names"]}
+    assert names == {"counterspell"}
+
+
+def test_clear_owned(client, auth):
+    _, headers = auth
+    client.post("/api/v1/owned", headers=headers, content="Sol Ring\n")
+    resp = client.request("DELETE", "/api/v1/owned", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["data"]["cleared"] is True
+
+    resp = client.get("/api/v1/owned", headers=headers)
+    assert resp.json()["data"]["count"] == 0
+
+
+def test_owned_cross_user_isolated(client, tmp_path):
+    from code.web.services.user_db import create_user, create_api_key
+
+    a = create_user("owna", "owna@example.com", "pw")
+    a_key, _ = create_api_key(a["id"])
+    b = create_user("ownb", "ownb@example.com", "pw")
+    b_key, _ = create_api_key(b["id"])
+
+    client.post("/api/v1/owned", headers={"Authorization": f"Bearer {a_key}"}, content="Black Lotus\n")
+
+    resp = client.get("/api/v1/owned", headers={"Authorization": f"Bearer {b_key}"})
+    assert resp.json()["data"] == {"names": [], "count": 0}

--- a/code/tests/test_api_v1_prices.py
+++ b/code/tests/test_api_v1_prices.py
@@ -1,0 +1,50 @@
+"""Tests for the public API's price lookup endpoint (Roadmap 28, Milestone 8).
+
+Public endpoint (no auth). The real PriceService is monkeypatched with a
+stub so tests don't depend on real price cache files being present.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+class _StubPriceService:
+    def get_price(self, name, region="usd", foil=False):
+        return 1.23 if name == "Sol Ring" else None
+
+    def get_ck_price(self, name):
+        return 4.56 if name == "Sol Ring" else None
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    import code.web.routes.api_v1.prices as prices_mod
+
+    monkeypatch.setattr(prices_mod, "get_price_service", lambda: _StubPriceService())
+    from code.web.app import app
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+def test_price_found(client):
+    resp = client.get("/api/v1/prices/Sol Ring")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["price"] == 1.23
+    assert data["ck_price"] == 4.56
+    assert data["found"] is True
+
+
+def test_price_not_found(client):
+    resp = client.get("/api/v1/prices/Nonexistent Card")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["price"] is None
+    assert data["found"] is False
+
+
+def test_price_no_auth_required(client):
+    """Prices are public -- no Authorization header needed."""
+    resp = client.get("/api/v1/prices/Sol Ring")
+    assert resp.status_code == 200

--- a/code/tests/test_api_v1_themes.py
+++ b/code/tests/test_api_v1_themes.py
@@ -1,0 +1,75 @@
+"""Tests for the public API's theme catalog endpoints (Roadmap 28, Milestone 6).
+
+Uses the real theme catalog (config/themes/), matching the existing
+convention in test_preview_export_endpoints.py / test_scryfall_name_normalization.py.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture()
+def client():
+    from code.web.app import app
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+@pytest.fixture()
+def sample_theme():
+    from code.web.services.theme_catalog_loader import load_index
+
+    idx = load_index()
+    if not idx.catalog.themes:
+        pytest.skip("No theme catalog available")
+    # Prefer a plain alphabetic theme name (some entries have symbols like
+    # "+1/+1 Counters" that don't round-trip cleanly through a URL path).
+    for entry in idx.catalog.themes:
+        if entry.theme.replace(" ", "").isalpha():
+            return entry.theme
+    return idx.catalog.themes[0].theme
+
+
+def test_list_themes_no_filters(client, sample_theme):
+    resp = client.get("/api/v1/themes")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["total_count"] >= 1
+    assert len(data["themes"]) >= 1
+
+
+def test_list_themes_by_query(client, sample_theme):
+    resp = client.get("/api/v1/themes", params={"q": sample_theme})
+    data = resp.json()["data"]
+    names = {t["theme"] for t in data["themes"]}
+    assert sample_theme in names
+
+
+def test_list_themes_pagination(client):
+    resp = client.get("/api/v1/themes", params={"page": 1, "page_size": 5})
+    data = resp.json()["data"]
+    assert len(data["themes"]) <= 5
+    assert data["page"] == 1
+    assert data["page_size"] == 5
+
+
+def test_theme_detail(client, sample_theme):
+    resp = client.get(f"/api/v1/themes/{sample_theme}")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["theme"] == sample_theme
+
+
+def test_theme_detail_not_found(client):
+    resp = client.get("/api/v1/themes/definitely-not-a-real-theme-xyz")
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "THEME_NOT_FOUND"
+
+
+def test_theme_detail_with_slash_in_name(client):
+    """Theme names like '+1/+1 Counters' contain a literal slash; the route
+    must use a :path converter to handle this correctly."""
+    resp = client.get("/api/v1/themes/+1/+1 Counters")
+    assert resp.status_code == 200
+    assert resp.json()["data"]["theme"] == "+1/+1 Counters"

--- a/code/tests/test_api_v1_users.py
+++ b/code/tests/test_api_v1_users.py
@@ -1,0 +1,114 @@
+"""Tests for the public API's user auth endpoints (Roadmap 28, Milestone 10).
+
+register/login/forgot are unauthenticated; logout/me require an API key.
+"""
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(autouse=True)
+def _isolated_db(tmp_path, monkeypatch):
+    import code.web.services.user_db as user_db
+    monkeypatch.setattr(user_db, "_DATA_DIR", tmp_path)
+    monkeypatch.setattr(user_db, "_DB_PATH", tmp_path / "users.db")
+    user_db.init_db()
+    yield
+
+
+@pytest.fixture()
+def client(_isolated_db):
+    from code.web.app import app
+    with TestClient(app, raise_server_exceptions=True) as c:
+        yield c
+
+
+def _register(client, username="regtest", email="regtest@example.com", password="password123"):
+    return client.post(
+        "/api/v1/auth/register",
+        json={"username": username, "email": email, "password": password},
+    )
+
+
+def test_register_success(client):
+    resp = _register(client)
+    assert resp.status_code == 201
+    data = resp.json()["data"]
+    assert data["username"] == "regtest"
+
+
+def test_register_duplicate(client):
+    _register(client)
+    resp = _register(client)
+    assert resp.status_code == 409
+    assert resp.json()["code"] == "USER_EXISTS"
+
+
+def test_register_short_password(client):
+    resp = _register(client, password="short")
+    assert resp.status_code == 422  # pydantic min_length validation
+
+
+def test_login_success(client):
+    _register(client)
+    resp = client.post("/api/v1/auth/login", json={"login": "regtest", "password": "password123"})
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["api_key"]
+    assert data["user"]["username"] == "regtest"
+
+
+def test_login_wrong_password(client):
+    _register(client)
+    resp = client.post("/api/v1/auth/login", json={"login": "regtest", "password": "wrong"})
+    assert resp.status_code == 401
+    assert resp.json()["code"] == "INVALID_CREDENTIALS"
+
+
+def test_login_device_label_reuses_key(client):
+    _register(client)
+    first = client.post(
+        "/api/v1/auth/login",
+        json={"login": "regtest", "password": "password123", "device_label": "phone"},
+    )
+    second = client.post(
+        "/api/v1/auth/login",
+        json={"login": "regtest", "password": "password123", "device_label": "phone"},
+    )
+    assert first.json()["data"]["api_key"] is not None
+    assert second.json()["data"]["api_key"] is None
+    assert first.json()["data"]["key_id"] == second.json()["data"]["key_id"]
+
+
+def test_me_requires_auth(client):
+    assert client.get("/api/v1/auth/me").status_code == 401
+
+
+def test_me_returns_profile(client):
+    _register(client)
+    login_resp = client.post("/api/v1/auth/login", json={"login": "regtest", "password": "password123"})
+    key = login_resp.json()["data"]["api_key"]
+    resp = client.get("/api/v1/auth/me", headers={"Authorization": f"Bearer {key}"})
+    assert resp.status_code == 200
+    assert resp.json()["data"]["username"] == "regtest"
+
+
+def test_logout_revokes_key(client):
+    _register(client)
+    login_resp = client.post("/api/v1/auth/login", json={"login": "regtest", "password": "password123"})
+    key = login_resp.json()["data"]["api_key"]
+    headers = {"Authorization": f"Bearer {key}"}
+
+    resp = client.post("/api/v1/auth/logout", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["data"]["loggedOut"] is True
+
+    resp = client.get("/api/v1/auth/me", headers=headers)
+    assert resp.status_code == 401
+
+
+def test_forgot_always_reports_submitted(client):
+    resp = client.post("/api/v1/auth/forgot", json={"email": "nobody@example.com"})
+    assert resp.status_code == 200
+    assert resp.json()["data"]["submitted"] is True

--- a/code/type_definitions.py
+++ b/code/type_definitions.py
@@ -62,6 +62,16 @@ class User(TypedDict):
     created_at: float     # unix timestamp
     updated_at: float     # unix timestamp
 
+
+# Public API key (R28) — never carries key_hash/plaintext; those stay in user_db.py
+class ApiKey(TypedDict):
+    id: str
+    user_id: str
+    label: Optional[str]
+    created_at: float
+    last_used: Optional[float]
+    is_active: bool
+
 # Bracket compliance typing
 Verdict = Literal["PASS", "WARN", "FAIL"]
 

--- a/code/web/app.py
+++ b/code/web/app.py
@@ -2449,6 +2449,7 @@ from .routes import price as price_routes  # noqa: E402
 from .routes import docs as docs_routes  # noqa: E402
 from .routes import auth as auth_routes  # noqa: E402
 from .routes import admin as admin_routes  # noqa: E402
+from .routes.api_v1.app import api_v1_app  # noqa: E402
 app.include_router(build_routes.router)
 app.include_router(build_validation_routes.router, prefix="/build")
 app.include_router(build_multicopy_routes.router, prefix="/build")
@@ -2478,6 +2479,10 @@ app.include_router(api_routes.router)
 app.include_router(price_routes.router)
 app.include_router(auth_routes.router)
 app.include_router(admin_routes.router)
+
+# Public REST API (R28): mounted as its own FastAPI sub-app (not just an
+# APIRouter) so it gets isolated docs (/api/v1/docs) and exception handlers.
+app.mount("/api/v1", api_v1_app)
 
 # Warm validation cache early to reduce first-call latency in tests and dev
 try:

--- a/code/web/routes/api_v1/__init__.py
+++ b/code/web/routes/api_v1/__init__.py
@@ -1,0 +1,1 @@
+"""API package marker for the versioned public REST API (`/api/v1`)."""

--- a/code/web/routes/api_v1/app.py
+++ b/code/web/routes/api_v1/app.py
@@ -1,0 +1,105 @@
+"""FastAPI sub-application for the public `/api/v1` REST API.
+
+Mounted onto the main app via `app.mount("/api/v1", api_v1_app)` in
+`code/web/app.py`. Deliberately a full `FastAPI` instance (not just an
+`APIRouter`) so it gets:
+
+  - its own OpenAPI schema and Swagger/Redoc docs, isolated from the main
+    app's `/docs` (which covers every internal HTML/HTMX route)
+  - its own exception handlers, wrapping every error into the `{ok, ...}`
+    envelope without touching the main app's HTML error pages
+
+See roadmap_28_public_api.md's "Docs isolation" and "Global error envelope"
+decisions.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+
+from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
+from starlette.exceptions import HTTPException as StarletteHTTPException
+
+from ...utils.api_response import err
+
+logger = logging.getLogger(__name__)
+
+
+def _as_bool(val: str | None, default: bool = False) -> bool:
+    if val is None:
+        return default
+    return val.strip().lower() in {"1", "true", "yes", "on"}
+
+
+# Set 0 to disable interactive docs (e.g. in production).
+API_DOCS_ENABLED = _as_bool(os.getenv("API_DOCS_ENABLED"), True)
+
+api_v1_app = FastAPI(
+    title="MTG Deckbuilder API",
+    version="1",
+    description=(
+        "Public REST API for the MTG Commander/EDH deckbuilder. Every response is a "
+        "JSON envelope: `{\"ok\": true, \"data\": ..., \"request_id\": \"...\"}` on "
+        "success, or `{\"ok\": false, \"error\": \"...\", \"code\": \"SNAKE_CASE\", "
+        "\"request_id\": \"...\"}` on failure. Authenticate with `Authorization: "
+        "Bearer <api_key>` (obtained via `POST /auth/login` or `POST /keys`); "
+        "endpoints without that requirement are public."
+    ),
+    docs_url="/docs" if API_DOCS_ENABLED else None,
+    redoc_url="/redoc" if API_DOCS_ENABLED else None,
+    openapi_url="/openapi.json" if API_DOCS_ENABLED else None,
+)
+
+
+def _request_id(request: Request) -> str:
+    return getattr(request.state, "request_id", None) or uuid.uuid4().hex
+
+
+@api_v1_app.exception_handler(StarletteHTTPException)
+async def _http_exception_handler(request: Request, exc: StarletteHTTPException):
+    rid = _request_id(request)
+    code = f"HTTP_{exc.status_code}"
+    headers = getattr(exc, "headers", None)
+    return err(str(exc.detail), code, exc.status_code, rid, headers=headers)
+
+
+@api_v1_app.exception_handler(RequestValidationError)
+async def _validation_exception_handler(request: Request, exc: RequestValidationError):
+    rid = _request_id(request)
+    return err("Invalid request parameters.", "VALIDATION_ERROR", 422, rid, details=exc.errors())
+
+
+@api_v1_app.exception_handler(Exception)
+async def _unhandled_exception_handler(request: Request, exc: Exception):
+    rid = _request_id(request)
+    logger.error(
+        "api_v1 unhandled exception [rid=%s] %s %s",
+        rid, request.method, request.url.path, exc_info=True,
+    )
+    return err("Internal server error.", "INTERNAL_ERROR", 500, rid)
+
+
+# Sub-routers
+from .keys import router as keys_router  # noqa: E402
+from .builds import router as builds_router  # noqa: E402
+from .cards import router as cards_router  # noqa: E402
+from .decks import router as decks_router  # noqa: E402
+from .commanders import router as commanders_router  # noqa: E402
+from .themes import router as themes_router  # noqa: E402
+from .owned import router as owned_router  # noqa: E402
+from .prices import router as prices_router  # noqa: E402
+from .configs import router as configs_router  # noqa: E402
+from .users import router as users_router  # noqa: E402
+
+api_v1_app.include_router(keys_router)
+api_v1_app.include_router(builds_router)
+api_v1_app.include_router(cards_router)
+api_v1_app.include_router(decks_router)
+api_v1_app.include_router(commanders_router)
+api_v1_app.include_router(themes_router)
+api_v1_app.include_router(owned_router)
+api_v1_app.include_router(prices_router)
+api_v1_app.include_router(configs_router)
+api_v1_app.include_router(users_router)

--- a/code/web/routes/api_v1/auth.py
+++ b/code/web/routes/api_v1/auth.py
@@ -1,0 +1,72 @@
+"""Bearer-token API key authentication for the `/api/v1` REST API.
+
+Fully independent from the web UI's cookie-based session auth
+(`code/web/services/auth.py`'s `mtg_session` cookie / `get_current_user()`).
+The public API never reads that cookie -- see roadmap_28_public_api.md's
+"Auth model" decision. Public (unauthenticated) endpoints simply don't
+declare `get_api_user` as a dependency.
+"""
+from __future__ import annotations
+
+import hashlib
+import time
+from typing import Optional
+
+from fastapi import Depends, HTTPException, Request
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+
+from code.type_definitions import User
+
+from ...services.auth import check_and_record_rate_limit
+from ...services.user_db import verify_api_key
+
+# 60 req/min per API key, per the roadmap's Rate Limiting contract.
+_RATE_LIMIT_MAX = 60
+_RATE_LIMIT_WINDOW_S = 60
+
+# auto_error=False so we control the error shape (our {ok:false,...} envelope
+# via the sub-app's exception handler) instead of FastAPI's default 403.
+# Declaring this as a dependency is also what makes Swagger UI (/api/v1/docs)
+# show an "Authorize" padlock so the endpoints are testable from the browser.
+_bearer_scheme = HTTPBearer(auto_error=False)
+
+
+async def get_api_user(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(_bearer_scheme),
+) -> User:
+    """Resolve the caller's User from the `Authorization: Bearer <key>` header.
+
+    Raises 401 if the header is missing/malformed or the key is invalid or
+    revoked, and 429 if the key has exceeded its rate limit.
+    """
+    if credentials is None or not credentials.credentials.strip():
+        raise HTTPException(status_code=401, detail="Missing or malformed Authorization header.")
+    key_plain = credentials.credentials.strip()
+
+    user = verify_api_key(key_plain)
+    if not user:
+        raise HTTPException(status_code=401, detail="Invalid or revoked API key.")
+
+    # Rate limit by key, not by user -- a user with multiple keys/devices
+    # gets independent budgets per key. Bucket on the key's hash (not the
+    # plaintext) to avoid keeping plaintext keys resident in memory any
+    # longer than the single request needs them for.
+    bucket_key = f"apikey:{hashlib.sha256(key_plain.encode()).hexdigest()}"
+    exceeded, remaining, reset_epoch = check_and_record_rate_limit(
+        bucket_key, _RATE_LIMIT_MAX, _RATE_LIMIT_WINDOW_S
+    )
+    request.state.rate_limit_remaining = remaining
+    request.state.rate_limit_reset = reset_epoch
+    if exceeded:
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit exceeded.",
+            headers={
+                "X-RateLimit-Limit": str(_RATE_LIMIT_MAX),
+                "X-RateLimit-Remaining": "0",
+                "X-RateLimit-Reset": str(reset_epoch),
+                "Retry-After": str(max(1, reset_epoch - int(time.time()))),
+            },
+        )
+    return user

--- a/code/web/routes/api_v1/builds.py
+++ b/code/web/routes/api_v1/builds.py
@@ -1,0 +1,158 @@
+"""Deck-build endpoints for the public REST API (R28 Milestone 3).
+
+Reuses the same staged build engine (`start_build_ctx` / `run_stage`) as the
+HTML/HTMX web UI, but tracks progress in `api_build_store.py` keyed by a
+`build_id` (not a cookie session), and runs stages in a worker thread so the
+event loop isn't blocked while a build is in progress.
+
+Auth required for every endpoint here -- the public API never creates guest
+builds (see roadmap_28_public_api.md's Milestone 3 note). Builds are only
+visible to the user who created them.
+
+Known limitation: `seed` is accepted but not yet wired up -- the staged
+build engine (`start_build_ctx`) has no deterministic-seed support today;
+that lives in a separate subsystem (`random_util.py`) used only by the
+"Random build" feature. Revisit if/when that's unified.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel, Field
+
+from code.type_definitions import User
+
+from ...services import api_build_store as build_store
+from ...services import orchestrator as orch
+from ...services.build_utils import owned_names as owned_names_helper
+from ...utils.api_response import err, ok
+from .auth import get_api_user
+
+router = APIRouter(prefix="/builds", tags=["builds"])
+
+
+def _rid(request: Request) -> str:
+    return getattr(request.state, "request_id", None) or uuid.uuid4().hex
+
+
+class CreateBuildRequest(BaseModel):
+    commander: str
+    themes: List[str] = Field(default_factory=list)
+    bracket: Optional[int] = None
+    budget: Optional[Dict[str, Any]] = None
+    seed: Optional[int] = None
+    owned_only: bool = False
+    prefer_owned: bool = False
+
+
+def _default_bracket() -> int:
+    opts = orch.bracket_options()
+    return int(opts[0]["level"]) if opts else 1
+
+
+def _status_payload(build: Dict[str, Any]) -> Dict[str, Any]:
+    payload = {
+        "status": build.get("status"),
+        "progress_pct": build.get("progress_pct", 0),
+        "stage_label": build.get("stage_label"),
+    }
+    if build.get("status") == "error":
+        payload["error"] = build.get("error")
+    return payload
+
+
+def _run_build_sync(build_id: str, ctx: Dict[str, Any]) -> None:
+    """Run every remaining stage to completion. Executed in a worker thread."""
+    build_store.update_progress(build_id, status="running")
+    try:
+        stages = ctx["stages"]
+        while ctx["idx"] < len(stages):
+            result = orch.run_stage(ctx)
+            build_store.update_progress(
+                build_id,
+                stage_idx=result.get("idx", ctx["idx"]),
+                stage_total=result.get("total", len(stages)),
+                stage_label=result.get("label"),
+            )
+            if result.get("done"):
+                build_store.mark_done(
+                    build_id,
+                    {
+                        "csv_path": result.get("csv_path"),
+                        "txt_path": result.get("txt_path"),
+                        "summary": result.get("summary"),
+                        "compliance": result.get("compliance"),
+                    },
+                )
+                return
+    except Exception as exc:  # noqa: BLE001 -- surfaced to the client via the store
+        build_store.mark_error(build_id, str(exc))
+
+
+@router.post("", summary="Create a deck build")
+async def create_build(body: CreateBuildRequest, request: Request, user: User = Depends(get_api_user)):
+    """Start a new deck build. Returns immediately with a `build_id` to poll."""
+    commander = body.commander.strip()
+    if not commander:
+        return err("commander is required.", "INVALID_COMMANDER", 400, _rid(request))
+    bracket = body.bracket if body.bracket is not None else _default_bracket()
+
+    owned_names_list = owned_names_helper() if (body.owned_only or body.prefer_owned) else None
+
+    try:
+        ctx = await asyncio.to_thread(
+            orch.start_build_ctx,
+            commander=commander,
+            tags=body.themes,
+            bracket=bracket,
+            ideals=orch.ideal_defaults(),
+            use_owned_only=body.owned_only,
+            prefer_owned=body.prefer_owned,
+            owned_names=owned_names_list,
+            budget_config=body.budget,
+        )
+    except ValueError as exc:
+        return err(str(exc), "INVALID_BUILD_REQUEST", 400, _rid(request))
+    except RuntimeError as exc:
+        return err(str(exc), "SETUP_NOT_READY", 503, _rid(request))
+
+    build_id = build_store.create_build(user["id"], body.model_dump())
+    asyncio.create_task(asyncio.to_thread(_run_build_sync, build_id, ctx))
+
+    return ok({"build_id": build_id, "status": "queued"}, _rid(request), status_code=202)
+
+
+@router.get("/{build_id}", summary="Get build status")
+async def get_build_status(build_id: str, request: Request, user: User = Depends(get_api_user)):
+    """Poll build status and progress."""
+    build = build_store.get_build(build_id)
+    if not build or build.get("user_id") != user["id"]:
+        return err("Build not found.", "BUILD_NOT_FOUND", 404, _rid(request))
+    return ok(_status_payload(build), _rid(request))
+
+
+@router.get("/{build_id}/deck", summary="Get finished deck")
+async def get_build_deck(build_id: str, request: Request, user: User = Depends(get_api_user)):
+    """Fetch the full deck JSON once a build has finished."""
+    build = build_store.get_build(build_id)
+    if not build or build.get("user_id") != user["id"]:
+        return err("Build not found.", "BUILD_NOT_FOUND", 404, _rid(request))
+    status = build.get("status")
+    if status == "error":
+        return err(build.get("error") or "Build failed.", "BUILD_FAILED", 409, _rid(request))
+    if status != "done":
+        return err("Build is not complete yet.", "BUILD_NOT_READY", 409, _rid(request))
+    return ok(build.get("result") or {}, _rid(request))
+
+
+@router.delete("/{build_id}", summary="Delete a build record")
+async def delete_build(build_id: str, request: Request, user: User = Depends(get_api_user)):
+    """Discard a build record. Does not interrupt an in-progress build thread."""
+    build = build_store.get_build(build_id)
+    if not build or build.get("user_id") != user["id"]:
+        return err("Build not found.", "BUILD_NOT_FOUND", 404, _rid(request))
+    build_store.delete_build(build_id)
+    return ok({"deleted": True}, _rid(request))

--- a/code/web/routes/api_v1/cards.py
+++ b/code/web/routes/api_v1/cards.py
@@ -1,0 +1,165 @@
+"""Card browser endpoints for the public REST API (R28 Milestone 4).
+
+Reuses `AllCardsLoader` (code/services/all_cards_loader.py), `CardSimilarity`
+(code/web/services/card_similarity.py), and `get_rulings()` from R27
+(code/web/services/rulings.py) -- the same building blocks as the HTML card
+browser (code/web/routes/card_browser.py) -- instead of duplicating filter
+logic. All endpoints here are public (no auth required).
+
+Route ordering note: `/similar` and `/rulings` are registered before the
+bare `/{name}` detail route, using `:path` converters, so double-faced card
+names containing `/` (e.g. "Fire // Ice") still resolve correctly -- mirrors
+the same trick used in card_browser.py.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Query, Request
+from fastapi.encoders import jsonable_encoder
+
+from code.deck_builder.builder_utils import parse_theme_tags
+from code.services.all_cards_loader import AllCardsLoader
+
+from ...services.card_similarity import CardSimilarity
+from ...services.rulings import get_rulings
+from ...utils.api_response import err, ok
+
+router = APIRouter(prefix="/cards", tags=["cards"])
+
+MAX_PAGE_SIZE = 100
+
+_loader: Optional[AllCardsLoader] = None
+_similarity: Optional[CardSimilarity] = None
+
+
+def _get_loader() -> AllCardsLoader:
+    global _loader
+    if _loader is None:
+        _loader = AllCardsLoader()
+    return _loader
+
+
+def _get_similarity() -> CardSimilarity:
+    global _similarity
+    if _similarity is None:
+        _similarity = CardSimilarity(_get_loader().load())
+    return _similarity
+
+
+def _rid(request: Request) -> str:
+    return getattr(request.state, "request_id", None) or uuid.uuid4().hex
+
+
+def _serialize_card(row, *, full: bool = False) -> Dict[str, Any]:
+    card = row.to_dict()
+    data: Dict[str, Any] = {
+        "name": card.get("name"),
+        "type": card.get("type"),
+        "manaValue": card.get("manaValue"),
+        "colorIdentity": card.get("colorIdentity"),
+        "rarity": card.get("rarity"),
+        "themeTags": parse_theme_tags(card.get("themeTags")),
+        "edhrecRank": card.get("edhrecRank"),
+        "scryfallID": card.get("scryfallID"),
+    }
+    if full:
+        data.update(
+            {
+                "text": card.get("text"),
+                "power": card.get("power"),
+                "toughness": card.get("toughness"),
+                "printings": card.get("printings"),
+                "layout": card.get("layout"),
+                "isNew": card.get("isNew"),
+            }
+        )
+    return jsonable_encoder(data)
+
+
+@router.get("", summary="Search cards")
+async def list_cards(
+    request: Request,
+    q: str = Query("", description="Name / type / oracle-text search"),
+    colors: str = Query("", description="Comma-separated color identity, e.g. W,U"),
+    tags: str = Query("", description="Comma-separated theme tags (AND logic)"),
+    min_cmc: Optional[float] = Query(None, ge=0),
+    max_cmc: Optional[float] = Query(None, ge=0),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=MAX_PAGE_SIZE),
+):
+    """Search/filter cards. Mirrors card_browser.py's filters, simplified for JSON I/O."""
+    df = _get_loader().load()
+
+    if q:
+        mask = df["name"].str.contains(q, case=False, na=False)
+        if "type" in df.columns:
+            mask |= df["type"].str.contains(q, case=False, na=False)
+        if "text" in df.columns:
+            mask |= df["text"].str.contains(q, case=False, na=False)
+        df = df[mask]
+
+    if colors:
+        color_list = [c.strip().upper() for c in colors.split(",") if c.strip()]
+        if color_list and "colorIdentity" in df.columns:
+            df = df[df["colorIdentity"].isin(color_list)]
+
+    if tags:
+        tag_list = [t.strip().lower() for t in tags.split(",") if t.strip()]
+        if tag_list and "themeTags" in df.columns:
+            # themeTags may be stored as a string, list, or numpy array depending on
+            # source (raw CSV vs. Parquet) -- parse_theme_tags() normalizes all of them.
+            parsed = df["themeTags"].apply(lambda v: {t.lower() for t in parse_theme_tags(v)})
+            mask = parsed.apply(lambda card_tags: all(tag in card_tags for tag in tag_list))
+            df = df[mask]
+
+    if min_cmc is not None and "manaValue" in df.columns:
+        df = df[df["manaValue"] >= min_cmc]
+    if max_cmc is not None and "manaValue" in df.columns:
+        df = df[df["manaValue"] <= max_cmc]
+
+    total = len(df)
+    start = (page - 1) * page_size
+    page_df = df.iloc[start : start + page_size]
+
+    return ok(
+        {
+            "cards": [_serialize_card(row) for _, row in page_df.iterrows()],
+            "total_count": total,
+            "page": page,
+            "page_size": page_size,
+            "total_pages": (total + page_size - 1) // page_size if page_size else 0,
+        },
+        _rid(request),
+    )
+
+
+@router.get("/{name:path}/similar", summary="Find similar cards")
+async def get_card_similar(name: str, request: Request, limit: int = Query(10, ge=1, le=50)):
+    """Similar cards by theme-tag overlap (reuses CardSimilarity)."""
+    row = _get_loader().get_by_name(name)
+    if row is None:
+        return err("Card not found.", "CARD_NOT_FOUND", 404, _rid(request))
+    similar = _get_similarity().find_similar(name, limit=limit)
+    return ok(jsonable_encoder(similar), _rid(request))
+
+
+@router.get("/{name:path}/rulings", summary="Get card rulings")
+async def get_card_rulings(name: str, request: Request):
+    """Card rulings, cache-first with a live Scryfall fallback (R27)."""
+    row = _get_loader().get_by_name(name)
+    if row is None:
+        return err("Card not found.", "CARD_NOT_FOUND", 404, _rid(request))
+    scryfall_id = row.get("scryfallID") or ""
+    rulings = await get_rulings(scryfall_id) if scryfall_id else []
+    return ok(jsonable_encoder(rulings), _rid(request))
+
+
+@router.get("/{name:path}", summary="Get card detail")
+async def get_card_detail(name: str, request: Request):
+    """Card detail: stats, tags, oracle text, scryfall_id."""
+    row = _get_loader().get_by_name(name)
+    if row is None:
+        return err("Card not found.", "CARD_NOT_FOUND", 404, _rid(request))
+    return ok(_serialize_card(row, full=True), _rid(request))

--- a/code/web/routes/api_v1/commanders.py
+++ b/code/web/routes/api_v1/commanders.py
@@ -1,0 +1,119 @@
+"""Commander catalog endpoints for the public REST API (R28 Milestone 6).
+
+Reuses `commander_catalog_loader.py` (the same catalog the HTML commander
+browser and partner-selection wizard use) instead of duplicating parsing or
+filtering logic. All endpoints here are public (no auth required).
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any, Dict
+
+from fastapi import APIRouter, Query, Request
+from fastapi.encoders import jsonable_encoder
+
+from ...services.commander_catalog_loader import (
+    CommanderRecord,
+    find_commander_record,
+    load_commander_catalog,
+)
+from ...utils.api_response import err, ok
+
+router = APIRouter(prefix="/commanders", tags=["commanders"])
+
+MAX_PAGE_SIZE = 100
+
+
+def _rid(request: Request) -> str:
+    return getattr(request.state, "request_id", None) or uuid.uuid4().hex
+
+
+def _serialize_commander(record: CommanderRecord, *, full: bool = False) -> Dict[str, Any]:
+    data: Dict[str, Any] = {
+        "name": record.display_name,
+        "slug": record.slug,
+        "color_identity": list(record.color_identity),
+        "mana_cost": record.mana_cost,
+        "mana_value": record.mana_value,
+        "type_line": record.type_line,
+        "edhrec_rank": record.edhrec_rank,
+        "image_normal_url": record.image_normal_url,
+        "is_partner": record.is_partner,
+        "supports_backgrounds": record.supports_backgrounds,
+        "is_background": record.is_background,
+    }
+    if full:
+        data.update(
+            {
+                "oracle_text": record.oracle_text,
+                "power": record.power,
+                "toughness": record.toughness,
+                "keywords": list(record.keywords),
+                "themes": list(record.themes),
+                "partner_with": list(record.partner_with),
+                "is_doctor": record.is_doctor,
+                "is_doctors_companion": record.is_doctors_companion,
+            }
+        )
+    return jsonable_encoder(data)
+
+
+@router.get("", summary="Search commanders")
+async def list_commanders(
+    request: Request,
+    q: str = Query("", description="Name / oracle-text search"),
+    colors: str = Query("", description="Comma-separated color identity, e.g. W,U (exact match)"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(20, ge=1, le=MAX_PAGE_SIZE),
+):
+    """Search/filter commanders."""
+    catalog = load_commander_catalog()
+    records = list(catalog.entries)
+
+    if q:
+        q_lower = q.lower()
+        records = [r for r in records if q_lower in r.search_haystack]
+
+    if colors:
+        color_list = [c.strip().upper() for c in colors.split(",") if c.strip()]
+        if "C" in color_list or "COLORLESS" in color_list:
+            records = [r for r in records if r.is_colorless]
+        elif color_list:
+            color_set = set(color_list)
+            records = [r for r in records if set(r.color_identity) == color_set]
+
+    total = len(records)
+    start = (page - 1) * page_size
+    page_records = records[start : start + page_size]
+
+    return ok(
+        {
+            "commanders": [_serialize_commander(r) for r in page_records],
+            "total_count": total,
+            "page": page,
+            "page_size": page_size,
+            "total_pages": (total + page_size - 1) // page_size if page_size else 0,
+        },
+        _rid(request),
+    )
+
+
+@router.get("/{name}/partners", summary="Get partner suggestions")
+async def get_commander_partners(name: str, request: Request):
+    """Valid partner/background suggestions for a commander (reuses build_partners.py)."""
+    from ...routes.build_partners import _build_partner_options
+
+    record = find_commander_record(name)
+    if record is None:
+        return err("Commander not found.", "COMMANDER_NOT_FOUND", 404, _rid(request))
+    options, variant = _build_partner_options(record)
+    return ok({"variant": variant, "options": jsonable_encoder(options)}, _rid(request))
+
+
+@router.get("/{name}", summary="Get commander detail")
+async def get_commander_detail(name: str, request: Request):
+    """Commander detail."""
+    record = find_commander_record(name)
+    if record is None:
+        return err("Commander not found.", "COMMANDER_NOT_FOUND", 404, _rid(request))
+    return ok(_serialize_commander(record, full=True), _rid(request))

--- a/code/web/routes/api_v1/configs.py
+++ b/code/web/routes/api_v1/configs.py
@@ -1,0 +1,99 @@
+"""Headless config management endpoints for the public REST API (R28 Milestone 9).
+
+Reuses `code/web/routes/configs.py`'s `_config_dir`/`_list_configs` helpers
+(the same per-user JSON config directory backing the HTML Configs page)
+instead of duplicating them. Auth required for every endpoint here; configs
+are always scoped to the calling API user's own directory
+(`config/{user_id}/`).
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any, Dict
+
+from fastapi import APIRouter, Depends, Request
+
+from code.type_definitions import User
+
+from ...utils.api_response import err, ok
+from ..configs import _config_dir, _list_configs
+from .auth import get_api_user
+
+router = APIRouter(prefix="/configs", tags=["configs"])
+
+
+def _rid(request: Request) -> str:
+    return getattr(request.state, "request_id", None) or uuid.uuid4().hex
+
+
+def _resolve_config_path(user_id: str, name: str):
+    """Return the resolved config path if it's a valid, existing JSON file
+    within the user's config dir, else None. Guards against path traversal.
+    """
+    base = _config_dir(user_id)
+    target = (base / name).resolve()
+    try:
+        if base != target and base not in target.parents:
+            return None
+    except Exception:
+        return None
+    if not (target.exists() and target.is_file() and target.suffix.lower() == ".json"):
+        return None
+    return target
+
+
+@router.get("", summary="List saved configs")
+async def list_configs(request: Request, user: User = Depends(get_api_user)):
+    """List the caller's saved headless configs."""
+    items = _list_configs(str(user["id"]))
+    return ok({"configs": items}, _rid(request))
+
+
+@router.get("/{name}", summary="Get a config")
+async def get_config(name: str, request: Request, user: User = Depends(get_api_user)):
+    """Return the raw JSON content of a saved config."""
+    p = _resolve_config_path(str(user["id"]), name)
+    if p is None:
+        return err("Config not found.", "CONFIG_NOT_FOUND", 404, _rid(request))
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except Exception as e:
+        return err(f"Failed to read config: {e}", "CONFIG_INVALID", 400, _rid(request))
+    return ok({"name": p.name, "config": data}, _rid(request))
+
+
+@router.post("/{name}", summary="Save or overwrite a config")
+async def save_config(name: str, request: Request, user: User = Depends(get_api_user)):
+    """Save/overwrite a config with the given name (JSON request body)."""
+    if not name.lower().endswith(".json"):
+        return err("Config name must end with .json", "INVALID_NAME", 400, _rid(request))
+    try:
+        payload: Dict[str, Any] = await request.json()
+        if not isinstance(payload, dict):
+            raise ValueError("Body must be a JSON object")
+    except Exception as e:
+        return err(f"Invalid JSON body: {e}", "INVALID_BODY", 400, _rid(request))
+
+    uid = str(user["id"])
+    base = _config_dir(uid)
+    target = (base / name).resolve()
+    if base != target and base not in target.parents:
+        return err("Invalid config name.", "INVALID_NAME", 400, _rid(request))
+
+    base.mkdir(parents=True, exist_ok=True)
+    target.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return ok({"name": target.name, "saved": True}, _rid(request))
+
+
+@router.delete("/{name}", summary="Delete a config")
+async def delete_config(name: str, request: Request, user: User = Depends(get_api_user)):
+    """Delete a saved config."""
+    p = _resolve_config_path(str(user["id"]), name)
+    if p is None:
+        return err("Config not found.", "CONFIG_NOT_FOUND", 404, _rid(request))
+    try:
+        p.unlink()
+    except Exception as e:
+        return err(f"Failed to delete config: {e}", "DELETE_FAILED", 500, _rid(request))
+    return ok({"deleted": True}, _rid(request))

--- a/code/web/routes/api_v1/decks.py
+++ b/code/web/routes/api_v1/decks.py
@@ -1,0 +1,209 @@
+"""Deck management endpoints for the public REST API (R28 Milestone 5).
+
+Reuses the same per-user deck directory conventions and CSV-download helper
+as the HTML web UI (`code/web/routes/decks.py`) instead of duplicating them.
+
+Auth required for every endpoint here -- decks are always scoped to the
+calling API user's own directory (`deck_files/{user_id}/`). There is no
+guest/legacy/public browsing surface in the public API; that's a web-UI-only
+concept for now (see roadmap_28_public_api.md's Milestone 5 note).
+"""
+from __future__ import annotations
+
+import csv
+import json
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, Depends, Query, Request
+from fastapi.encoders import jsonable_encoder
+from fastapi.responses import Response
+
+from code.type_definitions import User
+
+from ...utils.api_response import err, ok
+from ..decks import _build_csv_download_response, _deck_dir, _list_decks, _safe_within
+from .auth import get_api_user
+
+router = APIRouter(prefix="/decks", tags=["decks"])
+
+
+def _rid(request: Request) -> str:
+    return getattr(request.state, "request_id", None) or uuid.uuid4().hex
+
+
+def _resolve_deck_path(user_id: str, filename: str) -> Optional[Path]:
+    base = _deck_dir(user_id)
+    p = (base / filename).resolve()
+    if not _safe_within(base, p) or not (p.exists() and p.is_file() and p.suffix.lower() == ".csv"):
+        return None
+    return p
+
+
+def _parse_deck_cards(csv_path: Path) -> List[Dict[str, Any]]:
+    """Parse a deck CSV export into a flat card list for the API."""
+    cards: List[Dict[str, Any]] = []
+    with csv_path.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.reader(f)
+        headers = next(reader, [])
+        idx = {h: i for i, h in enumerate(headers)}
+
+        def col(row: List[str], key: str, default: str = "") -> str:
+            i = idx.get(key)
+            return row[i] if i is not None and i < len(row) else default
+
+        for row in reader:
+            if not row:
+                continue
+            name = col(row, "Name")
+            if not name or name == "Total":
+                continue
+            tags = [t.strip() for t in col(row, "Tags").split(";") if t.strip()]
+            try:
+                count = int(float(col(row, "Count", "1") or 1))
+            except ValueError:
+                count = 1
+            cards.append(
+                {
+                    "name": name,
+                    "count": count,
+                    "type": col(row, "Type"),
+                    "mana_value": col(row, "ManaValue"),
+                    "colors": col(row, "Colors"),
+                    "role": col(row, "Role"),
+                    "tags": tags,
+                }
+            )
+    return cards
+
+
+@router.get("", summary="List saved decks")
+async def list_decks(request: Request, user: User = Depends(get_api_user)):
+    """List the caller's saved decks."""
+    decks = _list_decks(str(user["id"]))
+    return ok(jsonable_encoder(decks), _rid(request))
+
+
+@router.get("/{filename}", summary="Get deck detail")
+async def get_deck_detail(filename: str, request: Request, user: User = Depends(get_api_user)):
+    """Deck detail: filename + parsed card list."""
+    p = _resolve_deck_path(str(user["id"]), filename)
+    if p is None:
+        return err("Deck not found.", "DECK_NOT_FOUND", 404, _rid(request))
+    cards = _parse_deck_cards(p)
+    return ok(
+        {"name": p.name, "cards": cards, "card_count": sum(c["count"] for c in cards)},
+        _rid(request),
+    )
+
+
+@router.get("/{filename}/export", summary="Export a deck")
+async def export_deck(
+    filename: str,
+    request: Request,
+    format: str = Query("csv", pattern="^(csv|txt|json)$"),
+    user: User = Depends(get_api_user),
+):
+    """Download a deck export. `format` is one of csv (default), txt, json."""
+    p = _resolve_deck_path(str(user["id"]), filename)
+    if p is None:
+        return err("Deck not found.", "DECK_NOT_FOUND", 404, _rid(request))
+
+    fmt = format.lower()
+    if fmt == "csv":
+        return _build_csv_download_response(p)
+
+    if fmt == "txt":
+        txt_p = p.with_suffix(".txt")
+        if not txt_p.exists():
+            return err("TXT export not available for this deck.", "EXPORT_NOT_FOUND", 404, _rid(request))
+        return Response(
+            content=txt_p.read_bytes(),
+            media_type="text/plain; charset=utf-8",
+            headers={"Content-Disposition": f'attachment; filename="{txt_p.name}"'},
+        )
+
+    # json
+    cards = _parse_deck_cards(p)
+    payload = jsonable_encoder(
+        {"name": p.name, "cards": cards, "card_count": sum(c["count"] for c in cards)}
+    )
+    return Response(
+        content=json.dumps(payload, indent=2).encode("utf-8"),
+        media_type="application/json",
+        headers={"Content-Disposition": f'attachment; filename="{p.stem}.json"'},
+    )
+
+
+@router.delete("/{filename}", summary="Delete a deck")
+async def delete_deck(filename: str, request: Request, user: User = Depends(get_api_user)):
+    """Delete a deck and its sidecars (CSV, TXT, summary/compliance JSON)."""
+    p = _resolve_deck_path(str(user["id"]), filename)
+    if p is None:
+        return err("Deck not found.", "DECK_NOT_FOUND", 404, _rid(request))
+
+    stem = p.stem
+    for suffix in (".csv", ".txt", ".summary.json", "_compliance.json"):
+        candidate = p.parent / (stem + suffix)
+        try:
+            if candidate.exists():
+                candidate.unlink()
+        except Exception:
+            pass
+    return ok({"deleted": True}, _rid(request))
+
+
+@router.get("/{filename}/upgrades", summary="Get upgrade suggestions")
+async def get_deck_upgrades(
+    filename: str,
+    request: Request,
+    section: str = Query("general", pattern="^(new|general|possible)$"),
+    page: int = Query(1, ge=1),
+    user: User = Depends(get_api_user),
+):
+    """Upgrade suggestions for a saved deck (R28 Milestone 8).
+
+    Reuses `upgrade_suggestions.py`'s deck loading + suggestion-building
+    helpers -- the same ones backing the HTML "Suggested Upgrades" page --
+    instead of duplicating the CSV-parsing/scoring logic.
+    """
+    from ...app import ENABLE_UPGRADE_SUGGESTIONS, UPGRADE_PAGE_SIZE
+    from .. import upgrade_suggestions as upg
+
+    if not ENABLE_UPGRADE_SUGGESTIONS:
+        return err("Upgrade suggestions are disabled.", "FEATURE_DISABLED", 404, _rid(request))
+
+    uid = str(user["id"])
+    csv_path, meta, deck_cards, themes, color_identity = upg._load_deck(filename, uid)
+    per_page = max(5, min(50, int(UPGRADE_PAGE_SIZE)))
+    excluded_names = meta.get("excluded_names") or set()
+    card_ceiling = meta.get("card_ceiling")
+
+    if section == "general":
+        section_ctx = upg._build_general_ctx(
+            deck_cards, color_identity, themes, page, per_page,
+            excluded_names=excluded_names, card_ceiling=card_ceiling,
+        )
+    elif section == "possible":
+        section_ctx = upg._build_possible_ctx(
+            deck_cards, color_identity, themes, page, per_page,
+            excluded_names=excluded_names, card_ceiling=card_ceiling,
+        )
+    else:
+        section_ctx = upg._build_new_ctx(
+            deck_cards, color_identity, page, per_page,
+            deck_themes=meta.get("deck_themes"), excluded_names=excluded_names,
+            card_ceiling=card_ceiling,
+        )
+
+    return ok(
+        jsonable_encoder(
+            {
+                "commander": meta.get("commander", ""),
+                "color_identity": color_identity,
+                **section_ctx,
+            }
+        ),
+        _rid(request),
+    )

--- a/code/web/routes/api_v1/keys.py
+++ b/code/web/routes/api_v1/keys.py
@@ -1,0 +1,55 @@
+"""API key management routes -- `GET/POST /api/v1/keys`, `DELETE /api/v1/keys/{id}`.
+
+See Milestone 2 of roadmap_28_public_api.md.
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, Request
+
+from code.type_definitions import User
+
+from ...services.user_db import create_api_key, list_api_keys, revoke_api_key
+from ...utils.api_response import err, ok
+from .auth import get_api_user
+
+router = APIRouter(prefix="/keys", tags=["keys"])
+
+
+def _rid(request: Request) -> str:
+    return getattr(request.state, "request_id", None) or uuid.uuid4().hex
+
+
+@router.get("", summary="List API keys")
+async def list_keys(request: Request, user: User = Depends(get_api_user)):
+    """List the caller's active API keys. Never reveals the key itself."""
+    keys = list_api_keys(user["id"])
+    return ok([dict(k) for k in keys], _rid(request))
+
+
+@router.post("", status_code=201, summary="Create an API key")
+async def create_key(request: Request, user: User = Depends(get_api_user)):
+    """Create a new API key. The plaintext key is returned once and never again."""
+    body = {}
+    try:
+        body = await request.json()
+    except Exception:
+        body = {}
+    label = (body or {}).get("label") if isinstance(body, dict) else None
+    if label is not None and not isinstance(label, str):
+        return err("label must be a string.", "INVALID_LABEL", 400, _rid(request))
+    key_plain, key = create_api_key(user["id"], label)
+    data = dict(key)
+    data["key"] = key_plain
+    return ok(data, _rid(request), status_code=201)
+
+
+@router.delete("/{key_id}", summary="Revoke an API key")
+async def delete_key(key_id: str, request: Request, user: User = Depends(get_api_user)):
+    """Revoke one of the caller's own API keys."""
+    try:
+        revoke_api_key(key_id, user["id"])
+    except ValueError:
+        return err("API key not found.", "KEY_NOT_FOUND", 404, _rid(request))
+    return ok({"revoked": True}, _rid(request))

--- a/code/web/routes/api_v1/owned.py
+++ b/code/web/routes/api_v1/owned.py
@@ -1,0 +1,53 @@
+"""Owned cards endpoints for the public REST API (R28 Milestone 7).
+
+Reuses `owned_store.py` (the same per-user JSON-backed store as the HTML
+Owned Library page) instead of duplicating parsing/persistence logic.
+Auth required for every endpoint -- scoped to the caller's own directory
+(`owned_cards/{user_id}/`).
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, Request
+
+from code.type_definitions import User
+
+from ...services import owned_store as store
+from ...utils.api_response import ok
+from .auth import get_api_user
+
+router = APIRouter(prefix="/owned", tags=["owned"])
+
+
+def _rid(request: Request) -> str:
+    return getattr(request.state, "request_id", None) or uuid.uuid4().hex
+
+
+@router.get("", summary="Get owned card list")
+async def get_owned(request: Request, user: User = Depends(get_api_user)):
+    """Return the caller's owned card list."""
+    names = store.get_names(str(user["id"]))
+    return ok({"names": names, "count": len(names)}, _rid(request))
+
+
+@router.post("", summary="Replace owned card list")
+async def upload_owned(request: Request, user: User = Depends(get_api_user)):
+    """Replace the caller's owned card list.
+
+    Body: plain text, one card name per line (optional leading count, e.g.
+    "1x Sol Ring", is stripped -- same parsing as the HTML upload form).
+    """
+    body = await request.body()
+    names = store.parse_txt_bytes(body)
+    uid = str(user["id"])
+    store.clear(uid)
+    added, total = store.add_and_enrich(names, uid)
+    return ok({"added": added, "total": total}, _rid(request))
+
+
+@router.delete("", summary="Clear owned card list")
+async def clear_owned(request: Request, user: User = Depends(get_api_user)):
+    """Clear the caller's owned card list."""
+    store.clear(str(user["id"]))
+    return ok({"cleared": True}, _rid(request))

--- a/code/web/routes/api_v1/prices.py
+++ b/code/web/routes/api_v1/prices.py
@@ -1,0 +1,44 @@
+"""Price check endpoint for the public REST API (R28 Milestone 8).
+
+Reuses `price_service.get_price_service()` (the same Scryfall-bulk-data +
+JSON-cache backed service used by `code/web/routes/price.py`) instead of
+duplicating price-cache logic. Public endpoint (no auth required).
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Query, Request
+
+from ...services.price_service import get_price_service
+from ...utils.api_response import ok
+
+router = APIRouter(prefix="/prices", tags=["prices"])
+
+
+def _rid(request: Request) -> str:
+    return getattr(request.state, "request_id", None) or uuid.uuid4().hex
+
+
+@router.get("/{card_name:path}", summary="Get card price")
+async def get_card_price(
+    card_name: str,
+    request: Request,
+    region: str = Query("usd", pattern="^(usd|eur)$"),
+    foil: bool = Query(False),
+):
+    """TCG (Scryfall) + Card Kingdom price lookup for a single card."""
+    svc = get_price_service()
+    price = svc.get_price(card_name, region=region, foil=foil)
+    ck_price = svc.get_ck_price(card_name)
+    return ok(
+        {
+            "card_name": card_name,
+            "price": price,
+            "ck_price": ck_price,
+            "region": region,
+            "foil": foil,
+            "found": price is not None,
+        },
+        _rid(request),
+    )

--- a/code/web/routes/api_v1/themes.py
+++ b/code/web/routes/api_v1/themes.py
@@ -1,0 +1,85 @@
+"""Theme catalog endpoints for the public REST API (R28 Milestone 6).
+
+Reuses `theme_catalog_loader.py` (list/filter/detail projections) and
+`theme_preview.py`'s `get_theme_preview()` (the same cached preview-card
+sampler used by the HTML theme browser) instead of duplicating logic. All
+endpoints here are public (no auth required).
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, Query, Request
+from fastapi.encoders import jsonable_encoder
+
+from ...services.theme_catalog_loader import (
+    filter_slugs_fast,
+    load_index,
+    summaries_for_slugs,
+)
+from ...services.theme_preview import get_theme_preview
+from ...utils.api_response import err, ok
+
+router = APIRouter(prefix="/themes", tags=["themes"])
+
+MAX_PAGE_SIZE = 100
+
+
+def _rid(request: Request) -> str:
+    return getattr(request.state, "request_id", None) or uuid.uuid4().hex
+
+
+@router.get("", summary="List themes")
+async def list_themes(
+    request: Request,
+    q: str = Query("", description="Substring filter on theme name/synergies"),
+    colors: str = Query("", description="Comma-separated color initials, e.g. G,W"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=MAX_PAGE_SIZE),
+):
+    """List/search all themes."""
+    try:
+        idx = load_index()
+    except FileNotFoundError:
+        return err("Theme catalog unavailable.", "CATALOG_UNAVAILABLE", 503, _rid(request))
+
+    color_list: Optional[list] = [c.strip() for c in colors.split(",") if c.strip()] if colors else None
+    slugs = filter_slugs_fast(idx, q=q or None, archetype=None, bucket=None, colors=color_list)
+
+    total = len(slugs)
+    start = (page - 1) * page_size
+    page_slugs = slugs[start : start + page_size]
+    items = summaries_for_slugs(idx, page_slugs)
+    for item in items:
+        item.pop("has_fallback_description", None)
+        item.pop("editorial_quality", None)
+
+    return ok(
+        {
+            "themes": jsonable_encoder(items),
+            "total_count": total,
+            "page": page,
+            "page_size": page_size,
+            "total_pages": (total + page_size - 1) // page_size if page_size else 0,
+        },
+        _rid(request),
+    )
+
+
+@router.get("/{theme:path}", summary="Get theme detail and preview")
+async def get_theme_detail(
+    theme: str,
+    request: Request,
+    preview_limit: int = Query(12, ge=1, le=30, description="Number of preview cards to include"),
+):
+    """Theme detail plus a sample of preview cards (reuses theme_preview.get_theme_preview)."""
+    try:
+        payload = get_theme_preview(theme, limit=preview_limit)
+    except KeyError:
+        return err("Theme not found.", "THEME_NOT_FOUND", 404, _rid(request))
+    except FileNotFoundError:
+        return err("Theme catalog unavailable.", "CATALOG_UNAVAILABLE", 503, _rid(request))
+    payload.pop("has_fallback_description", None)
+    payload.pop("editorial_quality", None)
+    return ok(jsonable_encoder(payload), _rid(request))

--- a/code/web/routes/api_v1/users.py
+++ b/code/web/routes/api_v1/users.py
@@ -1,0 +1,180 @@
+"""User auth endpoints for the public REST API (R28 Milestone 10).
+
+Reuses the same user store, password hashing, and rate-limiting helpers as
+the HTML auth routes (`code/web/routes/auth.py`) instead of duplicating
+them. `register`/`login`/`forgot` are unauthenticated; `logout`/`me`
+require a valid API key.
+
+Note: the admin synthetic login (`is_admin_login()` in `services/auth.py`)
+is intentionally NOT supported here -- the admin account has no `users`
+table row, and `api_keys.user_id` has a NOT NULL foreign key to
+`users(id)`, so minting a key for it would fail.
+"""
+from __future__ import annotations
+
+import hashlib
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Request
+from fastapi.security import HTTPAuthorizationCredentials
+from pydantic import BaseModel, Field
+
+from code.type_definitions import User
+
+from ...services.auth import (
+    _get_client_ip,
+    check_rate_limit,
+    check_username_rate_limit,
+    clear_failed_logins,
+    clear_failed_username,
+    create_reset_token,
+    record_failed_login,
+    record_failed_username,
+)
+from ...services.email import send_password_reset, send_welcome_email
+from ...services.user_db import (
+    create_api_key,
+    create_user,
+    get_or_create_api_key,
+    get_user_by_email,
+    get_user_by_login,
+    revoke_api_key_by_plain,
+    set_reset_token_hash,
+    verify_password,
+)
+from ...utils.api_response import err, ok
+from .auth import _bearer_scheme, get_api_user
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+def _rid(request: Request) -> str:
+    return getattr(request.state, "request_id", None) or uuid.uuid4().hex
+
+
+def _token_hash(token: str) -> str:
+    return hashlib.sha256(token.encode()).hexdigest()
+
+
+class RegisterBody(BaseModel):
+    username: str
+    email: str
+    password: str = Field(min_length=8)
+
+
+class LoginBody(BaseModel):
+    login: str
+    password: str
+    device_label: Optional[str] = None
+
+
+class ForgotBody(BaseModel):
+    email: str
+
+
+@router.post("/register", summary="Register a new user")
+async def register(body: RegisterBody, request: Request):
+    """Register a new user (mirrors the HTML `/auth/register` validation)."""
+    import os
+
+    admin_username = os.getenv("ADMIN_USERNAME", "").strip().lower()
+    if admin_username and body.username.strip().lower() == admin_username:
+        return err("That username is not available.", "USERNAME_UNAVAILABLE", 400, _rid(request))
+
+    try:
+        user = create_user(body.username.strip(), body.email.strip(), body.password)
+    except ValueError as exc:
+        return err(str(exc), "USER_EXISTS", 409, _rid(request))
+
+    login_url = str(request.base_url).rstrip("/") + "/auth/login"
+    try:
+        await send_welcome_email(user["email"], user["username"], login_url)
+    except Exception:
+        pass
+
+    return ok(
+        {"id": user["id"], "username": user["username"], "email": user["email"]},
+        _rid(request),
+        status_code=201,
+    )
+
+
+@router.post("/login", summary="Log in and mint an API key")
+async def login(body: LoginBody, request: Request):
+    """Authenticate and mint (or reuse) an API key.
+
+    Passing `device_label` reuses the existing active key for that label if
+    one exists (avoids key sprawl across repeated logins from the same
+    device); omitting it always mints a new key. The plaintext key is only
+    ever returned once -- on creation (`api_key` is `null` when an existing
+    labeled key was reused instead).
+    """
+    ip = _get_client_ip(request)
+    if check_rate_limit(ip) or check_username_rate_limit(body.login):
+        return err("Too many failed login attempts.", "RATE_LIMITED", 429, _rid(request))
+
+    user = get_user_by_login(body.login)
+    if not user or not verify_password(body.password, user["password_hash"]) or not user["is_active"]:
+        record_failed_login(ip)
+        record_failed_username(body.login)
+        return err("Invalid username/email or password.", "INVALID_CREDENTIALS", 401, _rid(request))
+
+    clear_failed_logins(ip)
+    clear_failed_username(body.login)
+
+    if body.device_label:
+        key_plain, api_key = get_or_create_api_key(user["id"], body.device_label)
+    else:
+        key_plain, api_key = create_api_key(user["id"], body.device_label)
+
+    return ok(
+        {
+            "user": {"id": user["id"], "username": user["username"], "email": user["email"]},
+            "api_key": key_plain,
+            "key_id": api_key["id"],
+            "label": api_key["label"],
+        },
+        _rid(request),
+    )
+
+
+@router.post("/logout", summary="Log out (revoke current key)")
+async def logout(
+    request: Request,
+    credentials: Optional[HTTPAuthorizationCredentials] = Depends(_bearer_scheme),
+    user: User = Depends(get_api_user),
+):
+    """Revoke the API key used to authenticate the current request."""
+    if credentials is not None and credentials.credentials.strip():
+        revoke_api_key_by_plain(credentials.credentials.strip())
+    return ok({"loggedOut": True}, _rid(request))
+
+
+@router.get("/me", summary="Get current user")
+async def me(request: Request, user: User = Depends(get_api_user)):
+    """Return the authenticated user's basic profile."""
+    return ok(
+        {
+            "id": user["id"],
+            "username": user["username"],
+            "email": user["email"],
+            "is_admin": bool(user.get("is_admin", False)),
+        },
+        _rid(request),
+    )
+
+
+@router.post("/forgot", summary="Request a password reset")
+async def forgot(body: ForgotBody, request: Request):
+    """Trigger a password reset email. Always reports success (no email enumeration)."""
+    user = get_user_by_email(body.email)
+    if user and not user["is_guest"] and user["is_active"]:
+        token = create_reset_token(body.email)
+        set_reset_token_hash(user["id"], _token_hash(token))
+        reset_url = str(request.base_url).rstrip("/") + f"/auth/reset/{token}"
+        try:
+            await send_password_reset(body.email, reset_url)
+        except Exception:
+            pass
+    return ok({"submitted": True}, _rid(request))

--- a/code/web/services/api_build_store.py
+++ b/code/web/services/api_build_store.py
@@ -1,0 +1,153 @@
+"""In-memory build-progress store for the public REST API (R28 Milestone 3).
+
+Keyed by `build_id` (a fresh UUID per build), not by cookie session id --
+the public API is bearer-token only and never touches `mtg_session`. Mirrors
+the TTL/cleanup pattern of `code/web/services/tasks.py`'s `SessionManager`.
+"""
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any, Dict, Optional
+
+from .base import StateService
+
+# Builds are short-lived; 1 hour is generous for polling clients to finish.
+BUILD_TTL_SECONDS = 60 * 60
+
+
+class ApiBuildStore(StateService):
+    """Thread-safe build-state store, one entry per `build_id`."""
+
+    def __init__(self, ttl_seconds: int = BUILD_TTL_SECONDS) -> None:
+        super().__init__()
+        self._ttl_seconds = ttl_seconds
+
+    def new_build_id(self) -> str:
+        return uuid.uuid4().hex
+
+    def create_build(self, build_id: str, user_id: str, config: Dict[str, Any]) -> Dict[str, Any]:
+        with self._lock:
+            state = self.get_state(build_id)
+            state.update(
+                {
+                    "user_id": user_id,
+                    "status": "queued",
+                    "progress_pct": 0,
+                    "stage_label": None,
+                    "stage_idx": 0,
+                    "stage_total": 0,
+                    "config": config,
+                    "result": None,
+                    "error": None,
+                }
+            )
+            return state
+
+    def get_build(self, build_id: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            return self._state.get(build_id)
+
+    def update_progress(
+        self,
+        build_id: str,
+        *,
+        status: Optional[str] = None,
+        stage_idx: Optional[int] = None,
+        stage_total: Optional[int] = None,
+        stage_label: Optional[str] = None,
+    ) -> None:
+        with self._lock:
+            state = self._state.get(build_id)
+            if state is None:
+                return
+            if status is not None:
+                state["status"] = status
+            if stage_idx is not None:
+                state["stage_idx"] = stage_idx
+            if stage_total is not None:
+                state["stage_total"] = stage_total
+            if stage_total or state.get("stage_total"):
+                total = stage_total if stage_total is not None else state.get("stage_total")
+                idx = stage_idx if stage_idx is not None else state.get("stage_idx", 0)
+                state["progress_pct"] = int(min(100, (idx / total) * 100)) if total else 0
+            if stage_label is not None:
+                state["stage_label"] = stage_label
+            state["updated"] = time.time()
+
+    def mark_done(self, build_id: str, result: Dict[str, Any]) -> None:
+        with self._lock:
+            state = self._state.get(build_id)
+            if state is None:
+                return
+            state["status"] = "done"
+            state["progress_pct"] = 100
+            state["result"] = result
+            state["updated"] = time.time()
+
+    def mark_error(self, build_id: str, message: str) -> None:
+        with self._lock:
+            state = self._state.get(build_id)
+            if state is None:
+                return
+            state["status"] = "error"
+            state["error"] = message
+            state["updated"] = time.time()
+
+    def delete_build(self, build_id: str) -> bool:
+        with self._lock:
+            if build_id in self._state:
+                del self._state[build_id]
+                return True
+            return False
+
+    def _initialize_state(self, key: str) -> Dict[str, Any]:
+        now = time.time()
+        return {"created": now, "updated": now, "status": "queued"}
+
+    def _should_cleanup(self, key: str, state: Dict[str, Any]) -> bool:
+        now = time.time()
+        updated = state.get("updated", now)
+        return (now - updated) > self._ttl_seconds
+
+
+# Module-level singleton, mirroring tasks.py's _get_manager() pattern.
+_store: Optional[ApiBuildStore] = None
+
+
+def _get_store() -> ApiBuildStore:
+    global _store
+    if _store is None:
+        _store = ApiBuildStore()
+    return _store
+
+
+def create_build(user_id: str, config: Dict[str, Any]) -> str:
+    store = _get_store()
+    build_id = store.new_build_id()
+    store.create_build(build_id, user_id, config)
+    return build_id
+
+
+def get_build(build_id: str) -> Optional[Dict[str, Any]]:
+    return _get_store().get_build(build_id)
+
+
+def update_progress(build_id: str, **kwargs: Any) -> None:
+    _get_store().update_progress(build_id, **kwargs)
+
+
+def mark_done(build_id: str, result: Dict[str, Any]) -> None:
+    _get_store().mark_done(build_id, result)
+
+
+def mark_error(build_id: str, message: str) -> None:
+    _get_store().mark_error(build_id, message)
+
+
+def delete_build(build_id: str) -> bool:
+    return _get_store().delete_build(build_id)
+
+
+def cleanup_expired() -> int:
+    return _get_store().cleanup_state()

--- a/code/web/services/auth.py
+++ b/code/web/services/auth.py
@@ -106,6 +106,39 @@ def clear_failed_username(username: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Generic keyed rate limiter (R28: reused by the /api/v1 bearer-token auth
+# instead of adding a new dependency like slowapi/limits)
+# ---------------------------------------------------------------------------
+
+_generic_hits: dict[str, deque[float]] = defaultdict(deque)
+_generic_lock = Lock()
+
+
+def check_and_record_rate_limit(bucket_key: str, max_count: int, window_seconds: int) -> tuple[bool, int, int]:
+    """Increment the hit counter for *bucket_key* and report limit status.
+
+    *bucket_key* should already encode whatever the limit is scoped to, e.g.
+    ``f"apikey:{api_key_id}"`` or ``f"apikey-anon:{ip}"``.
+
+    Returns ``(exceeded, remaining, reset_epoch)``. ``remaining`` is clamped
+    to 0 when exceeded; ``reset_epoch`` is an approximate unix timestamp when
+    the oldest hit in the window will fall out of it.
+    """
+    now = time.monotonic()
+    with _generic_lock:
+        q = _generic_hits[bucket_key]
+        while q and now - q[0] > window_seconds:
+            q.popleft()
+        q.append(now)
+        count = len(q)
+        oldest = q[0]
+    exceeded = count > max_count
+    remaining = max(0, max_count - count)
+    reset_epoch = int(time.time() + max(0.0, window_seconds - (now - oldest)))
+    return exceeded, remaining, reset_epoch
+
+
+# ---------------------------------------------------------------------------
 # Admin synthetic user
 # ---------------------------------------------------------------------------
 

--- a/code/web/services/user_db.py
+++ b/code/web/services/user_db.py
@@ -8,6 +8,7 @@ Docker-volume-mounted so they persist across container restarts.
 """
 from __future__ import annotations
 
+import hashlib
 import logging
 import sqlite3
 import time
@@ -17,7 +18,7 @@ from typing import Optional
 
 import bcrypt as _bcrypt  # type: ignore[import]
 
-from code.type_definitions import User
+from code.type_definitions import ApiKey, User
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +66,29 @@ CREATE TABLE IF NOT EXISTS users (
 );
 """
 
+# R28: public API keys, one row per issued key. `key_hash` is a SHA-256 hex
+# digest (not bcrypt) -- the plaintext key is already a 256-bit random token
+# (secrets.token_urlsafe(32)), so a fast deterministic hash gives an indexed
+# O(1) lookup on verify. Bcrypt is for low-entropy human passwords and can't
+# be looked up by hash without an O(n) scan over every active key.
+_CREATE_API_KEYS_TABLE = """
+CREATE TABLE IF NOT EXISTS api_keys (
+    id         TEXT PRIMARY KEY,
+    user_id    TEXT NOT NULL REFERENCES users(id),
+    key_hash   TEXT NOT NULL,
+    label      TEXT,
+    created_at REAL NOT NULL,
+    last_used  REAL,
+    is_active  INTEGER NOT NULL DEFAULT 1
+);
+"""
+_CREATE_API_KEYS_HASH_INDEX = (
+    "CREATE UNIQUE INDEX IF NOT EXISTS idx_api_keys_hash ON api_keys(key_hash)"
+)
+_CREATE_API_KEYS_USER_INDEX = (
+    "CREATE INDEX IF NOT EXISTS idx_api_keys_user ON api_keys(user_id)"
+)
+
 _GUEST_EMAIL = "guest@localhost"
 _GUEST_USERNAME = "guest"
 
@@ -74,6 +98,9 @@ def init_db() -> None:
     _DATA_DIR.mkdir(parents=True, exist_ok=True)
     with _connect() as conn:
         conn.execute(_CREATE_USERS_TABLE)
+        conn.execute(_CREATE_API_KEYS_TABLE)
+        conn.execute(_CREATE_API_KEYS_HASH_INDEX)
+        conn.execute(_CREATE_API_KEYS_USER_INDEX)
         # Migration: add reset_token_hash column if not already present
         try:
             conn.execute("ALTER TABLE users ADD COLUMN reset_token_hash TEXT DEFAULT NULL")
@@ -308,3 +335,129 @@ def consume_reset_token(user_id: str, token_hash: str) -> bool:
         )
         conn.commit()
     return True
+
+
+# ---------------------------------------------------------------------------
+# Public API keys (R28)
+# ---------------------------------------------------------------------------
+
+def _hash_api_key(key_plain: str) -> str:
+    return hashlib.sha256(key_plain.encode()).hexdigest()
+
+
+def _row_to_api_key(row: sqlite3.Row) -> ApiKey:
+    return ApiKey(
+        id=row["id"],
+        user_id=row["user_id"],
+        label=row["label"],
+        created_at=float(row["created_at"]),
+        last_used=float(row["last_used"]) if row["last_used"] is not None else None,
+        is_active=bool(row["is_active"]),
+    )
+
+
+def create_api_key(user_id: str, label: Optional[str] = None) -> tuple[str, ApiKey]:
+    """Mint a new API key for *user_id*. Returns (plaintext_key, ApiKey).
+
+    The plaintext key is never stored and is only returned here, once.
+    """
+    import secrets as _secrets
+
+    key_plain = _secrets.token_urlsafe(32)
+    key_id = str(uuid.uuid4())
+    now = time.time()
+    with _connect() as conn:
+        conn.execute(
+            "INSERT INTO api_keys (id, user_id, key_hash, label, created_at, last_used, is_active)"
+            " VALUES (?, ?, ?, ?, ?, NULL, 1)",
+            (key_id, user_id, _hash_api_key(key_plain), label, now),
+        )
+        conn.commit()
+        row = conn.execute("SELECT * FROM api_keys WHERE id = ?", (key_id,)).fetchone()
+    return key_plain, _row_to_api_key(row)
+
+
+def get_or_create_api_key(user_id: str, label: str) -> tuple[Optional[str], ApiKey]:
+    """Return the existing active key for (*user_id*, *label*) if one exists, else mint one.
+
+    Used by the login endpoint's per-device reuse: repeated logins with the
+    same ``device_label`` return the same key's metadata instead of minting a
+    new key each time. Returns ``(None, ApiKey)`` when reusing an existing
+    key, since the plaintext is never re-shown after creation.
+    """
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT * FROM api_keys WHERE user_id = ? AND label = ? AND is_active = 1",
+            (user_id, label),
+        ).fetchone()
+    if row:
+        return None, _row_to_api_key(row)
+    return create_api_key(user_id, label)
+
+
+def list_api_keys(user_id: str) -> list[ApiKey]:
+    """Return the user's active API keys, oldest first. Never includes the key itself."""
+    with _connect() as conn:
+        rows = conn.execute(
+            "SELECT * FROM api_keys WHERE user_id = ? AND is_active = 1 ORDER BY created_at ASC",
+            (user_id,),
+        ).fetchall()
+    return [_row_to_api_key(r) for r in rows]
+
+
+def revoke_api_key(key_id: str, user_id: str) -> None:
+    """Deactivate a key. Raises ValueError if it doesn't exist or isn't owned by *user_id*."""
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT id FROM api_keys WHERE id = ? AND user_id = ? AND is_active = 1",
+            (key_id, user_id),
+        ).fetchone()
+        if not row:
+            raise ValueError("API key not found.")
+        conn.execute("UPDATE api_keys SET is_active = 0 WHERE id = ?", (key_id,))
+        conn.commit()
+
+
+def verify_api_key(key_plain: str) -> Optional[User]:
+    """Return the User owning *key_plain* if it's a valid, active key; else None.
+
+    Updates ``last_used`` on success as a side effect.
+    """
+    if not key_plain:
+        return None
+    key_hash = _hash_api_key(key_plain)
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT * FROM api_keys WHERE key_hash = ? AND is_active = 1", (key_hash,)
+        ).fetchone()
+        if not row:
+            return None
+        conn.execute(
+            "UPDATE api_keys SET last_used = ? WHERE id = ?", (time.time(), row["id"])
+        )
+        conn.commit()
+    user = get_user_by_id(row["user_id"])
+    if not user or not user["is_active"]:
+        return None
+    return user
+
+
+def revoke_api_key_by_plain(key_plain: str) -> bool:
+    """Deactivate the API key matching *key_plain*. Returns True if a key was found.
+
+    Used by the `POST /api/v1/auth/logout` endpoint to revoke the exact key
+    the caller authenticated with, without needing to know its key id.
+    """
+    if not key_plain:
+        return False
+    key_hash = _hash_api_key(key_plain)
+    with _connect() as conn:
+        row = conn.execute(
+            "SELECT id FROM api_keys WHERE key_hash = ? AND is_active = 1", (key_hash,)
+        ).fetchone()
+        if not row:
+            return False
+        conn.execute("UPDATE api_keys SET is_active = 0 WHERE id = ?", (row["id"],))
+        conn.commit()
+    return True
+

--- a/code/web/utils/api_response.py
+++ b/code/web/utils/api_response.py
@@ -1,0 +1,37 @@
+"""Response envelope helpers for the public `/api/v1` REST API.
+
+Every `/api/v1` endpoint returns one of two shapes:
+
+    Success: {"ok": true, "data": ..., "request_id": "..."}
+    Error:   {"ok": false, "error": "...", "code": "SNAKE_CASE", "request_id": "...", "details"?: ...}
+
+Kept separate from `code/web/utils/responses.py` (the HTML/HTMX-era error
+builder) since the public API contract intentionally differs from the
+internal web UI's error shape.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping, Optional
+
+from fastapi.responses import JSONResponse
+
+
+def ok(data: Any, request_id: str, status_code: int = 200) -> JSONResponse:
+    """Build a success envelope response."""
+    return JSONResponse({"ok": True, "data": data, "request_id": request_id}, status_code=status_code)
+
+
+def err(
+    message: str,
+    code: str,
+    status_code: int,
+    request_id: str,
+    *,
+    details: Optional[Any] = None,
+    headers: Optional[Mapping[str, str]] = None,
+) -> JSONResponse:
+    """Build an error envelope response."""
+    content: dict[str, Any] = {"ok": False, "error": message, "code": code, "request_id": request_id}
+    if details is not None:
+        content["details"] = details
+    return JSONResponse(content, status_code=status_code, headers=dict(headers) if headers else None)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       SHOW_NEW_BADGE: "1"           # 1=show "New" badge on recently released cards site-wide; 0=hide badge only
       UPGRADE_WINDOW_MONTHS: "6"    # Rolling-months window for New Cards pool (default: 6)
       UPGRADE_PAGE_SIZE: "16"       # Cards per page on Potential Upgrades (default: 16, range 5-50)
+      API_DOCS_ENABLED: "1"         # 1=serve Swagger UI at /api/v1/docs and Redoc at /api/v1/redoc; 0=disable in production
       # LAND_PROFILE: "mid"         # Optional: force a land profile (basics|mid|fixing); skips auto-detection
       # LAND_COUNT: "36"            # Optional: force total land count; skips curve calculation
       

--- a/dockerhub-docker-compose.yml
+++ b/dockerhub-docker-compose.yml
@@ -50,6 +50,7 @@ services:
       SHOW_NEW_BADGE: "1"           # 1=show "New" badge on recently released cards site-wide; 0=hide badge only
       UPGRADE_WINDOW_MONTHS: "6"    # Rolling-months window for New Cards pool (default: 6)
       UPGRADE_PAGE_SIZE: "16"       # Cards per page on Potential Upgrades (default: 16, range 5-50)
+      API_DOCS_ENABLED: "1"         # 1=serve Swagger UI at /api/v1/docs and Redoc at /api/v1/redoc; 0=disable in production
       # LAND_PROFILE: "mid"         # Optional: force a land profile (basics|mid|fixing); skips auto-detection
       # LAND_COUNT: "36"            # Optional: force total land count; skips curve calculation
       


### PR DESCRIPTION
Adds a versioned public JSON REST API for third-party tools and the upcoming mobile app.

## What's included

- **Deck building** (`/builds`): start a build, poll progress, fetch the finished deck
- **Deck management** (`/decks`): list, view, export (csv/txt/json), delete, upgrade suggestions
- **Card/commander/theme browsing** (`/cards`, `/commanders`, `/themes`): search and detail lookups
- **Owned-card lists** (`/owned`), **price checks** (`/prices`), and **saved headless configs** (`/configs`)
- **Account auth** (`/auth`): register, login (with per-device API key reuse), logout, current-user info, forgot-password
- **API key management** (`/keys`): create, list, and revoke keys
- Bearer-token authentication independent of the website's login cookie, with per-key rate limiting (60 req/min)
- Consistent `{ok, data/error, request_id}` JSON envelope across every endpoint
- Interactive docs at `/api/v1/docs` (Swagger) and `/api/v1/redoc`, toggled with `API_DOCS_ENABLED`

See `CHANGELOG.md` for full details.