### PR TITLE
feat: mobile app API support (guided builds, CORS, deck analysis, card faces)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -225,6 +225,7 @@ DEBIAN_FRONTEND=noninteractive      # Suppress apt UI in Docker builds.
 # Public REST API (/api/v1)
 ############################
 API_DOCS_ENABLED=1                  # dockerhub: API_DOCS_ENABLED="1" (1=serve Swagger UI at /api/v1/docs and Redoc at /api/v1/redoc; 0=disable in production)
+# CORS_ALLOWED_ORIGINS=*            # dockerhub: CORS_ALLOWED_ORIGINS="*" (comma-separated allowed origins for browser-based clients, or "*" for any; default is "*" when unset. Set to "none" to disable CORS entirely)
 
 ############################
 # Editorial / Theme Catalog (Phase D) – Advanced

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,18 @@ This format follows Keep a Changelog principles and aims for Semantic Versioning
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- Guided (stage-by-stage) deck building for the public REST API: `POST /api/v1/builds` accepts `mode: "guided"` to pause after each build stage instead of running straight through; `POST /api/v1/builds/{id}/advance` runs the next stage and returns the cards it added for review, `GET /api/v1/builds/{id}/alternatives` suggests role-based swap candidates for a card already in the deck-in-progress, and `POST /api/v1/builds/{id}/replace` swaps a card in place and locks the replacement so later stages won't remove it
+- CORS support for the public REST API, open to any origin by default so browser-based clients (e.g. the mobile companion app's web dev build) work with no configuration; restrict via `CORS_ALLOWED_ORIGINS` (comma-separated allow-list) or disable entirely with `CORS_ALLOWED_ORIGINS=none`
+- `/api/images/{size}/{card_name}` now accepts `art_crop` as an image size, for clients that want just the illustration rather than the full card
+- `GET /api/v1/decks/{filename}/analysis`: commander, color identity, mana curve, pip distribution, mana source breakdown, land summary (including MDFC lands counted as extra land slots), and total price for a saved deck, for clients (like the mobile app) that want the same "Mana Overview"/"Land Summary" data as the web deck view without re-deriving it from the CSV export
+- `GET /api/v1/decks/{filename}`: card entries now include a `layout` field (Scryfall layout, e.g. `transform`, `modal_dfc`, `split`), so clients can tell double-faced cards with separate front/back images apart from split/adventure/aftermath cards that share one combined image
+- `GET /api/v1/cards/{name}` now includes a `faces` array with per-face details (name, side, type, text, mana value, power/toughness, color identity) for split, adventure, transform, modal DFC, flip, and aftermath cards, letting clients show the "other side" of a multi-faced card, which the tagged card dataset otherwise omits
 
 ### Changed
 _No unreleased changes yet_
 
 ### Fixed
-_No unreleased changes yet_
+- `GET /api/v1/cards/{name}` returned `CARD_NOT_FOUND` for basic lands (Plains, Island, Swamp, Mountain, Forest, Wastes), which are intentionally excluded from the local tagged card dataset; it now falls back to a live Scryfall lookup for any card missing locally
 
 ### Removed
 _No unreleased changes yet_

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -309,6 +309,7 @@ See `.env.example` for the full catalog. Common knobs:
 | `UPGRADE_WINDOW_MONTHS` | `6` | Rolling-months window used to identify New Cards (cards released within the last N months). |
 | `UPGRADE_PAGE_SIZE` | `16` | Cards shown per page on the Potential Upgrades page (valid range: 5–50). |
 | `API_DOCS_ENABLED` | `1` | Serve interactive Swagger UI at `/api/v1/docs` and Redoc at `/api/v1/redoc` for the public REST API. Set to `0` to disable both in production. |
+| `CORS_ALLOWED_ORIGINS` | `*` | CORS policy for the public REST API. Defaults to allowing any origin (`*`) so browser-based clients, including the Flutter web dev build of the mobile companion app, work with no configuration; the API is Bearer-token authenticated, so this doesn't expose the cookie-based web UI session. Set a comma-separated allow-list to restrict to specific origins, or `none` to disable CORS entirely. |
 
 ### Random build controls
 

--- a/README.md
+++ b/README.md
@@ -257,6 +257,7 @@ A full JSON REST API mirroring the web UI's core features, for scripting and thi
 - Base path `/api/v1`; every response is a JSON envelope (`{"ok": true, "data": ...}` or `{"ok": false, "error": ..., "code": ...}`).
 - Covers deck building, deck management, card/commander/theme browsing, owned-card lists, price checks, upgrade suggestions, headless configs, and account auth (register/login/logout), all authenticated with per-account API keys (`Authorization: Bearer <key>`).
 - Interactive docs at `/api/v1/docs` (Swagger UI) and `/api/v1/redoc`; toggle both with `API_DOCS_ENABLED`.
+- CORS is open to any origin by default so browser-based clients (e.g. the mobile companion app's web dev build) work with no setup; restrict with `CORS_ALLOWED_ORIGINS` (comma-separated allow-list) or disable entirely with `CORS_ALLOWED_ORIGINS=none`.
 
 ---
 
@@ -480,6 +481,7 @@ Most defaults are defined in `docker-compose.yml` and documented in `.env.exampl
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `API_DOCS_ENABLED` | `1` | Serve Swagger UI (`/api/v1/docs`) and Redoc (`/api/v1/redoc`) for the public REST API. Set to `0` to disable both in production. |
+| `CORS_ALLOWED_ORIGINS` | `*` | CORS policy for the public REST API. Defaults to any origin (`*`); set a comma-separated allow-list to restrict, or `none` to disable CORS entirely. |
 
 ### Supplemental themes
 | Variable | Default | Purpose |

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -2,13 +2,18 @@
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- Guided (stage-by-stage) deck building for the public REST API: `POST /api/v1/builds` accepts `mode: "guided"` to pause after each build stage instead of running straight through; `POST /api/v1/builds/{id}/advance` runs the next stage and returns the cards it added for review, `GET /api/v1/builds/{id}/alternatives` suggests role-based swap candidates for a card already in the deck-in-progress, and `POST /api/v1/builds/{id}/replace` swaps a card in place and locks the replacement so later stages won't remove it
+- CORS support for the public REST API, open to any origin by default so browser-based clients (e.g. the mobile companion app's web dev build) work with no configuration; restrict via `CORS_ALLOWED_ORIGINS` (comma-separated allow-list) or disable entirely with `CORS_ALLOWED_ORIGINS=none`
+- `/api/images/{size}/{card_name}` now accepts `art_crop` as an image size, for clients that want just the illustration rather than the full card
+- `GET /api/v1/decks/{filename}/analysis`: commander, color identity, mana curve, pip distribution, mana source breakdown, land summary (including MDFC lands counted as extra land slots), and total price for a saved deck, for clients (like the mobile app) that want the same "Mana Overview"/"Land Summary" data as the web deck view without re-deriving it from the CSV export
+- `GET /api/v1/decks/{filename}`: card entries now include a `layout` field (Scryfall layout, e.g. `transform`, `modal_dfc`, `split`), so clients can tell double-faced cards with separate front/back images apart from split/adventure/aftermath cards that share one combined image
+- `GET /api/v1/cards/{name}` now includes a `faces` array with per-face details (name, side, type, text, mana value, power/toughness, color identity) for split, adventure, transform, modal DFC, flip, and aftermath cards, letting clients show the "other side" of a multi-faced card, which the tagged card dataset otherwise omits
 
 ### Changed
 _No unreleased changes yet_
 
 ### Fixed
-_No unreleased changes yet_
+- Fixed basic lands (Plains, Island, Swamp, Mountain, Forest, Wastes) showing up as "not found" in the card detail API; they now fall back to Scryfall for their info and art
 
 ### Removed
 _No unreleased changes yet_

--- a/code/settings.py
+++ b/code/settings.py
@@ -163,6 +163,29 @@ ENABLE_BATCH_BUILD = os.getenv('ENABLE_BATCH_BUILD', '1').lower() not in ('0', '
 PRICE_STALE_WARNING_HOURS: int = max(0, int(os.getenv('PRICE_STALE_WARNING_HOURS', '24')))
 
 # ----------------------------------------------------------------------------------
+# PUBLIC API / CORS SETTINGS
+# ----------------------------------------------------------------------------------
+
+# CORS for the public REST API. Browser-based clients (Flutter web, other
+# self-hosted frontends, etc.) need CORS enabled to call the API from a
+# different origin; native mobile/desktop HTTP clients are never subject to
+# CORS at all, so this setting only matters for in-browser usage.
+#
+# Default: allow any origin ("*"). This API is authenticated with per-account
+# Bearer API keys (not cookies), so an open CORS policy doesn't expose the
+# cookie-based web UI session; a third-party site still can't do anything
+# without a valid API key of its own. To restrict to specific origins, set a
+# comma-separated allow-list (e.g. "http://localhost:5050,https://example.com").
+# To disable CORS entirely, set CORS_ALLOWED_ORIGINS=none.
+_cors_raw = os.getenv('CORS_ALLOWED_ORIGINS', '*').strip()
+if _cors_raw.lower() in ('none', 'off', 'disabled', '0'):
+    CORS_ALLOWED_ORIGINS: list[str] = []
+elif _cors_raw == '*' or not _cors_raw:
+    CORS_ALLOWED_ORIGINS = ['*']
+else:
+    CORS_ALLOWED_ORIGINS = [origin.strip() for origin in _cors_raw.split(',') if origin.strip()]
+
+# ----------------------------------------------------------------------------------
 # THEME CATALOG SETTINGS
 # ----------------------------------------------------------------------------------
 

--- a/code/tests/test_api_v1_builds.py
+++ b/code/tests/test_api_v1_builds.py
@@ -91,6 +91,149 @@ def test_create_build_requires_commander(client, auth_headers, monkeypatch):
     assert resp.json()["code"] == "INVALID_COMMANDER"
 
 
+def test_create_build_uses_per_user_deck_dir(client, auth_headers, monkeypatch):
+    """Regression: builds must export into deck_files/{user_id}/, not the shared root
+    (see decks.py's _deck_dir), so GET /api/v1/decks/{filename} can find them."""
+    import code.web.routes.api_v1.builds as builds_route
+    from code.web.services.user_db import verify_api_key
+
+    seen_kwargs: dict = {}
+
+    def _capturing_start_build_ctx(**kwargs):
+        seen_kwargs.update(kwargs)
+        return {"stages": [0], "idx": 0}
+
+    monkeypatch.setattr(builds_route.orch, "start_build_ctx", _capturing_start_build_ctx)
+    monkeypatch.setattr(builds_route.orch, "ideal_defaults", lambda: {})
+    monkeypatch.setattr(builds_route.orch, "bracket_options", lambda: [{"level": 1}])
+
+    resp = client.post("/api/v1/builds", json={"commander": "Test Commander"}, headers=auth_headers)
+    assert resp.status_code == 202
+
+    token = auth_headers["Authorization"].split(" ", 1)[1]
+    user = verify_api_key(token)
+    expected_suffix = str(builds_route._deck_dir(str(user["id"])))
+    assert seen_kwargs["deck_dir"] == expected_suffix
+    assert seen_kwargs["deck_dir"] != "deck_files"
+
+
+def _fake_guided_orchestrator(monkeypatch, *, stage_count: int = 2):
+    """Like _fake_orchestrator, but run_stage never batches -- each call advances
+    exactly one stage and returns added_cards, matching guided-mode semantics."""
+    import code.web.routes.api_v1.builds as builds_route
+
+    class _FakeBuilder:
+        def __init__(self):
+            self.card_library = {
+                "Sol Ring": {"Count": 1, "Role": "ramp", "SubRole": "", "TriggerTag": ""},
+            }
+            self._combined_cards_df = None
+            self.commander_name = "Test Commander"
+
+    def _fake_start_build_ctx(**kwargs):
+        return {"stages": list(range(stage_count)), "idx": 0, "builder": _FakeBuilder(), "locks": set(), "alts_exclude": set()}
+
+    def _fake_run_stage(ctx, *args, **kwargs):
+        ctx["idx"] += 1
+        if ctx["idx"] >= len(ctx["stages"]):
+            return {
+                "done": True,
+                "idx": ctx["idx"],
+                "total": len(ctx["stages"]),
+                "label": "Complete",
+                "csv_path": "deck_files/Test.csv",
+                "txt_path": "deck_files/Test.txt",
+                "summary": {"type_breakdown": {"total": 100}},
+                "compliance": {"overall": "PASS"},
+            }
+        return {
+            "done": False,
+            "idx": ctx["idx"],
+            "total": len(ctx["stages"]),
+            "label": "Stage",
+            "added_cards": [{"name": "Sol Ring", "count": 1, "role": "ramp"}],
+        }
+
+    monkeypatch.setattr(builds_route.orch, "start_build_ctx", _fake_start_build_ctx)
+    monkeypatch.setattr(builds_route.orch, "run_stage", _fake_run_stage)
+    monkeypatch.setattr(builds_route.orch, "ideal_defaults", lambda: {})
+    monkeypatch.setattr(builds_route.orch, "bracket_options", lambda: [{"level": 1}])
+
+
+def test_guided_build_advance_flow(client, auth_headers, monkeypatch):
+    _fake_guided_orchestrator(monkeypatch, stage_count=2)
+
+    resp = client.post(
+        "/api/v1/builds", json={"commander": "Test Commander", "mode": "guided"}, headers=auth_headers
+    )
+    assert resp.status_code == 201
+    data = resp.json()["data"]
+    assert data["status"] == "ready"
+    assert data["mode"] == "guided"
+    build_id = data["build_id"]
+
+    # Guided builds start in "ready" state; nothing runs until /advance is called.
+    resp = client.get(f"/api/v1/builds/{build_id}", headers=auth_headers)
+    assert resp.json()["data"]["status"] == "ready"
+
+    resp = client.post(f"/api/v1/builds/{build_id}/advance", headers=auth_headers)
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["done"] is False
+    assert data["added_cards"][0]["name"] == "Sol Ring"
+
+    resp = client.post(f"/api/v1/builds/{build_id}/advance", headers=auth_headers)
+    data = resp.json()["data"]
+    assert data["done"] is True
+
+    resp = client.get(f"/api/v1/builds/{build_id}/deck", headers=auth_headers)
+    assert resp.status_code == 200
+    assert resp.json()["data"]["summary"]["type_breakdown"]["total"] == 100
+
+
+def test_guided_build_advance_rejects_auto_mode(client, auth_headers, monkeypatch):
+    _fake_orchestrator(monkeypatch)
+    resp = client.post("/api/v1/builds", json={"commander": "Test Commander"}, headers=auth_headers)
+    build_id = resp.json()["data"]["build_id"]
+
+    resp = client.post(f"/api/v1/builds/{build_id}/advance", headers=auth_headers)
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "BUILD_NOT_FOUND"
+
+
+def test_guided_build_replace_and_alternatives(client, auth_headers, monkeypatch):
+    _fake_guided_orchestrator(monkeypatch, stage_count=1)
+
+    resp = client.post(
+        "/api/v1/builds", json={"commander": "Test Commander", "mode": "guided"}, headers=auth_headers
+    )
+    build_id = resp.json()["data"]["build_id"]
+
+    resp = client.get(
+        f"/api/v1/builds/{build_id}/alternatives", params={"card": "Sol Ring"}, headers=auth_headers
+    )
+    assert resp.status_code == 200
+    assert "items" in resp.json()["data"]
+
+    resp = client.post(
+        f"/api/v1/builds/{build_id}/replace",
+        json={"old_name": "Sol Ring", "new_name": "Arcane Signet"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["old_name"] == "Sol Ring"
+    assert data["new_name"] == "Arcane Signet"
+
+    resp = client.post(
+        f"/api/v1/builds/{build_id}/replace",
+        json={"old_name": "Not In Deck", "new_name": "Whatever"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 404
+    assert resp.json()["code"] == "CARD_NOT_IN_DECK"
+
+
 def test_full_build_lifecycle(client, auth_headers, monkeypatch):
     _fake_orchestrator(monkeypatch)
 

--- a/code/tests/test_api_v1_decks.py
+++ b/code/tests/test_api_v1_decks.py
@@ -143,6 +143,25 @@ def test_delete_deck(client, auth, tmp_path):
     assert not csv_path.with_suffix(".txt").exists()
 
 
+def test_deck_analysis_fallback_no_sidecar(client, auth, tmp_path):
+    """Without a `.summary.json` sidecar, falls back to a CSV-only curve
+    reconstruction (pips/sources default to zero, per `_read_csv_summary`)."""
+    user, headers = auth
+    _write_sample_deck(user["id"], tmp_path)
+    resp = client.get("/api/v1/decks/Test Deck.csv/analysis", headers=headers)
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["commander"] == "Test Deck"
+    assert data["mana_curve"]["1"] == 2
+    assert data["pip_distribution"]["counts"] == {c: 0 for c in ("W", "U", "B", "R", "G")}
+
+
+def test_deck_analysis_not_found(client, auth):
+    _, headers = auth
+    resp = client.get("/api/v1/decks/Nope.csv/analysis", headers=headers)
+    assert resp.status_code == 404
+
+
 # ---------------------------------------------------------------------------
 # Milestone 8: upgrade suggestions
 # ---------------------------------------------------------------------------

--- a/code/web/app.py
+++ b/code/web/app.py
@@ -13,6 +13,7 @@ import logging
 import math
 from starlette.exceptions import HTTPException as StarletteHTTPException
 from starlette.middleware.gzip import GZipMiddleware
+from starlette.middleware.cors import CORSMiddleware
 from typing import Any, Optional, Dict, Iterable, Mapping
 from contextlib import asynccontextmanager
 
@@ -26,6 +27,7 @@ from .services.user_db import init_db, ensure_guest_user
 from .services.audit_db import init_audit_db
 from .services.auth import AuthMiddleware
 from code.exceptions import DeckBuilderError
+from code.settings import CORS_ALLOWED_ORIGINS
 from .utils.responses import deck_builder_error_response
 
 # Logger for app-level logging
@@ -123,6 +125,18 @@ async def _lifespan(app: FastAPI):  # pragma: no cover - simple infra glue
 
 app = FastAPI(title="MTG Deckbuilder Web UI", lifespan=_lifespan)
 app.add_middleware(GZipMiddleware, minimum_size=500)
+if CORS_ALLOWED_ORIGINS:
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=CORS_ALLOWED_ORIGINS,
+        # Credentials (cookies) can't be combined with a wildcard origin per
+        # the CORS spec; the API itself is Bearer-token authenticated, not
+        # cookie-based, so this only affects whether cookies would be sent
+        # for a specific configured origin (harmless either way for /api/v1).
+        allow_credentials=CORS_ALLOWED_ORIGINS != ["*"],
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
 app.add_middleware(AuthMiddleware)
 
 # Mount static if present

--- a/code/web/routes/api.py
+++ b/code/web/routes/api.py
@@ -7,8 +7,10 @@ import logging
 import threading
 import time
 from pathlib import Path
+from typing import Optional
 from urllib.parse import quote_plus
 
+import httpx
 from fastapi import APIRouter, Query
 from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
 
@@ -30,6 +32,7 @@ _image_cache = ImageCache()
 _SCRYFALL_MIN_INTERVAL = 0.50  # seconds between fallback redirects (2 req/s per Scryfall docs)
 _scryfall_lock = asyncio.Lock()
 _scryfall_last_redirect: float = 0.0
+_SCRYFALL_USER_AGENT = "MTGPythonDeckbuilder/1.0 (contact via GitHub)"
 
 
 async def _scryfall_rate_limit() -> None:
@@ -41,6 +44,49 @@ async def _scryfall_rate_limit() -> None:
         if wait > 0:
             await asyncio.sleep(wait)
         _scryfall_last_redirect = time.monotonic()
+
+
+async def _resolve_scryfall_image_url(
+    name: str, size: str, *, exact: bool = False, face: str = "front"
+) -> Optional[str]:
+    """Resolve a direct Scryfall CDN image URL server-side.
+
+    api.scryfall.com requires a User-Agent and Accept header on every
+    request; redirecting a client straight to it (the previous approach)
+    fails with a 400 for clients that don't send those headers -- observed
+    with the mobile app's HTTP client for basic lands, which always hit
+    this fallback (not cached locally). Fetching the card JSON here (with
+    proper headers) and returning the plain CDN image URL
+    (cards.scryfall.io, no special headers required) sidesteps that.
+    """
+    params = {"exact": name} if exact else {"fuzzy": name}
+    await _scryfall_rate_limit()
+    try:
+        async with httpx.AsyncClient(
+            headers={"User-Agent": _SCRYFALL_USER_AGENT, "Accept": "application/json"},
+            timeout=10.0,
+        ) as client:
+            resp = await client.get("https://api.scryfall.com/cards/named", params=params)
+            if resp.status_code == 404:
+                return None
+            resp.raise_for_status()
+            data = resp.json()
+    except httpx.HTTPError as e:
+        logger.warning(f"Scryfall image lookup failed for '{name}': {e}")
+        return None
+    except Exception as e:
+        logger.warning(f"Unexpected error resolving Scryfall image for '{name}': {e}")
+        return None
+
+    image_uris = data.get("image_uris")
+    if not image_uris:
+        faces = data.get("card_faces") or []
+        face_index = 1 if face == "back" and len(faces) > 1 else 0
+        if face_index < len(faces):
+            image_uris = faces[face_index].get("image_uris")
+    if not image_uris:
+        return None
+    return image_uris.get(size) or image_uris.get("normal")
 
 
 @router.get("/images/status")
@@ -152,7 +198,7 @@ async def get_card_image(size: str, card_name: str, face: str = Query(default="f
     Serve card image from cache or redirect to Scryfall API.
     
     Args:
-        size: Image size ('small' or 'normal')
+        size: Image size ('small', 'normal', or 'art_crop')
         card_name: Name of the card
         face: Which face to show ('front' or 'back') for DFC cards
         
@@ -160,11 +206,11 @@ async def get_card_image(size: str, card_name: str, face: str = Query(default="f
         FileResponse if cached locally, RedirectResponse to Scryfall API otherwise
     """
     # Validate size parameter
-    if size not in ["small", "normal"]:
+    if size not in ["small", "normal", "art_crop"]:
         size = "normal"
     
-    # Check if caching is enabled
-    cache_enabled = _image_cache.is_enabled()
+    # Check if caching is enabled (local cache only stores small/normal; art_crop always redirects)
+    cache_enabled = _image_cache.is_enabled() and size != "art_crop"
     
     # Check if image exists in cache
     if cache_enabled:
@@ -198,11 +244,12 @@ async def get_card_image(size: str, card_name: str, face: str = Query(default="f
         else:
             logger.debug(f"No cached image found for: {card_name} (face: {face})")
     
-    # Fallback to Scryfall API
-    # For back face requests of DFC cards, we need the full card name
+    # Fallback to Scryfall, resolved server-side (api.scryfall.com rejects
+    # requests missing headers most simple HTTP clients don't send -- see
+    # _resolve_scryfall_image_url).
     scryfall_card_name = card_name
-    scryfall_params = f"fuzzy={quote_plus(scryfall_card_name)}&format=image&version={size}"
-    
+    use_exact = False
+
     # If this is a back face request, try to find the full DFC name
     if face == "back":
         try:
@@ -218,16 +265,19 @@ async def get_card_image(size: str, card_name: str, face: str = Query(default="f
                 dfc_matches = matching[matching['name'].str.contains(' // ', na=False, regex=False)]
                 if not dfc_matches.empty:
                     # Use the first matching DFC card's full name
-                    full_name = dfc_matches.iloc[0]['name']
-                    scryfall_card_name = full_name
-                    # Add face parameter to Scryfall request
-                    scryfall_params = f"exact={quote_plus(full_name)}&format=image&version={size}&face=back"
+                    scryfall_card_name = dfc_matches.iloc[0]['name']
+                    use_exact = True
         except Exception as e:
             logger.warning(f"Could not lookup full card name for back face '{card_name}': {e}")
-    
-    scryfall_url = f"https://api.scryfall.com/cards/named?{scryfall_params}"
-    await _scryfall_rate_limit()
-    return RedirectResponse(scryfall_url)
+
+    image_url = await _resolve_scryfall_image_url(scryfall_card_name, size, exact=use_exact, face=face)
+    if image_url:
+        return RedirectResponse(image_url)
+
+    # Last resort -- redirect straight to the Scryfall API; works for
+    # clients that do send the headers it requires (e.g. browsers).
+    scryfall_params = f"fuzzy={quote_plus(card_name)}&format=image&version={size}"
+    return RedirectResponse(f"https://api.scryfall.com/cards/named?{scryfall_params}")
 
 
 @router.post("/images/download")

--- a/code/web/routes/api_v1/builds.py
+++ b/code/web/routes/api_v1/builds.py
@@ -23,12 +23,16 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, Request
 from pydantic import BaseModel, Field
 
+from code.deck_builder.builder import DeckBuilder
+from code.deck_builder import builder_utils as bu
 from code.type_definitions import User
 
+from ...services import api_alternatives
 from ...services import api_build_store as build_store
 from ...services import orchestrator as orch
 from ...services.build_utils import owned_names as owned_names_helper
 from ...utils.api_response import err, ok
+from ..decks import _deck_dir
 from .auth import get_api_user
 
 router = APIRouter(prefix="/builds", tags=["builds"])
@@ -46,6 +50,25 @@ class CreateBuildRequest(BaseModel):
     seed: Optional[int] = None
     owned_only: bool = False
     prefer_owned: bool = False
+    # "auto" runs every stage immediately in the background (default, unchanged
+    # behavior). "guided" stops after each stage so a client can review/swap
+    # cards via POST /{build_id}/advance before continuing.
+    mode: str = "auto"
+    # Multi-copy "package" selection, e.g. {"id": "hare_apparent", "name": "Hare
+    # Apparent", "count": 25}. See GET /builds/multi-copy-options for viable
+    # choices for a given commander/themes.
+    multi_copy: Optional[Dict[str, Any]] = None
+    # Any subset of the ideal-count categories (ramp, lands, basic_lands,
+    # creatures, removal, wipes, card_advantage, protection). Missing keys
+    # fall back to the server defaults (see GET /builds/ideal-defaults).
+    ideal_counts: Optional[Dict[str, int]] = None
+    include_cards: Optional[List[str]] = None
+    exclude_cards: Optional[List[str]] = None
+
+
+class ReplaceCardRequest(BaseModel):
+    old_name: str
+    new_name: str
 
 
 def _default_bracket() -> int:
@@ -77,6 +100,15 @@ def _run_build_sync(build_id: str, ctx: Dict[str, Any]) -> None:
                 stage_total=result.get("total", len(stages)),
                 stage_label=result.get("label"),
             )
+            if result.get("gated"):
+                # Compliance gating (see run_stage's bracket-FAIL branch)
+                # holds ctx["idx"] in place so a human can review/adjust via
+                # guided mode. Auto mode has no reviewer, so accept the
+                # stage's result and advance past the gate instead of
+                # looping forever re-checking the same stage.
+                ctx.pop("gating", None)
+                ctx["idx"] = int(result.get("idx", ctx["idx"]))
+                continue
             if result.get("done"):
                 build_store.mark_done(
                     build_id,
@@ -85,6 +117,7 @@ def _run_build_sync(build_id: str, ctx: Dict[str, Any]) -> None:
                         "txt_path": result.get("txt_path"),
                         "summary": result.get("summary"),
                         "compliance": result.get("compliance"),
+                        "include_exclude_diagnostics": result.get("include_exclude_diagnostics"),
                     },
                 )
                 return
@@ -94,13 +127,25 @@ def _run_build_sync(build_id: str, ctx: Dict[str, Any]) -> None:
 
 @router.post("", summary="Create a deck build")
 async def create_build(body: CreateBuildRequest, request: Request, user: User = Depends(get_api_user)):
-    """Start a new deck build. Returns immediately with a `build_id` to poll."""
+    """Start a new deck build. Returns immediately with a `build_id` to poll.
+
+    `mode="guided"` skips the automatic background run; call
+    `POST /{build_id}/advance` repeatedly to step through stages instead.
+    """
     commander = body.commander.strip()
     if not commander:
         return err("commander is required.", "INVALID_COMMANDER", 400, _rid(request))
+    if body.mode not in ("auto", "guided"):
+        return err("mode must be 'auto' or 'guided'.", "INVALID_MODE", 400, _rid(request))
     bracket = body.bracket if body.bracket is not None else _default_bracket()
 
     owned_names_list = owned_names_helper() if (body.owned_only or body.prefer_owned) else None
+
+    deck_dir = str(_deck_dir(str(user["id"])))
+
+    ideals = orch.ideal_defaults()
+    if body.ideal_counts:
+        ideals.update({k: int(v) for k, v in body.ideal_counts.items()})
 
     try:
         ctx = await asyncio.to_thread(
@@ -108,11 +153,15 @@ async def create_build(body: CreateBuildRequest, request: Request, user: User = 
             commander=commander,
             tags=body.themes,
             bracket=bracket,
-            ideals=orch.ideal_defaults(),
+            ideals=ideals,
             use_owned_only=body.owned_only,
             prefer_owned=body.prefer_owned,
             owned_names=owned_names_list,
             budget_config=body.budget,
+            deck_dir=deck_dir,
+            multi_copy=body.multi_copy,
+            include_cards=body.include_cards,
+            exclude_cards=body.exclude_cards,
         )
     except ValueError as exc:
         return err(str(exc), "INVALID_BUILD_REQUEST", 400, _rid(request))
@@ -120,9 +169,64 @@ async def create_build(body: CreateBuildRequest, request: Request, user: User = 
         return err(str(exc), "SETUP_NOT_READY", 503, _rid(request))
 
     build_id = build_store.create_build(user["id"], body.model_dump())
-    asyncio.create_task(asyncio.to_thread(_run_build_sync, build_id, ctx))
 
+    if body.mode == "guided":
+        build_store.set_ctx(build_id, ctx)
+        stage_total = len(ctx.get("stages", []))
+        build_store.update_progress(build_id, status="ready", stage_idx=0, stage_total=stage_total)
+        return ok(
+            {"build_id": build_id, "status": "ready", "mode": "guided", "stage_total": stage_total},
+            _rid(request),
+            status_code=201,
+        )
+
+    asyncio.create_task(asyncio.to_thread(_run_build_sync, build_id, ctx))
     return ok({"build_id": build_id, "status": "queued"}, _rid(request), status_code=202)
+
+
+def _detect_multi_copy_options_sync(commander: str, themes: List[str]) -> List[Dict[str, Any]]:
+    """Lightweight, no-data-load detection of viable multi-copy packages.
+
+    Mirrors `build_multicopy.py`'s `/multicopy/check` route (used by the HTML
+    web UI), just without the session/HTML-modal plumbing.
+    """
+    tmp = DeckBuilder(output_func=lambda *_: None, input_func=lambda *_: "", headless=True)
+    df = tmp.load_commander_data()
+    row = df[df["name"].astype(str) == commander]
+    if row.empty:
+        raise ValueError(f"Commander not found: {commander}")
+    tmp._apply_commander_selection(row.iloc[0])
+    tmp.selected_tags = list(themes or [])
+    tmp.determine_color_identity()
+    return bu.detect_viable_multi_copy_archetypes(tmp) or []
+
+
+@router.get("/multi-copy-options", summary="Suggest multi-copy packages")
+async def get_multi_copy_options(
+    commander: str,
+    request: Request,
+    themes: str = "",
+    user: User = Depends(get_api_user),
+):
+    """Viable multi-copy "package" archetypes (Relentless Rats, Hare Apparent,
+    etc.) for a commander/theme combo, for use as `multi_copy` in
+    `POST /builds`. Empty list means none apply.
+    """
+    theme_list = [t.strip() for t in themes.split(",") if t.strip()]
+    try:
+        items = await asyncio.to_thread(_detect_multi_copy_options_sync, commander.strip(), theme_list)
+    except ValueError as exc:
+        return err(str(exc), "INVALID_COMMANDER", 400, _rid(request))
+    return ok({"items": items}, _rid(request))
+
+
+@router.get("/ideal-defaults", summary="Get default ideal counts")
+async def get_ideal_defaults(request: Request, user: User = Depends(get_api_user)):
+    """Server-side defaults for the `ideal_counts` field of `POST /builds`
+    (ramp, lands, basic_lands, creatures, removal, wipes, card_advantage,
+    protection). Use these to pre-fill an editable form.
+    """
+    return ok({"defaults": orch.ideal_defaults(), "labels": orch.ideal_labels()}, _rid(request))
 
 
 @router.get("/{build_id}", summary="Get build status")
@@ -146,6 +250,220 @@ async def get_build_deck(build_id: str, request: Request, user: User = Depends(g
     if status != "done":
         return err("Build is not complete yet.", "BUILD_NOT_READY", 409, _rid(request))
     return ok(build.get("result") or {}, _rid(request))
+
+
+def _guided_build_or_none(build_id: str, user_id: str) -> Optional[Dict[str, Any]]:
+    build = build_store.get_build(build_id)
+    if not build or build.get("user_id") != user_id:
+        return None
+    if (build.get("config") or {}).get("mode") != "guided":
+        return None
+    return build
+
+
+def _run_stage_sync(ctx: Dict[str, Any], lock) -> Dict[str, Any]:
+    with lock:
+        return orch.run_stage(ctx, rerun=False, show_skipped=False)
+
+
+@router.post("/{build_id}/advance", summary="Run the next build stage (guided mode)")
+async def advance_build(build_id: str, request: Request, user: User = Depends(get_api_user)):
+    """Run exactly one stage of a guided-mode build and return it for review.
+
+    Call this repeatedly until the response has `"done": true`.
+    """
+    build = _guided_build_or_none(build_id, user["id"])
+    if build is None:
+        return err("Guided build not found.", "BUILD_NOT_FOUND", 404, _rid(request))
+    if build.get("status") == "done":
+        return err("Build is already complete.", "BUILD_ALREADY_DONE", 409, _rid(request))
+    if build.get("status") == "error":
+        return err(build.get("error") or "Build failed.", "BUILD_FAILED", 409, _rid(request))
+
+    ctx = build_store.get_ctx(build_id)
+    lock = build_store.get_stage_lock(build_id)
+    if ctx is None or lock is None:
+        return err("Build session expired.", "BUILD_SESSION_EXPIRED", 410, _rid(request))
+
+    try:
+        result = await asyncio.to_thread(_run_stage_sync, ctx, lock)
+    except Exception as exc:  # noqa: BLE001
+        build_store.mark_error(build_id, str(exc))
+        return err(str(exc), "BUILD_STAGE_FAILED", 500, _rid(request))
+
+    stage_total = int(result.get("total") or len(ctx.get("stages", [])) or 0)
+    stage_idx = int(result.get("idx") or 0)
+    done = bool(result.get("done"))
+    if done:
+        build_store.mark_done(
+            build_id,
+            {
+                "csv_path": result.get("csv_path"),
+                "txt_path": result.get("txt_path"),
+                "summary": result.get("summary"),
+                "compliance": result.get("compliance"),
+                "include_exclude_diagnostics": result.get("include_exclude_diagnostics"),
+            },
+        )
+    else:
+        build_store.update_progress(
+            build_id,
+            status="running",
+            stage_idx=stage_idx,
+            stage_total=stage_total,
+            stage_label=result.get("label"),
+        )
+
+    payload = {
+        "done": done,
+        "status": "done" if done else "running",
+        "stage_label": result.get("label"),
+        "stage_idx": stage_idx,
+        "stage_total": stage_total,
+        "added_cards": result.get("added_cards") or [],
+        "skipped": bool(result.get("skipped")),
+        "gated": bool(result.get("gated")),
+    }
+    return ok(payload, _rid(request))
+
+
+@router.get("/{build_id}/alternatives", summary="Suggest alternative cards (guided mode)")
+async def get_build_alternatives(
+    build_id: str,
+    card: str,
+    request: Request,
+    owned_only: bool = False,
+    exclude: Optional[str] = None,
+    user: User = Depends(get_api_user),
+):
+    """Suggest alternatives for a card already in a guided build's deck-in-progress.
+
+    `exclude` is an optional comma-separated list of card names to omit from
+    the results (in addition to the build's own swap history) -- used by
+    clients to "reroll" and see a different batch of suggestions.
+    """
+    build = _guided_build_or_none(build_id, user["id"])
+    if build is None:
+        return err("Guided build not found.", "BUILD_NOT_FOUND", 404, _rid(request))
+    ctx = build_store.get_ctx(build_id)
+    if ctx is None:
+        return err("Build session expired.", "BUILD_SESSION_EXPIRED", 410, _rid(request))
+    b = ctx.get("builder")
+    if b is None:
+        return err("Build session expired.", "BUILD_SESSION_EXPIRED", 410, _rid(request))
+
+    exclude_set = set(ctx.get("alts_exclude") or [])
+    if exclude:
+        exclude_set.update(x.strip() for x in exclude.split(",") if x.strip())
+
+    items = await asyncio.to_thread(
+        api_alternatives.suggest_alternatives,
+        b,
+        card,
+        owned_only=owned_only,
+        exclude=exclude_set,
+        locked=ctx.get("locks"),
+        commander=getattr(b, "commander_name", None) or getattr(b, "commander", None),
+    )
+    return ok({"items": items}, _rid(request))
+
+
+def _replace_card_sync(ctx: Dict[str, Any], old_name: str, new_name: str) -> Dict[str, str]:
+    b = ctx.get("builder")
+    o_disp = str(old_name).strip()
+    n_disp = str(new_name).strip()
+    o = o_disp.lower()
+    n = n_disp.lower()
+
+    lib = getattr(b, "card_library", {}) or {}
+    old_key = None
+    if o_disp in lib:
+        old_key = o_disp
+    else:
+        for k in list(lib.keys()):
+            if str(k).strip().lower() == o:
+                old_key = k
+                break
+    if old_key is None:
+        raise KeyError(f"'{old_name}' is not in the deck.")
+
+    old_info = dict(lib.get(old_key) or {})
+    role = str(old_info.get("Role") or "").strip()
+    sub_role = str(old_info.get("SubRole") or "").strip()
+    try:
+        count = int(old_info.get("Count", 1))
+    except Exception:
+        count = 1
+    del lib[old_key]
+
+    df = getattr(b, "_combined_cards_df", None)
+    new_key = n_disp
+    card_type = ""
+    mana_cost = ""
+    if df is not None:
+        try:
+            row = df[df["name"].astype(str).str.strip().str.lower() == n]
+            if not row.empty:
+                new_key = str(row.iloc[0]["name"]) or n_disp
+                card_type = str(row.iloc[0].get("type", row.iloc[0].get("type_line", "")) or "")
+                mana_cost = str(row.iloc[0].get("mana_cost", row.iloc[0].get("manaCost", "")) or "")
+        except Exception:
+            pass
+
+    lib[new_key] = {
+        "Count": count,
+        "Card Type": card_type,
+        "Mana Cost": mana_cost,
+        "Role": role,
+        "SubRole": sub_role,
+        "AddedBy": "Replace",
+        "TriggerTag": str(old_info.get("TriggerTag") or ""),
+    }
+    try:
+        preferred = getattr(b, "preferred_replacements", {}) or {}
+        preferred[o] = n
+        setattr(b, "preferred_replacements", preferred)
+    except Exception:
+        pass
+
+    locks = set(ctx.get("locks") or [])
+    locks.discard(o)
+    locks.add(n)
+    ctx["locks"] = locks
+    exclude = set(ctx.get("alts_exclude") or [])
+    exclude.add(o)
+    ctx["alts_exclude"] = exclude
+
+    return {"old_name": old_key, "new_name": new_key}
+
+
+@router.post("/{build_id}/replace", summary="Swap a card in a guided build's deck-in-progress")
+async def replace_build_card(
+    build_id: str, body: ReplaceCardRequest, request: Request, user: User = Depends(get_api_user)
+):
+    """Replace `old_name` with `new_name` in the deck-in-progress, then lock
+    `new_name` in place so later stages won't remove it.
+    """
+    build = _guided_build_or_none(build_id, user["id"])
+    if build is None:
+        return err("Guided build not found.", "BUILD_NOT_FOUND", 404, _rid(request))
+    ctx = build_store.get_ctx(build_id)
+    lock = build_store.get_stage_lock(build_id)
+    if ctx is None or lock is None:
+        return err("Build session expired.", "BUILD_SESSION_EXPIRED", 410, _rid(request))
+
+    def _run():
+        with lock:
+            return _replace_card_sync(ctx, body.old_name, body.new_name)
+
+    try:
+        result = await asyncio.to_thread(_run)
+    except KeyError as exc:
+        return err(str(exc), "CARD_NOT_IN_DECK", 404, _rid(request))
+    except Exception as exc:  # noqa: BLE001
+        return err(str(exc), "REPLACE_FAILED", 500, _rid(request))
+
+    return ok(result, _rid(request))
 
 
 @router.delete("/{build_id}", summary="Delete a build record")

--- a/code/web/routes/api_v1/cards.py
+++ b/code/web/routes/api_v1/cards.py
@@ -13,9 +13,20 @@ the same trick used in card_browser.py.
 """
 from __future__ import annotations
 
+import asyncio
+import logging
+import math
+import re
+import shlex
+import time
 import uuid
-from typing import Any, Dict, Optional
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
 
+import httpx
+import pandas as pd
 from fastapi import APIRouter, Query, Request
 from fastapi.encoders import jsonable_encoder
 
@@ -26,7 +37,82 @@ from ...services.card_similarity import CardSimilarity
 from ...services.rulings import get_rulings
 from ...utils.api_response import err, ok
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/cards", tags=["cards"])
+
+# --- Live Scryfall fallback for cards missing from the local tagged dataset
+#
+# Basic lands (Plains, Island, Swamp, Mountain, Forest, Wastes, and their
+# snow-covered variants) are intentionally excluded from tagging/all_cards.parquet
+# -- there's nothing to tag on a card with no rules text -- but the mobile app's
+# card detail/summary dialog still needs *something* to show for them. More
+# generally, any card can be temporarily missing if the local database hasn't
+# been refreshed yet, so this fallback applies to every miss, not just basics.
+_SCRYFALL_NAMED_URL = "https://api.scryfall.com/cards/named"
+_SCRYFALL_USER_AGENT = "MTGPythonDeckbuilder/1.0 (contact via GitHub)"
+_SCRYFALL_FALLBACK_RATE_LIMIT = 0.1  # 100ms between live fetches (10 req/s)
+_scryfall_fallback_lock = asyncio.Lock()
+_scryfall_fallback_last_fetch: float = 0.0
+
+
+async def _scryfall_card_fallback(name: str) -> Optional[Dict[str, Any]]:
+    """Live Scryfall lookup for a card missing from the local tagged dataset,
+    shaped like _serialize_card(..., full=True). Returns None on any miss/error."""
+    global _scryfall_fallback_last_fetch
+    async with _scryfall_fallback_lock:
+        wait = _SCRYFALL_FALLBACK_RATE_LIMIT - (time.monotonic() - _scryfall_fallback_last_fetch)
+        if wait > 0:
+            await asyncio.sleep(wait)
+        try:
+            async with httpx.AsyncClient(headers={"User-Agent": _SCRYFALL_USER_AGENT}, timeout=10.0) as client:
+                resp = await client.get(_SCRYFALL_NAMED_URL, params={"exact": name})
+                _scryfall_fallback_last_fetch = time.monotonic()
+                if resp.status_code == 404:
+                    return None
+                resp.raise_for_status()
+                data = resp.json()
+        except httpx.HTTPError as e:
+            logger.warning(f"Scryfall card fallback failed for '{name}': {e}")
+            return None
+        except Exception as e:
+            logger.warning(f"Unexpected error in Scryfall card fallback for '{name}': {e}")
+            return None
+
+    card_faces = data.get("card_faces") or []
+    primary_face = card_faces[0] if card_faces else {}
+    result: Dict[str, Any] = {
+        "name": data.get("name"),
+        "type": data.get("type_line"),
+        "manaValue": data.get("cmc"),
+        "colorIdentity": ",".join(data.get("color_identity") or []),
+        "rarity": data.get("rarity"),
+        "themeTags": [],
+        "edhrecRank": data.get("edhrec_rank"),
+        "scryfallID": data.get("id"),
+        "text": data.get("oracle_text") or primary_face.get("oracle_text"),
+        "power": data.get("power") or primary_face.get("power"),
+        "toughness": data.get("toughness") or primary_face.get("toughness"),
+        "printings": None,
+        "layout": data.get("layout"),
+        "isNew": None,
+        "faces": [
+            {
+                "name": face.get("name"),
+                "side": chr(ord("a") + i),
+                "type": face.get("type_line"),
+                "text": face.get("oracle_text"),
+                "manaValue": face.get("cmc"),
+                "power": face.get("power"),
+                "toughness": face.get("toughness"),
+                "colorIdentity": ",".join(face.get("colors") or []),
+            }
+            for i, face in enumerate(card_faces)
+        ]
+        if len(card_faces) > 1
+        else [],
+    }
+    return jsonable_encoder({k: _json_safe(v) for k, v in result.items()})
 
 MAX_PAGE_SIZE = 100
 
@@ -48,8 +134,77 @@ def _get_similarity() -> CardSimilarity:
     return _similarity
 
 
+_RAW_CARDS_PATH = Path("card_files/raw/cards.parquet")
+_raw_faces_df: Optional[pd.DataFrame] = None
+
+
+def _get_raw_faces_df() -> Optional[pd.DataFrame]:
+    """Lazily load + cache a deduplicated (name, side) slice of the raw
+    MTGJSON card data (one row per printing), used only to recover
+    secondary-face details -- type, text, mana value, power/toughness --
+    for split/adventure/transform/flip/etc. cards. The tagged dataset
+    (`AllCardsLoader`) collapses multi-face cards down to a single
+    primary-face row during tagging (see `multi_face_merger.py`), dropping
+    everything but the back face's type (for MDFC land detection).
+    """
+    global _raw_faces_df
+    if _raw_faces_df is None:
+        if not _RAW_CARDS_PATH.exists():
+            return None
+        cols = [
+            "name", "faceName", "side", "type", "text", "faceManaValue", "power", "toughness",
+            "colorIdentity",
+        ]
+        try:
+            df = pd.read_parquet(_RAW_CARDS_PATH, columns=cols)
+        except Exception:
+            return None
+        df = df[df["side"].notna() & (df["side"].astype(str) != "")]
+        df = df.drop_duplicates(subset=["name", "side"], keep="first")
+        _raw_faces_df = df
+    return _raw_faces_df
+
+
+def _get_card_faces(name: str) -> List[Dict[str, Any]]:
+    """Per-face details (type/text/mana value/power/toughness) for a
+    multi-faced card, sorted front-to-back (side a, b, c...). Returns an
+    empty list for single-faced cards or if the raw dataset is unavailable.
+    """
+    df = _get_raw_faces_df()
+    if df is None:
+        return []
+    rows = df[df["name"] == name]
+    if len(rows) < 2:
+        return []
+    rows = rows.sort_values("side")
+    faces: List[Dict[str, Any]] = []
+    for _, row in rows.iterrows():
+        faces.append(
+            {
+                "name": _json_safe(row.get("faceName")) or _json_safe(row.get("name")),
+                "side": _json_safe(row.get("side")),
+                "type": _json_safe(row.get("type")) or None,
+                "text": _json_safe(row.get("text")) or None,
+                "manaValue": _json_safe(row.get("faceManaValue")),
+                "power": _json_safe(row.get("power")) or None,
+                "toughness": _json_safe(row.get("toughness")) or None,
+                "colorIdentity": _json_safe(row.get("colorIdentity")) or None,
+            }
+        )
+    return faces
+
+
 def _rid(request: Request) -> str:
     return getattr(request.state, "request_id", None) or uuid.uuid4().hex
+
+
+def _json_safe(value: Any) -> Any:
+    """Convert NaN/Infinity floats (common for missing edhrecRank/manaValue
+    values in the card data) to None -- Starlette's JSONResponse uses
+    allow_nan=False, so leaving these in raises a 500 at render time."""
+    if isinstance(value, float) and (math.isnan(value) or math.isinf(value)):
+        return None
+    return value
 
 
 def _serialize_card(row, *, full: bool = False) -> Dict[str, Any]:
@@ -73,17 +228,421 @@ def _serialize_card(row, *, full: bool = False) -> Dict[str, Any]:
                 "printings": card.get("printings"),
                 "layout": card.get("layout"),
                 "isNew": card.get("isNew"),
+                "faces": _get_card_faces(str(card.get("name") or "")),
             }
         )
+    data = {k: _json_safe(v) for k, v in data.items()}
     return jsonable_encoder(data)
+
+
+def _parse_color_cell(raw: Any) -> set:
+    """Parse a `colors`/`colorIdentity`-style cell into a set of color
+    letters (empty set for colorless). Mirrors card_browser.py's
+    "Colorless" special-case. Cells use a comma delimiter, with or without
+    a following space, depending on the source column."""
+    if not raw or not isinstance(raw, str):
+        return set()
+    if raw.strip().lower() == "colorless":
+        return set()
+    return {c.strip().upper() for c in raw.split(",") if c.strip()}
+
+
+# --- Scryfall-style search syntax -------------------------------------------
+#
+# The `q` search box supports plain text (matched against card name only,
+# the default) plus real Scryfall search keywords -- see
+# https://scryfall.com/docs/syntax. Only the categories relevant to this
+# dataset are supported: colors/identity, card types, card text, mana costs,
+# and power/toughness. Loyalty is intentionally unsupported (no loyalty data
+# in this dataset); rarity/tag/is=new flags are also parsed as a bonus but
+# are secondary to the `colors`/`tags`/`is_new` query params below.
+#
+# NOTE: bare colon (`:`) has different default semantics for color vs.
+# identity, matching how each concept is actually used:
+#   - `id:br` -- subset ("works with a black/red identity"): matches mono-B,
+#     mono-R, BR, and colorless cards. Same logic as the deck-builder's
+#     color-identity pool filtering. Use `id=br` for an exact-identity-only match.
+#   - `color:br` -- superset ("includes at least black and red"): also
+#     matches BRU, BRG, etc. Use `color=br` for an exact-colors-only match.
+#
+# Examples: `c:rg`, `id<=esper`, `t:goblin -t:creature`, `o:"draw a card"`,
+# `m:2WW`, `mv>=4`, `pow>=4 tou<=2`, `pow>tou`. Any keyword may be negated
+# with a leading `-` (e.g. `-t:land`); plain words without a keyword match
+# (or exclude, with `-`) the card name.
+
+_FLAG_TOKEN_RE = re.compile(r"^(-)?([A-Za-z]+)(:|>=|<=|!=|>|<|=)(.+)$")
+
+_KEY_ALIASES: Dict[str, str] = {
+    "name": "name", "n": "name",
+    "type": "type", "t": "type",
+    "oracle": "oracle", "text": "oracle", "o": "oracle",
+    "color": "color", "c": "color",
+    "identity": "identity", "id": "identity",
+    "power": "power", "pow": "power",
+    "toughness": "toughness", "tou": "toughness", "tough": "toughness",
+    "mana": "manacost", "m": "manacost",
+    "manavalue": "cmc", "mv": "cmc", "cmc": "cmc",
+    "rarity": "rarity", "r": "rarity",
+    "tag": "tag", "theme": "tag",
+    "is": "is",
+}
+
+_COLOR_LETTERS = set("WUBRG")
+_STAT_VALUE_ALIASES = {
+    "power": "power", "pow": "power",
+    "toughness": "toughness", "tou": "toughness", "tough": "toughness",
+}
+_BRACED_SYMBOL_RE = re.compile(r"\{([^}]+)\}")
+
+# Full color names, guild names (2-color), and shard/wedge names (3-color) --
+# resolve to the same letter set regardless of which order the name/letters
+# are given in, e.g. `rg`, `gr`, and `gruul` are all equivalent.
+_COLOR_NICKNAMES: Dict[str, Set[str]] = {
+    "white": {"W"}, "blue": {"U"}, "black": {"B"}, "red": {"R"}, "green": {"G"},
+    # Guilds
+    "azorius": {"W", "U"}, "dimir": {"U", "B"}, "rakdos": {"B", "R"},
+    "gruul": {"R", "G"}, "selesnya": {"G", "W"}, "orzhov": {"W", "B"},
+    "izzet": {"U", "R"}, "golgari": {"B", "G"}, "boros": {"R", "W"},
+    "simic": {"G", "U"},
+    # Shards and wedges
+    "bant": {"G", "W", "U"}, "esper": {"W", "U", "B"}, "grixis": {"U", "B", "R"},
+    "jund": {"B", "R", "G"}, "naya": {"R", "G", "W"}, "abzan": {"W", "B", "G"},
+    "jeskai": {"U", "R", "W"}, "sultai": {"B", "G", "U"}, "mardu": {"R", "W", "B"},
+    "temur": {"G", "U", "R"},
+    # Five-color
+    "wubrg": set(_COLOR_LETTERS), "rainbow": set(_COLOR_LETTERS), "five-color": set(_COLOR_LETTERS),
+}
+
+
+@dataclass
+class ColorClause:
+    op: str
+    letters: Set[str] = field(default_factory=set)
+    count: Optional[int] = None
+    special: Optional[str] = None  # "colorless" | "multicolor" | None
+    negate: bool = False
+
+
+@dataclass
+class NumericClause:
+    op: str
+    value: Optional[float] = None
+    compare_to: Optional[str] = None  # cross-field, e.g. "pow>tou"
+    negate: bool = False
+
+
+@dataclass
+class ManaCostClause:
+    op: str
+    generic: int = 0
+    symbols: Counter = field(default_factory=Counter)
+    negate: bool = False
+
+
+@dataclass
+class ParsedSearch:
+    name_include: List[str] = field(default_factory=list)
+    name_exclude: List[str] = field(default_factory=list)
+    type_include: List[str] = field(default_factory=list)
+    type_exclude: List[str] = field(default_factory=list)
+    oracle_include: List[str] = field(default_factory=list)
+    oracle_exclude: List[str] = field(default_factory=list)
+    color_clauses: List[ColorClause] = field(default_factory=list)
+    identity_clauses: List[ColorClause] = field(default_factory=list)
+    power_clauses: List[NumericClause] = field(default_factory=list)
+    toughness_clauses: List[NumericClause] = field(default_factory=list)
+    cmc_clauses: List[NumericClause] = field(default_factory=list)
+    mana_cost_clauses: List[ManaCostClause] = field(default_factory=list)
+    rarity: Optional[Set[str]] = None
+    tags: Optional[Set[str]] = None
+    is_new: Optional[bool] = None
+
+
+def _parse_color_value(value: str) -> Tuple[Set[str], Optional[int], Optional[str]]:
+    """Parse a color/identity flag value into (letters, count, special).
+    Only one of the three will be populated -- e.g. `c` (colorless), `m`
+    (multicolor), a bare number (color count), color letters (any order,
+    e.g. `rg`/`gr`), or a full name/guild/shard/wedge nickname (e.g.
+    `green`, `gruul`, `esper` -- see _COLOR_NICKNAMES)."""
+    v = value.strip().lower()
+    if v in ("c", "colorless"):
+        return set(), None, "colorless"
+    if v in ("m", "multicolor"):
+        return set(), None, "multicolor"
+    if v.lstrip("-").isdigit():
+        return set(), int(v), None
+    if v in _COLOR_NICKNAMES:
+        return set(_COLOR_NICKNAMES[v]), None, None
+    letters = {ch for ch in v.upper() if ch in _COLOR_LETTERS}
+    return letters, None, None
+
+
+def _compare_numeric(actual: Any, op: str, expected: Any) -> Any:
+    """Apply a comparison operator; works for both scalars and pandas Series."""
+    if op in (":", "="):
+        return actual == expected
+    if op == ">":
+        return actual > expected
+    if op == "<":
+        return actual < expected
+    if op == ">=":
+        return actual >= expected
+    if op == "<=":
+        return actual <= expected
+    if op == "!=":
+        return actual != expected
+    return False
+
+
+def _color_matches(card_letters: Set[str], clause: ColorClause) -> bool:
+    if clause.special == "colorless":
+        matched = len(card_letters) == 0
+    elif clause.special == "multicolor":
+        matched = len(card_letters) >= 2
+    elif clause.count is not None:
+        matched = bool(_compare_numeric(len(card_letters), clause.op, clause.count))
+    else:
+        req = clause.letters
+        op = clause.op
+        if op in (":", "="):
+            matched = card_letters == req
+        elif op == ">=":
+            matched = req.issubset(card_letters)
+        elif op == "<=":
+            matched = card_letters.issubset(req)
+        elif op == ">":
+            matched = req.issubset(card_letters) and card_letters != req
+        elif op == "<":
+            matched = card_letters.issubset(req) and card_letters != req
+        elif op == "!=":
+            matched = card_letters != req
+        else:
+            matched = False
+    return (not matched) if clause.negate else matched
+
+
+def _apply_color_clauses(df: "pd.DataFrame", column: str, clauses: List[ColorClause]) -> "pd.DataFrame":
+    if not clauses or column not in df.columns:
+        return df
+
+    def _row_matches(raw: Any) -> bool:
+        card_letters = _parse_color_cell(raw)
+        return all(_color_matches(card_letters, clause) for clause in clauses)
+
+    return df[df[column].apply(_row_matches)]
+
+
+def _apply_numeric_clauses(df: "pd.DataFrame", column: str, clauses: List[NumericClause]) -> "pd.DataFrame":
+    """Filter `df` by numeric comparisons on `column`, coercing non-numeric
+    values (e.g. "*" power/toughness) to NaN and excluding them. Supports
+    cross-field comparisons like `pow>tou` via `compare_to`."""
+    if not clauses or column not in df.columns:
+        return df
+    numeric = pd.to_numeric(df[column], errors="coerce")
+    mask = pd.Series(True, index=df.index)
+    for clause in clauses:
+        if clause.compare_to and clause.compare_to in df.columns:
+            other = pd.to_numeric(df[clause.compare_to], errors="coerce")
+        else:
+            other = clause.value
+        clause_mask = _compare_numeric(numeric, clause.op, other).fillna(False)
+        if clause.negate:
+            clause_mask = ~clause_mask
+        mask &= clause_mask
+    return df[mask]
+
+
+def _tokenize_mana_shorthand(text: str) -> List[str]:
+    """Tokenize non-braced mana shorthand (e.g. "2WW") into symbols,
+    grouping consecutive digits into one generic-mana symbol."""
+    tokens: List[str] = []
+    i = 0
+    while i < len(text):
+        ch = text[i]
+        if ch.isdigit():
+            j = i
+            while j < len(text) and text[j].isdigit():
+                j += 1
+            tokens.append(text[i:j])
+            i = j
+        elif ch.isalpha():
+            tokens.append(ch.upper())
+            i += 1
+        else:
+            i += 1
+    return tokens
+
+
+def _parse_mana_cost(cost: str) -> Tuple[int, Counter]:
+    """Parse a mana cost string -- braced like "{2}{W}{W}" (as stored in the
+    dataset) or Scryfall shorthand like "2WW" (as typed by a user) -- into
+    (generic_total, Counter of other symbols)."""
+    generic = 0
+    symbols: Counter = Counter()
+    if not cost or not isinstance(cost, str):
+        return generic, symbols
+    braced = _BRACED_SYMBOL_RE.findall(cost)
+    remainder = _BRACED_SYMBOL_RE.sub("", cost)
+    tokens = list(braced) + _tokenize_mana_shorthand(remainder)
+    for tok in tokens:
+        if tok.isdigit():
+            generic += int(tok)
+        else:
+            symbols[tok.upper()] += 1
+    return generic, symbols
+
+
+def _mana_cost_superset(card: Tuple[int, Counter], query: Tuple[int, Counter]) -> bool:
+    card_generic, card_symbols = card
+    query_generic, query_symbols = query
+    if card_generic < query_generic:
+        return False
+    return all(card_symbols.get(sym, 0) >= count for sym, count in query_symbols.items())
+
+
+def _mana_cost_equal(card: Tuple[int, Counter], query: Tuple[int, Counter]) -> bool:
+    card_generic, card_symbols = card
+    query_generic, query_symbols = query
+    return card_generic == query_generic and dict(card_symbols) == dict(query_symbols)
+
+
+def _mana_cost_matches(cost: Any, clause: ManaCostClause) -> bool:
+    card = _parse_mana_cost(cost)
+    query = (clause.generic, clause.symbols)
+    op = clause.op
+    if op in (":", ">="):
+        matched = _mana_cost_superset(card, query)
+    elif op == ">":
+        matched = _mana_cost_superset(card, query) and not _mana_cost_equal(card, query)
+    elif op == "<=":
+        matched = _mana_cost_superset(query, card)
+    elif op == "<":
+        matched = _mana_cost_superset(query, card) and not _mana_cost_equal(card, query)
+    elif op == "=":
+        matched = _mana_cost_equal(card, query)
+    elif op == "!=":
+        matched = not _mana_cost_equal(card, query)
+    else:
+        matched = False
+    return (not matched) if clause.negate else matched
+
+
+def _apply_mana_cost_clauses(df: "pd.DataFrame", clauses: List[ManaCostClause]) -> "pd.DataFrame":
+    if not clauses or "manaCost" not in df.columns:
+        return df
+    return df[df["manaCost"].apply(lambda raw: all(_mana_cost_matches(raw, c) for c in clauses))]
+
+
+def _apply_text_clauses(df: "pd.DataFrame", column: str, include: List[str], exclude: List[str]) -> "pd.DataFrame":
+    if column not in df.columns:
+        return df
+    for term in include:
+        df = df[df[column].str.contains(term, case=False, na=False, regex=False)]
+    for term in exclude:
+        df = df[~df[column].str.contains(term, case=False, na=False, regex=False)]
+    return df
+
+
+def _apply_search_flag(parsed: ParsedSearch, canonical: str, op: str, value: str, *, negate: bool) -> None:
+    if not value:
+        return
+    if canonical == "name":
+        (parsed.name_exclude if negate else parsed.name_include).append(value)
+    elif canonical == "type":
+        (parsed.type_exclude if negate else parsed.type_include).append(value)
+    elif canonical == "oracle":
+        (parsed.oracle_exclude if negate else parsed.oracle_include).append(value)
+    elif canonical in ("color", "identity"):
+        letters, count, special = _parse_color_value(value)
+        effective_op = op
+        if op == ":" and count is None and special is None:
+            # Bare colon has different default semantics for color vs.
+            # identity: `id:br` means "works with a black/red identity"
+            # (subset -- mono-B, mono-R, BR, and colorless all match, same
+            # as the deck-builder's pool filtering), while `color:br` means
+            # "includes at least black and red" (superset -- BRU, BRG,
+            # etc. also match). Use `=` for an exact-match-only search.
+            effective_op = "<=" if canonical == "identity" else ">="
+        clause = ColorClause(op=effective_op, letters=letters, count=count, special=special, negate=negate)
+        (parsed.color_clauses if canonical == "color" else parsed.identity_clauses).append(clause)
+    elif canonical in ("power", "toughness", "cmc"):
+        target = {
+            "power": parsed.power_clauses,
+            "toughness": parsed.toughness_clauses,
+            "cmc": parsed.cmc_clauses,
+        }[canonical]
+        compare_to = _STAT_VALUE_ALIASES.get(value.lower()) if canonical != "cmc" else None
+        if compare_to:
+            target.append(NumericClause(op=op, compare_to=compare_to, negate=negate))
+        else:
+            try:
+                target.append(NumericClause(op=op, value=float(value), negate=negate))
+            except ValueError:
+                pass
+    elif canonical == "manacost":
+        generic, symbols = _parse_mana_cost(value)
+        parsed.mana_cost_clauses.append(ManaCostClause(op=op, generic=generic, symbols=symbols, negate=negate))
+    elif canonical == "rarity":
+        rarities = {v.strip().lower() for v in value.split(",") if v.strip()}
+        if rarities:
+            parsed.rarity = (parsed.rarity or set()) | rarities
+    elif canonical == "tag":
+        tags = {v.strip().lower() for v in value.split(",") if v.strip()}
+        if tags:
+            parsed.tags = (parsed.tags or set()) | tags
+    elif canonical == "is" and value.lower() == "new":
+        parsed.is_new = False if negate else True
+
+
+def _parse_search_query(q: str) -> ParsedSearch:
+    """Parse the free-text search box into structured filters using real
+    Scryfall keyword syntax (see module-level comment above)."""
+    parsed = ParsedSearch()
+    try:
+        tokens = shlex.split(q)
+    except ValueError:
+        # Unbalanced quotes -- fall back to naive whitespace splitting
+        # rather than erroring out the whole search.
+        tokens = q.split()
+
+    for token in tokens:
+        m = _FLAG_TOKEN_RE.match(token)
+        if m:
+            neg_prefix, key, op, value = m.groups()
+            canonical = _KEY_ALIASES.get(key.lower())
+            if canonical:
+                _apply_search_flag(parsed, canonical, op, value.strip(), negate=bool(neg_prefix))
+                continue
+        # Bare word -- matches the card name by default; "-word" excludes it.
+        if token.startswith("-") and len(token) > 1:
+            parsed.name_exclude.append(token[1:])
+        else:
+            parsed.name_include.append(token)
+
+    return parsed
 
 
 @router.get("", summary="Search cards")
 async def list_cards(
     request: Request,
-    q: str = Query("", description="Name / type / oracle-text search"),
-    colors: str = Query("", description="Comma-separated color identity, e.g. W,U"),
+    q: str = Query(
+        "",
+        description=(
+            "Search box text. Plain words match the card name (default). "
+            "Also supports real Scryfall search keywords (see "
+            "https://scryfall.com/docs/syntax): c:/color:, id:/identity:, "
+            "t:/type:, o:/oracle:, m:/mana:, mv:/cmc:/manavalue:, pow:/power:, "
+            "tou:/toughness: -- each accepts :, =, >, <, >=, <=, or != and may be "
+            "negated with a leading -. Note: bare `id:br` matches anything playable "
+            "with a black/red identity (subset, incl. colorless), while `id=br` "
+            "matches only exact black/red; bare `color:br` matches cards including "
+            "at least black and red (superset), while `color=br` is exact-only. "
+            "e.g. `c:rg t:creature o:\"draw a card\" pow>=4`"
+        ),
+    ),
+    colors: str = Query("", description="Comma-separated colors, e.g. W,U -- cards whose color identity is a subset of these are matched; include C to also allow colorless"),
     tags: str = Query("", description="Comma-separated theme tags (AND logic)"),
+    is_new: bool = Query(False, description="Only recently released cards"),
     min_cmc: Optional[float] = Query(None, ge=0),
     max_cmc: Optional[float] = Query(None, ge=0),
     page: int = Query(1, ge=1),
@@ -92,32 +651,73 @@ async def list_cards(
     """Search/filter cards. Mirrors card_browser.py's filters, simplified for JSON I/O."""
     df = _get_loader().load()
 
-    if q:
-        mask = df["name"].str.contains(q, case=False, na=False)
-        if "type" in df.columns:
-            mask |= df["type"].str.contains(q, case=False, na=False)
-        if "text" in df.columns:
-            mask |= df["text"].str.contains(q, case=False, na=False)
+    parsed = _parse_search_query(q) if q else ParsedSearch()
+
+    df = _apply_text_clauses(df, "name", parsed.name_include, parsed.name_exclude)
+    df = _apply_text_clauses(df, "type", parsed.type_include, parsed.type_exclude)
+    df = _apply_text_clauses(df, "text", parsed.oracle_include, parsed.oracle_exclude)
+
+    # Colors (c:/color:) match the card's own mana cost colors; identity
+    # (id:/identity:) matches its commander color identity -- two separate
+    # columns/concepts.
+    df = _apply_color_clauses(df, "colors", parsed.color_clauses)
+    df = _apply_color_clauses(df, "colorIdentity", parsed.identity_clauses)
+
+    df = _apply_numeric_clauses(df, "power", parsed.power_clauses)
+    df = _apply_numeric_clauses(df, "toughness", parsed.toughness_clauses)
+    df = _apply_numeric_clauses(df, "manaValue", parsed.cmc_clauses)
+    df = _apply_mana_cost_clauses(df, parsed.mana_cost_clauses)
+
+    if parsed.rarity and "rarity" in df.columns:
+        df = df[df["rarity"].str.lower().isin(parsed.rarity)]
+
+    if "isNew" in df.columns:
+        if parsed.is_new is True or is_new:
+            df = df[df["isNew"] == True]  # noqa: E712
+        elif parsed.is_new is False:
+            df = df[df["isNew"] == False]  # noqa: E712
+
+    # Colors -- the explicit `colors` param (used by the mobile app's chip
+    # filter UI) is a simple subset-match against colorIdentity, separate
+    # from the id:/identity: flag syntax parsed above.
+    requested_colors = {c.strip().upper() for c in colors.split(",") if c.strip()}
+    if requested_colors and "colorIdentity" in df.columns:
+        allow_colorless = "C" in requested_colors
+        color_letters = requested_colors - {"C"}
+
+        def _matches_colors(raw: Any) -> bool:
+            card_colors = _parse_color_cell(raw)
+            if not card_colors:
+                return allow_colorless
+            return card_colors.issubset(color_letters)
+
+        df = df[df["colorIdentity"].apply(_matches_colors)]
+
+    # Theme tags -- combine the explicit `tags` param with any `tag=` flags
+    # parsed out of `q`; AND logic (a card must have all requested tags).
+    requested_tags = {t.strip().lower() for t in tags.split(",") if t.strip()}
+    if parsed.tags:
+        requested_tags |= parsed.tags
+    if requested_tags and "themeTags" in df.columns:
+        # themeTags may be stored as a string, list, or numpy array depending on
+        # source (raw CSV vs. Parquet) -- parse_theme_tags() normalizes all of them.
+        card_tag_sets = df["themeTags"].apply(lambda v: {t.lower() for t in parse_theme_tags(v)})
+        mask = card_tag_sets.apply(lambda card_tags: all(tag in card_tags for tag in requested_tags))
         df = df[mask]
 
-    if colors:
-        color_list = [c.strip().upper() for c in colors.split(",") if c.strip()]
-        if color_list and "colorIdentity" in df.columns:
-            df = df[df["colorIdentity"].isin(color_list)]
-
-    if tags:
-        tag_list = [t.strip().lower() for t in tags.split(",") if t.strip()]
-        if tag_list and "themeTags" in df.columns:
-            # themeTags may be stored as a string, list, or numpy array depending on
-            # source (raw CSV vs. Parquet) -- parse_theme_tags() normalizes all of them.
-            parsed = df["themeTags"].apply(lambda v: {t.lower() for t in parse_theme_tags(v)})
-            mask = parsed.apply(lambda card_tags: all(tag in card_tags for tag in tag_list))
-            df = df[mask]
 
     if min_cmc is not None and "manaValue" in df.columns:
         df = df[df["manaValue"] >= min_cmc]
     if max_cmc is not None and "manaValue" in df.columns:
         df = df[df["manaValue"] <= max_cmc]
+
+    # Default sort: Name A-Z, matching the HTML card browser's default sort
+    # (card_browser.py's "name_asc"), so results aren't left in arbitrary
+    # data-file order.
+    if "name" in df.columns and len(df):
+        sort_key = df["name"].str.replace('"', "", regex=False).str.replace("'", "", regex=False)
+        sort_key = sort_key.apply(lambda x: x.replace("_", " ") if isinstance(x, str) and x.startswith("_") else x)
+        df = df.assign(_sort_key=sort_key).sort_values("_sort_key", key=lambda col: col.str.lower()).drop(columns="_sort_key")
 
     total = len(df)
     start = (page - 1) * page_size
@@ -158,8 +758,15 @@ async def get_card_rulings(name: str, request: Request):
 
 @router.get("/{name:path}", summary="Get card detail")
 async def get_card_detail(name: str, request: Request):
-    """Card detail: stats, tags, oracle text, scryfall_id."""
+    """Card detail: stats, tags, oracle text, scryfall_id.
+
+    Falls back to a live Scryfall lookup when the card isn't in the local
+    tagged dataset (e.g. basic lands, which are excluded from tagging).
+    """
     row = _get_loader().get_by_name(name)
-    if row is None:
-        return err("Card not found.", "CARD_NOT_FOUND", 404, _rid(request))
-    return ok(_serialize_card(row, full=True), _rid(request))
+    if row is not None:
+        return ok(_serialize_card(row, full=True), _rid(request))
+    fallback = await _scryfall_card_fallback(name)
+    if fallback is not None:
+        return ok(fallback, _rid(request))
+    return err("Card not found.", "CARD_NOT_FOUND", 404, _rid(request))

--- a/code/web/routes/api_v1/commanders.py
+++ b/code/web/routes/api_v1/commanders.py
@@ -17,6 +17,7 @@ from ...services.commander_catalog_loader import (
     find_commander_record,
     load_commander_catalog,
 )
+from ...routes.commanders import _MIN_NAME_MATCH_SCORE, _commander_name_match_score
 from ...utils.api_response import err, ok
 
 router = APIRouter(prefix="/commanders", tags=["commanders"])
@@ -72,7 +73,33 @@ async def list_commanders(
 
     if q:
         q_lower = q.lower()
-        records = [r for r in records if q_lower in r.search_haystack]
+        substring_matches = [r for r in records if q_lower in r.search_haystack]
+
+        # Name-aware fuzzy match on top of the plain substring search above.
+        # This tolerates punctuation differences (e.g. "Bria Riptide Rogue"
+        # vs. the card's actual "Bria, Riptide Rogue") and small typos (e.g.
+        # "Riptie" vs. "Riptide") that a pure substring check would miss.
+        scored: list[tuple[float, CommanderRecord]] = []
+        for r in records:
+            score = _commander_name_match_score(q, r)
+            if score >= _MIN_NAME_MATCH_SCORE:
+                scored.append((score, r))
+
+        if scored:
+            scored.sort(key=lambda pair: (-pair[0], pair[1].display_name.lower()))
+            seen: set[int] = set()
+            merged: list[CommanderRecord] = []
+            for _score, r in scored:
+                if id(r) not in seen:
+                    seen.add(id(r))
+                    merged.append(r)
+            for r in substring_matches:
+                if id(r) not in seen:
+                    seen.add(id(r))
+                    merged.append(r)
+            records = merged
+        else:
+            records = substring_matches
 
     if colors:
         color_list = [c.strip().upper() for c in colors.split(",") if c.strip()]

--- a/code/web/routes/api_v1/decks.py
+++ b/code/web/routes/api_v1/decks.py
@@ -20,13 +20,23 @@ from fastapi import APIRouter, Depends, Query, Request
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import Response
 
+from code.services.all_cards_loader import AllCardsLoader
 from code.type_definitions import User
 
 from ...utils.api_response import err, ok
-from ..decks import _build_csv_download_response, _deck_dir, _list_decks, _safe_within
+from ..decks import _build_csv_download_response, _deck_dir, _list_decks, _read_csv_summary, _safe_within
 from .auth import get_api_user
 
 router = APIRouter(prefix="/decks", tags=["decks"])
+
+_loader: Optional[AllCardsLoader] = None
+
+
+def _get_loader() -> AllCardsLoader:
+    global _loader
+    if _loader is None:
+        _loader = AllCardsLoader()
+    return _loader
 
 
 def _rid(request: Request) -> str:
@@ -73,8 +83,26 @@ def _parse_deck_cards(csv_path: Path) -> List[Dict[str, Any]]:
                     "colors": col(row, "Colors"),
                     "role": col(row, "Role"),
                     "tags": tags,
+                    "layout": None,
                 }
             )
+
+    # Double-faced card names contain " // " (e.g. "Akki Lavarunner //
+    # Tok-Tok, Volcano Born"); look up each one's Scryfall layout so callers
+    # can tell true DFCs (transform/modal_dfc, separate front/back images --
+    # eligible for a "flip" control) apart from split/adventure/aftermath
+    # cards (single combined image, same " // " name shape, no back face).
+    dfc_names = {c["name"] for c in cards if " // " in c["name"]}
+    if dfc_names:
+        try:
+            df = _get_loader().load()
+            matches = df[df["name"].isin(dfc_names)][["name", "layout"]]
+            layouts = dict(zip(matches["name"], matches["layout"]))
+            for c in cards:
+                if c["name"] in layouts:
+                    c["layout"] = layouts[c["name"]]
+        except Exception:
+            pass
     return cards
 
 
@@ -94,6 +122,76 @@ async def get_deck_detail(filename: str, request: Request, user: User = Depends(
     cards = _parse_deck_cards(p)
     return ok(
         {"name": p.name, "cards": cards, "card_count": sum(c["count"] for c in cards)},
+        _rid(request),
+    )
+
+
+@router.get("/{filename}/analysis", summary="Get deck mana analysis")
+async def get_deck_analysis(filename: str, request: Request, user: User = Depends(get_api_user)):
+    """Commander, mana curve, pip distribution, mana sources, land summary
+    (including MDFC lands), and total price.
+
+    Reads the same `.summary.json` sidecar the HTML deck-view page uses
+    (`_render_deck_view` in `code/web/routes/decks.py`) so this data matches
+    what's shown there exactly, instead of recomputing it. Falls back to a
+    CSV-only reconstruction (curve only; pips/sources/land summary default to
+    empty/zero) for decks that predate/lack a sidecar, via the same
+    `_read_csv_summary` helper the HTML route uses for that case.
+
+    Total price is computed from the local price cache (`price_service`,
+    already used by `/api/v1/prices/{card_name}`), not a live Scryfall call
+    per card.
+    """
+    p = _resolve_deck_path(str(user["id"]), filename)
+    if p is None:
+        return err("Deck not found.", "DECK_NOT_FOUND", 404, _rid(request))
+
+    summary: Optional[Dict[str, Any]] = None
+    commander = ""
+    sidecar = p.with_suffix(".summary.json")
+    if sidecar.exists():
+        try:
+            payload = json.loads(sidecar.read_text(encoding="utf-8"))
+            if isinstance(payload, dict):
+                summary = payload.get("summary")
+                meta = payload.get("meta", {})
+                if isinstance(meta, dict):
+                    commander = meta.get("commander") or ""
+        except Exception:
+            summary = None
+
+    if not summary:
+        summary, _type_counts, _curve_counts, _type_cards = _read_csv_summary(p)
+
+    if not commander:
+        parts = p.stem.split("_")
+        commander = parts[0] if parts else ""
+
+    total_price: Optional[float] = None
+    try:
+        from ...services.price_service import get_price_service
+
+        cards = _parse_deck_cards(p)
+        names = [c["name"] for c in cards if c["name"] != commander]
+        prices = get_price_service().get_prices_batch(names)
+        found = [prices[name] * next(c["count"] for c in cards if c["name"] == name) for name in prices if prices[name] is not None]
+        if found:
+            total_price = round(sum(found), 2)
+    except Exception:
+        total_price = None
+
+    return ok(
+        jsonable_encoder(
+            {
+                "commander": commander,
+                "colors": summary.get("colors", []) if summary else [],
+                "mana_curve": (summary or {}).get("mana_curve", {}),
+                "pip_distribution": (summary or {}).get("pip_distribution", {}),
+                "mana_generation": (summary or {}).get("mana_generation", {}),
+                "land_summary": (summary or {}).get("land_summary", {}),
+                "total_price": total_price,
+            }
+        ),
         _rid(request),
     )
 

--- a/code/web/services/api_alternatives.py
+++ b/code/web/services/api_alternatives.py
@@ -1,0 +1,224 @@
+"""Role-based alternative card suggestions for the public REST API.
+
+Lighter-weight sibling of `routes/build_alternatives.py` (the HTML/session
+route used by the web wizard). Shares the same role-resolution and filtering
+approach (role from the deck-library entry, role-tag pool filtering, sort by
+edhrecRank/manaValue, tag-overlap fallback), but returns plain JSON-ready
+dicts instead of an HTML partial and takes explicit params instead of reading
+a cookie session. Intentionally skips the web route's land-specific
+sub-heuristics (mono-color exclusions, fetch/dual/triple sub-role bucketing,
+World Tree color check) -- those are cosmetic refinements, not needed for a
+correct v1 API result set.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional
+
+from deck_builder import builder_utils as bu
+
+from .build_utils import builder_display_map, builder_present_names, owned_set as owned_set_helper
+
+_ROLE_TAG_ROLES = {"ramp", "removal", "wipe", "card_advantage", "protection", "creature", "land"}
+
+
+def _is_wipe(tags: List[str]) -> bool:
+    return any(("board wipe" in t) or ("mass removal" in t) for t in tags)
+
+
+def _is_removal(tags: List[str]) -> bool:
+    return any(("removal" in t) or ("spot removal" in t) for t in tags)
+
+
+def _is_draw(tags: List[str]) -> bool:
+    return any(("draw" in t) or ("card advantage" in t) for t in tags)
+
+
+def _clean(value: Any) -> str:
+    if value is None:
+        return ""
+    try:
+        if isinstance(value, float) and value != value:  # NaN
+            return ""
+        return str(value).strip()
+    except Exception:
+        return ""
+
+
+def suggest_alternatives(
+    b: Any,
+    card_name: str,
+    *,
+    role_hint: Optional[str] = None,
+    owned_only: bool = False,
+    exclude: Optional[Iterable[str]] = None,
+    locked: Optional[Iterable[str]] = None,
+    commander: Optional[str] = None,
+    limit: int = 10,
+) -> List[Dict[str, Any]]:
+    """Suggest up to `limit` alternative cards for `card_name`.
+
+    Resolves role from `role_hint` if given, else from the card's current
+    `Role` entry in `b.card_library`. Falls back to tag-overlap similarity
+    when the role can't be determined or card data is unavailable.
+    """
+    name_disp = str(card_name).strip()
+    name_l = name_disp.lower()
+    commander_l = str(commander or "").strip().lower()
+    locked_set = {str(x).strip().lower() for x in (locked or [])}
+    exclude_set = {str(x).strip().lower() for x in (exclude or [])}
+    owned = owned_set_helper()
+
+    lib = getattr(b, "card_library", {}) or {}
+    lib_key = None
+    if name_disp in lib:
+        lib_key = name_disp
+    else:
+        lower_map = {str(k).strip().lower(): k for k in lib.keys()}
+        lib_key = lower_map.get(name_l)
+    entry = lib.get(lib_key) if lib_key else None
+
+    role = (role_hint or "").strip().lower() or None
+    if not role and isinstance(entry, dict):
+        raw_role = entry.get("Role")
+        role = str(raw_role).strip().lower() if raw_role else None
+    if isinstance(entry, dict):
+        card_type = str(entry.get("Card Type") or entry.get("Type") or "").lower()
+        if "land" in card_type:
+            role = "land"
+
+    # The specific theme tag(s) that caused this card to be added (e.g. a
+    # creature added during the "Creatures: Primary" stage for an "Angel
+    # Kindred" theme carries `TriggerTag='Angel Kindred'`). When present,
+    # alternatives are narrowed to cards sharing at least one of these tags
+    # so swaps stay on-theme instead of pulling from the whole role pool.
+    trigger_tags: List[str] = []
+    if isinstance(entry, dict):
+        raw_trigger = entry.get("TriggerTag")
+        if raw_trigger:
+            trigger_tags = [t.strip().lower() for t in str(raw_trigger).split(",") if t.strip()]
+
+    in_deck = builder_present_names(b)
+    df = getattr(b, "_combined_cards_df", None)
+
+    items: List[Dict[str, Any]] = []
+
+    def _excluded(nm_l: str) -> bool:
+        return (
+            nm_l == name_l
+            or nm_l in in_deck
+            or nm_l in locked_set
+            or nm_l in exclude_set
+            or (commander_l and nm_l == commander_l)
+        )
+
+    if df is not None and hasattr(df, "copy") and role in _ROLE_TAG_ROLES:
+        pool = df.copy()
+        try:
+            pool["_ltags"] = pool.get("themeTags", []).apply(bu.normalize_tag_cell)
+        except Exception:
+            pool["_ltags"] = pool.get("themeTags", []).apply(
+                lambda x: [str(t).strip().lower() for t in (x or [])] if isinstance(x, list) else []
+            )
+        if "type" in pool.columns:
+            if role == "land":
+                pool = pool[pool["type"].fillna("").str.contains("Land", case=False, na=False)]
+            else:
+                pool = pool[~pool["type"].fillna("").str.contains("Land", case=False, na=False)]
+        if "name" in pool.columns and commander_l:
+            pool = pool[pool["name"].astype(str).str.strip().str.lower() != commander_l]
+
+        if role == "ramp":
+            pool = pool[pool["_ltags"].apply(lambda tags: any("ramp" in t for t in tags))]
+        elif role == "removal":
+            pool = pool[pool["_ltags"].apply(_is_removal) & ~pool["_ltags"].apply(_is_wipe)]
+        elif role == "wipe":
+            pool = pool[pool["_ltags"].apply(_is_wipe)]
+        elif role == "card_advantage":
+            pool = pool[pool["_ltags"].apply(_is_draw)]
+        elif role == "protection":
+            pool = pool[pool["_ltags"].apply(lambda tags: any("protection" in t for t in tags))]
+        elif role == "creature":
+            if "type" in pool.columns:
+                pool = pool[pool["type"].fillna("").str.contains("Creature", case=False, na=False)]
+        # role == "land": no extra tag filter beyond the type filter above
+
+        if trigger_tags:
+            def _matches_trigger(tags: List[str]) -> bool:
+                return any(t in tags or any(t in x for x in tags) for t in trigger_tags)
+
+            themed_pool = pool[pool["_ltags"].apply(_matches_trigger)]
+            if not themed_pool.empty:
+                pool = themed_pool
+
+        try:
+            pool = bu.sort_by_priority(pool, ["edhrecRank", "manaValue"])
+        except Exception:
+            pass
+
+        if owned_only and owned:
+            try:
+                pool = pool[pool["name"].astype(str).str.strip().str.lower().isin(owned)]
+            except Exception:
+                pass
+
+        if "name" in pool.columns:
+            lower_names: List[str] = pool["name"].astype(str).str.strip().str.lower().tolist()
+            display_map = builder_display_map(b, set(lower_names))
+            for nm_l in lower_names:
+                if _excluded(nm_l):
+                    continue
+                row = pool[pool["name"].astype(str).str.strip().str.lower() == nm_l]
+                mana = rarity = ""
+                tags: List[str] = []
+                if not row.empty:
+                    r0 = row.iloc[0]
+                    mana = _clean(r0.get("mana_cost") or r0.get("manaCost") or r0.get("manaValue"))
+                    rarity = _clean(r0.get("rarity"))
+                    tags = [str(t).strip() for t in (r0.get("_ltags") or []) if str(t).strip()]
+                    if trigger_tags:
+                        def _matches_tag(tag: str, _trigger_tags: List[str] = trigger_tags) -> bool:
+                            tl = tag.lower()
+                            return any(tt in tl or tl in tt for tt in _trigger_tags)
+
+                        tags.sort(key=lambda t: 0 if _matches_tag(t) else 1)
+                items.append(
+                    {
+                        "name": display_map.get(nm_l, nm_l),
+                        "role": role,
+                        "mana_cost": mana,
+                        "rarity": rarity,
+                        "tags": tags,
+                        "owned": nm_l in owned,
+                    }
+                )
+                if len(items) >= limit:
+                    break
+
+    if items:
+        return items
+
+    # Fallback: tag-overlap similarity (mirrors the web route's fallback).
+    tags_idx = getattr(b, "_card_name_tags_index", {}) or {}
+    seed_tags = set(tags_idx.get(name_l) or [])
+    candidates: List[tuple[str, int]] = []
+    for nm in tags_idx.keys():
+        if _excluded(nm):
+            continue
+        score = len(seed_tags & set(tags_idx.get(nm) or []))
+        if score <= 0:
+            continue
+        candidates.append((nm, score))
+    candidates.sort(key=lambda x: (-x[1], 0 if x[0] in owned else 1, x[0]))
+    display_map = builder_display_map(b, {nm for nm, _s in candidates[:limit]})
+    for nm, _score in candidates[:limit]:
+        items.append(
+            {
+                "name": display_map.get(nm, nm),
+                "role": role or "",
+                "mana_cost": "",
+                "rarity": "",
+                "tags": list(tags_idx.get(nm) or []),
+                "owned": nm in owned,
+            }
+        )
+    return items

--- a/code/web/services/api_build_store.py
+++ b/code/web/services/api_build_store.py
@@ -6,6 +6,7 @@ the TTL/cleanup pattern of `code/web/services/tasks.py`'s `SessionManager`.
 """
 from __future__ import annotations
 
+import threading
 import time
 import uuid
 from typing import Any, Dict, Optional
@@ -101,6 +102,28 @@ class ApiBuildStore(StateService):
                 return True
             return False
 
+    def set_ctx(self, build_id: str, ctx: Dict[str, Any]) -> None:
+        """Attach a live guided-mode build context (holds the `DeckBuilder`).
+
+        Not JSON-serializable -- never returned directly from an API response.
+        """
+        with self._lock:
+            state = self._state.get(build_id)
+            if state is not None:
+                state["_ctx"] = ctx
+                state.setdefault("_stage_lock", threading.Lock())
+
+    def get_ctx(self, build_id: str) -> Optional[Dict[str, Any]]:
+        with self._lock:
+            state = self._state.get(build_id)
+            return state.get("_ctx") if state else None
+
+    def get_stage_lock(self, build_id: str) -> Optional[threading.Lock]:
+        """Per-build lock serializing concurrent advance/replace calls."""
+        with self._lock:
+            state = self._state.get(build_id)
+            return state.get("_stage_lock") if state else None
+
     def _initialize_state(self, key: str) -> Dict[str, Any]:
         now = time.time()
         return {"created": now, "updated": now, "status": "queued"}
@@ -147,6 +170,18 @@ def mark_error(build_id: str, message: str) -> None:
 
 def delete_build(build_id: str) -> bool:
     return _get_store().delete_build(build_id)
+
+
+def set_ctx(build_id: str, ctx: Dict[str, Any]) -> None:
+    _get_store().set_ctx(build_id, ctx)
+
+
+def get_ctx(build_id: str) -> Optional[Dict[str, Any]]:
+    return _get_store().get_ctx(build_id)
+
+
+def get_stage_lock(build_id: str) -> Optional[threading.Lock]:
+    return _get_store().get_stage_lock(build_id)
 
 
 def cleanup_expired() -> int:

--- a/code/web/services/orchestrator.py
+++ b/code/web/services/orchestrator.py
@@ -2980,6 +2980,7 @@ def run_stage(ctx: Dict[str, Any], rerun: bool = False, show_skipped: bool = Fal
             "txt_path": ctx.get("txt_path"),
             "summary": summary,
             "compliance": ctx.get("compliance"),
+            "include_exclude_diagnostics": getattr(b, "include_exclude_diagnostics", None),
         }
 
     # Determine which stage index to run (rerun last visible, else current)
@@ -3852,4 +3853,5 @@ def run_stage(ctx: Dict[str, Any], rerun: bool = False, show_skipped: bool = Fal
         "total_cards": total_cards,
         "added_total": 0,
         "compliance": ctx.get("compliance"),
+        "include_exclude_diagnostics": getattr(b, "include_exclude_diagnostics", None),
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,6 +49,7 @@ services:
       UPGRADE_WINDOW_MONTHS: "6"    # Rolling-months window for New Cards pool (default: 6)
       UPGRADE_PAGE_SIZE: "16"       # Cards per page on Potential Upgrades (default: 16, range 5-50)
       API_DOCS_ENABLED: "1"         # 1=serve Swagger UI at /api/v1/docs and Redoc at /api/v1/redoc; 0=disable in production
+      CORS_ALLOWED_ORIGINS: "*"      # Comma-separated allowed origins for the public API, or "*" for any (default); set to "none" to disable CORS entirely
       # LAND_PROFILE: "mid"         # Optional: force a land profile (basics|mid|fixing); skips auto-detection
       # LAND_COUNT: "36"            # Optional: force total land count; skips curve calculation
       

--- a/dockerhub-docker-compose.yml
+++ b/dockerhub-docker-compose.yml
@@ -51,6 +51,7 @@ services:
       UPGRADE_WINDOW_MONTHS: "6"    # Rolling-months window for New Cards pool (default: 6)
       UPGRADE_PAGE_SIZE: "16"       # Cards per page on Potential Upgrades (default: 16, range 5-50)
       API_DOCS_ENABLED: "1"         # 1=serve Swagger UI at /api/v1/docs and Redoc at /api/v1/redoc; 0=disable in production
+      CORS_ALLOWED_ORIGINS: "*"      # Comma-separated allowed origins for the public API, or "*" for any (default); set to "none" to disable CORS entirely
       # LAND_PROFILE: "mid"         # Optional: force a land profile (basics|mid|fixing); skips auto-detection
       # LAND_COUNT: "36"            # Optional: force total land count; skips curve calculation
       


### PR DESCRIPTION
Adds the backend API surface the mobile companion app needs, plus a couple of bug fixes discovered while integrating it. `CHANGELOG.md`/`RELEASE_NOTES_TEMPLATE.md` updated.

- Guided (stage-by-stage) deck building: `POST /api/v1/builds` `mode: "guided"`, `POST /{id}/advance`, `GET /{id}/alternatives`, `POST /{id}/replace` (new `code/web/services/api_alternatives.py`)
- CORS support for the public REST API (`CORS_ALLOWED_ORIGINS`, default `*`), so browser-based clients work with no config
- `/api/images/{size}/{card_name}` accepts `art_crop`
- `GET /api/v1/decks/{filename}/analysis`: commander, mana curve/pips/sources, land summary, total price
- `GET /api/v1/decks/{filename}` and `GET /api/v1/cards/{name}`: per-face `layout`/`faces` data for multi-faced cards
- Fix: auto-mode builds could hang indefinitely at a compliance-gated stage (e.g. board wipes)
- Fix: basic lands (Plains, Island, etc.) 404'd on card detail and images; both now fall back to a live Scryfall lookup, resolved server-side to avoid Scryfall's header requirements

Tests: `test_api_v1_builds.py`, `test_api_v1_decks.py` (24 passed).