### PR TITLE
Foil finish support, color filter fixes, and DFC Transform button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,22 @@ This format follows Keep a Changelog principles and aims for Semantic Versioning
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- `POST /api/v1/decks/{filename}/foil` and `POST /api/v1/builds/{id}/foil`: set a card's foil finish on a saved deck or in-progress build, mirroring the existing printing-selection endpoints
+- `GET /api/v1/decks/{filename}` card entries now include `is_foil`
+- `POST /api/price/batch` accepts an optional `foil_map` (per-card foil overrides); deck CSV-with-prices downloads and `GET /api/v1/decks/{filename}/analysis`'s total price now price each card at its own foil finish instead of assuming nonfoil
+- Card detail page's market price panel now shows both the nonfoil and foil TCGPlayer prices together (e.g. "TCG $21.19 / ✨ $38.80") for the selected printing, and updates when the printing or foil toggle changes instead of always showing the nonfoil price
+- Card detail page's foil toggle is hidden for printings with no foil version, and locked on for foil-only printings
+- A static, rainbow foil overlay now shows over the card image anywhere a foil card's image is displayed: card detail page, saved deck view (commander header and card thumbnails), the new-deck and partner commander-selection previews, the deck builder's review stage (commander, partner, and card list), the owned card library, the card browser grid, and the commander directory; the printing/foil buttons are overlaid directly on the card image (bottom-left corner) instead of below it, matching the on-image button placement used elsewhere in the app
+- Card browser and owned library tiles now show clickable guild/shard/wedge/nephilim color-identity names (e.g. "Bant", with "Azorius"/"Selesnya"/"Simic" sub-badges) alongside the color pips; clicking a pip or name applies a color filter, clicking the card image opens its details page, and clicking a theme tag runs a theme search
+- Card browser and owned library color filters now have an "Inclusive match" toggle: exact mode (default) matches only that exact color combination, inclusive mode matches any card whose color identity contains the selected colors (e.g. searching "WU" also finds Bant, Esper, and Jeskai cards)
+- Card detail page now shows a "Transform" button for double-faced/split/flip/meld cards to flip the card image (also updating when you change the printing), with both faces' type, mana cost, power/toughness, and oracle text always shown
 
 ### Changed
 _No unreleased changes yet_
 
 ### Fixed
-_No unreleased changes yet_
+- The card browser's color filter now matches color identity regardless of the raw data's letter order (previously required an exact string match, so some valid filter selections silently returned no results)
+- `GET /api/printings/{card_name}` now resolves double-faced/split/flip/meld names ("A // B") to their front face before looking up printings, instead of always returning an empty list for those names
 
 ### Removed
 _No unreleased changes yet_

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -2,13 +2,22 @@
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- `POST /api/v1/decks/{filename}/foil` and `POST /api/v1/builds/{id}/foil`: set a card's foil finish on a saved deck or in-progress build, mirroring the existing printing-selection endpoints
+- `GET /api/v1/decks/{filename}` card entries now include `is_foil`
+- `POST /api/price/batch` accepts an optional `foil_map` (per-card foil overrides); deck CSV-with-prices downloads and `GET /api/v1/decks/{filename}/analysis`'s total price now price each card at its own foil finish instead of assuming nonfoil
+- Card detail page's market price panel now shows both the nonfoil and foil TCGPlayer prices together (e.g. "TCG $21.19 / ✨ $38.80") for the selected printing, and updates when the printing or foil toggle changes instead of always showing the nonfoil price
+- Card detail page's foil toggle is hidden for printings with no foil version, and locked on for foil-only printings
+- A static, rainbow foil overlay now shows over the card image anywhere a foil card's image is displayed: card detail page, saved deck view (commander header and card thumbnails), the new-deck and partner commander-selection previews, the deck builder's review stage (commander, partner, and card list), the owned card library, the card browser grid, and the commander directory; the printing/foil buttons are overlaid directly on the card image instead of below it
+- Card browser and owned library tiles now show clickable guild/shard/wedge/nephilim color-identity names (e.g. "Bant", with "Azorius"/"Selesnya"/"Simic" sub-badges) alongside the color pips; clicking a pip or name applies a color filter, clicking the card image opens its details page, and clicking a theme tag runs a theme search
+- Card browser and owned library color filters now have an "Inclusive match" toggle: exact mode (default) matches only that exact color combination, inclusive mode matches any card whose color identity contains the selected colors (e.g. searching "WU" also finds Bant, Esper, and Jeskai cards)
+- Card detail page now shows a "Transform" button for double-faced/split/flip/meld cards to flip the card image (also updating when you change the printing), with both faces' type, mana cost, power/toughness, and oracle text always shown
 
 ### Changed
 _No unreleased changes yet_
 
 ### Fixed
-_No unreleased changes yet_
+- The card browser's color filter now matches color identity regardless of the raw data's letter order (previously required an exact string match, so some valid filter selections silently returned no results)
+- `GET /api/printings/{card_name}` now resolves double-faced/split/flip/meld names ("A // B") to their front face before looking up printings, instead of always returning an empty list for those names
 
 ### Removed
 _No unreleased changes yet_

--- a/code/deck_builder/builder_utils.py
+++ b/code/deck_builder/builder_utils.py
@@ -518,7 +518,108 @@ def read_printing_overrides_from_csv(csv_path: Path) -> Dict[str, str]:
 		if sid:
 			overrides[name.lower()] = sid
 	return overrides
+
+
+def set_card_foil(card_library: Dict[str, dict], name: str, foil: bool) -> bool:
+	"""Set (or clear) a card's "use the foil printing" preference directly on
+	its `card_library` entry, mirroring `set_card_printing()` -- baked into
+	the deck itself at export time (see `export_decklist_csv`'s "Foil"
+	column) rather than living only in an ephemeral session/build override.
+
+	Matches `name` case-insensitively against `card_library` keys. Returns
+	True if a matching entry was found and updated, False otherwise. Absence
+	of the `Foil` key (or a falsy value) means "use the nonfoil price/art",
+	which preserves current behavior for every existing deck/test.
+	"""
+	key = str(name).strip().lower()
+	entry_key = None
+	if name in card_library:
+		entry_key = name
+	else:
+		for k in card_library.keys():
+			if str(k).strip().lower() == key:
+				entry_key = k
+				break
+	if entry_key is None:
+		return False
+	if foil:
+		card_library[entry_key]["Foil"] = True
+	else:
+		card_library[entry_key].pop("Foil", None)
 	return True
+
+
+def set_card_foil_csv(csv_path: Path, name: str, foil: bool) -> bool:
+	"""Set (or clear) a saved deck's per-card `Foil` column directly in its
+	exported CSV, in-place -- the on-disk counterpart to `set_card_foil()`.
+	Mirrors `set_card_printing_csv()`. Decks exported before this column
+	existed get it appended to the header (and every row padded to match) on
+	first use. Returns True if a matching, non-summary card row was found
+	and updated, False otherwise.
+	"""
+	with csv_path.open("r", encoding="utf-8", newline="") as f:
+		rows = list(csv.reader(f))
+	if not rows:
+		return False
+	header = rows[0]
+	try:
+		name_idx = header.index("Name")
+	except ValueError:
+		return False
+	if "Foil" in header:
+		foil_idx = header.index("Foil")
+	else:
+		foil_idx = len(header)
+		header.append("Foil")
+
+	target = str(name).strip().lower()
+	found = False
+	for row in rows[1:]:
+		if not row:
+			continue
+		while len(row) <= foil_idx:
+			row.append("")
+		if row[name_idx] in ("", "Total"):
+			continue
+		if not found and str(row[name_idx]).strip().lower() == target:
+			row[foil_idx] = "True" if foil else ""
+			found = True
+
+	if not found:
+		return False
+
+	with csv_path.open("w", encoding="utf-8", newline="") as f:
+		csv.writer(f).writerows(rows)
+	return True
+
+
+def read_foil_overrides_from_csv(csv_path: Path) -> Dict[str, bool]:
+	"""Return a `{name_lower: True}` map of every card marked foil in an
+	exported deck CSV. Mirrors `read_printing_overrides_from_csv()`; only
+	`True` entries are included (a card absent from the map is nonfoil).
+	"""
+	overrides: Dict[str, bool] = {}
+	try:
+		with csv_path.open("r", encoding="utf-8", newline="") as f:
+			rows = list(csv.reader(f))
+	except Exception:
+		return overrides
+	if not rows:
+		return overrides
+	header = rows[0]
+	if "Name" not in header or "Foil" not in header:
+		return overrides
+	name_idx = header.index("Name")
+	foil_idx = header.index("Foil")
+	for row in rows[1:]:
+		if not row or len(row) <= foil_idx or len(row) <= name_idx:
+			continue
+		name = str(row[name_idx]).strip()
+		if not name or name == "Total":
+			continue
+		if str(row[foil_idx]).strip().lower() in ("true", "1", "y", "yes"):
+			overrides[name.lower()] = True
+	return overrides
 
 
 def compute_color_source_matrix(card_library: Dict[str, dict], full_df) -> Dict[str, Dict[str, int]]:

--- a/code/deck_builder/color_identity_utils.py
+++ b/code/deck_builder/color_identity_utils.py
@@ -1,6 +1,7 @@
 """Utilities for working with Magic color identity tuples and labels."""
 from __future__ import annotations
 
+from itertools import combinations
 from typing import Iterable, List
 
 __all__ = [
@@ -8,6 +9,7 @@ __all__ = [
     "format_color_label",
     "color_label_from_code",
     "normalize_colors",
+    "color_identity_badges",
 ]
 
 _WUBRG_ORDER: tuple[str, ...] = ("W", "U", "B", "R", "G")
@@ -132,3 +134,47 @@ def color_label_from_code(code: str) -> str:
 
 def format_color_label(identity: Iterable[str] | str | None) -> str:
     return color_label_from_code(canon_color_code(identity))
+
+
+def color_identity_badges(identity: Iterable[str] | str | None) -> dict:
+    """Return clickable guild/shard/wedge/N-color name(s) and WUBRG pip dots
+    for a color identity, for card browser/owned library tile badges.
+
+    Returns a dict with:
+      - "dots": WUBRG-ordered list of individual color letters present
+        (empty for colorless/no colors)
+      - "primary": {"name": str, "filter": str} for 2+ colors (guild name for
+        2, shard/wedge name for 3, nephilim name for 4, "Five-Color" for 5),
+        else None
+      - "subs": list of {"name": str, "filter": str} pairwise guild names,
+        populated only for exactly 3 colors (e.g. Bant -> Selesnya, Azorius,
+        Simic), so a shard/wedge card also exposes its component guilds
+
+    Each "filter" value is a WUBRG-canonical color code (e.g. "WUG") suitable
+    for the card browser's `color` or owned library's `filter_color` params.
+    """
+    colors = normalize_colors(identity)
+    result: dict = {"dots": colors, "primary": None, "subs": []}
+    if len(colors) < 2:
+        return result
+    code = canon_color_code(colors)
+    name: str | None = None
+    if len(colors) == 2:
+        name = _TWO_COLOR_LABELS.get(code)
+    elif len(colors) == 3:
+        name = _THREE_COLOR_LABELS.get(code)
+    elif len(colors) == 4:
+        name = _FOUR_COLOR_LABELS.get(code)
+    elif code == "WUBRG":
+        name = "Five-Color"
+    if name:
+        result["primary"] = {"name": name, "filter": code}
+    if len(colors) == 3:
+        subs = []
+        for a, b in combinations(colors, 2):
+            pair_code = canon_color_code([a, b])
+            pair_name = _TWO_COLOR_LABELS.get(pair_code)
+            if pair_name:
+                subs.append({"name": pair_name, "filter": pair_code})
+        result["subs"] = subs
+    return result

--- a/code/deck_builder/phases/phase6_reporting.py
+++ b/code/deck_builder/phases/phase6_reporting.py
@@ -591,6 +591,7 @@ class ReportingMixin:
                 'tags': list(info.get('Tags', []) or []),
                 'isNew': bool(row_lookup.get(name, None) is not None and row_lookup[name].get('isNew', False)),
                 'scryfall_id': info.get('ScryfallID') or None,
+                'is_foil': bool(info.get('Foil')),
             }
             dfc_meta = dfc_land_lookup.get(name)
             if dfc_meta:
@@ -903,7 +904,7 @@ class ReportingMixin:
 
         headers = [
             "Name","Count","Type","ManaCost","ManaValue","Colors","Power","Toughness",
-            "Role","SubRole","AddedBy","TriggerTag","Synergy","Tags","MetadataTags","Text","DFCNote","Owned","Price (TCGPlayer)","ScryfallID"
+            "Role","SubRole","AddedBy","TriggerTag","Synergy","Tags","MetadataTags","Text","DFCNote","Owned","Price (TCGPlayer)","ScryfallID","Foil"
         ]
 
         # Auto-inject price service when running in the web context
@@ -1064,7 +1065,8 @@ class ReportingMixin:
                 dfc_note,
                 owned_flag,
                 (f"{prices_map[name]:.2f}" if prices_map.get(name) is not None else ''),
-                info.get('ScryfallID') or ''
+                info.get('ScryfallID') or '',
+                'True' if info.get('Foil') else ''
             ]))
 
         # Now sort (category precedence, then alphabetical name)

--- a/code/tests/test_api_v1_decks.py
+++ b/code/tests/test_api_v1_decks.py
@@ -186,7 +186,7 @@ def test_deck_analysis_honors_printing_map(client, auth, tmp_path, monkeypatch):
     captured: dict = {}
 
     class _StubPriceService:
-        def get_prices_batch(self, names, region="usd", foil=False, printing_map=None):
+        def get_prices_batch(self, names, region="usd", foil=False, printing_map=None, foil_map=None):
             captured["printing_map"] = printing_map
             return {n: 20.0 for n in names}
 

--- a/code/tests/test_price_service.py
+++ b/code/tests/test_price_service.py
@@ -47,6 +47,10 @@ def _write_bulk_data(path: str, cards: list) -> None:
 def bulk_data_file(tmp_path):
     """Minimal Scryfall bulk data with known prices."""
     cards = [
+        # Foil-only promo printing (no "usd" price, only "usd_foil") -- used
+        # to test that a specific-printing lookup falls back to this same
+        # printing's foil price instead of a different printing's price.
+        {"object": "card", "id": "foil-only-promo", "name": "Lightning Bolt", "prices": {"usd": None, "usd_foil": "9.99", "eur": None, "eur_foil": None, "tix": None}},
         {"object": "card", "name": "Lightning Bolt", "prices": {"usd": "0.50", "usd_foil": "2.00", "eur": "0.40", "eur_foil": None, "tix": None}},
         {"object": "card", "name": "Sol Ring", "prices": {"usd": "2.00", "usd_foil": "5.00", "eur": "1.80", "eur_foil": None, "tix": None}},
         {"object": "card", "name": "Mana Crypt", "prices": {"usd": "150.00", "usd_foil": "300.00", "eur": "120.00", "eur_foil": None, "tix": None}},
@@ -92,6 +96,34 @@ def test_get_price_foil(price_svc):
 def test_get_price_eur_region(price_svc):
     price = price_svc.get_price("Sol Ring", region="eur")
     assert price == pytest.approx(1.80)
+
+
+def test_get_price_foil_only_printing_falls_back_to_own_foil_price(price_svc):
+    """A specific foil-only printing has no nonfoil price -- it should use
+    its own foil price, not a different (cheapest) printing's nonfoil price."""
+    price = price_svc.get_price("Lightning Bolt", scryfall_id="foil-only-promo")
+    assert price == pytest.approx(9.99)
+
+
+def test_get_price_detail_reports_actual_foil_for_foil_only_printing(price_svc):
+    price, actual_foil = price_svc.get_price_detail("Lightning Bolt", scryfall_id="foil-only-promo")
+    assert price == pytest.approx(9.99)
+    assert actual_foil is True
+
+
+def test_get_price_detail_matches_requested_foil_when_available(price_svc):
+    price, actual_foil = price_svc.get_price_detail("Lightning Bolt", foil=True, scryfall_id="foil-only-promo")
+    assert price == pytest.approx(9.99)
+    assert actual_foil is True
+
+
+def test_get_prices_batch_printing_map_foil_only_fallback(price_svc):
+    """Batch lookup with a printing_map pointing at a foil-only printing
+    should also use that printing's own foil price."""
+    result = price_svc.get_prices_batch(
+        ["Lightning Bolt"], printing_map={"lightning bolt": "foil-only-promo"}
+    )
+    assert result["Lightning Bolt"] == pytest.approx(9.99)
 
 
 def test_get_price_unknown_card_returns_none(price_svc):

--- a/code/web/routes/api.py
+++ b/code/web/routes/api.py
@@ -201,15 +201,21 @@ async def get_card_printings(card_name: str):
     `ImageCache.build_printings_index()`).
 
     Args:
-        card_name: Name of the card (or a single face's name for DFCs)
+        card_name: Name of the card (or a single face's name for DFCs). The
+            printings index is keyed per-face, so a combined double-faced/
+            split/flip/meld name ("A // B") is resolved to its front face
+            ("A") before lookup -- both faces of a physical printing share
+            the same set of printings, so this works regardless of which
+            face a caller (e.g. the mobile app) is currently displaying.
 
     Returns:
         JSON with a list of printings (set, set_name, collector_number,
         released_at, scryfall_id, is_default, ...) and the default printing's
         scryfall_id.
     """
-    printings = _image_cache.get_printings(card_name)
-    default_id = _image_cache.get_default_printing_id(card_name)
+    face_name = card_name.split(" // ")[0].strip() if " // " in card_name else card_name
+    printings = _image_cache.get_printings(face_name)
+    default_id = _image_cache.get_default_printing_id(face_name)
     return JSONResponse({
         "card_name": card_name,
         "default_scryfall_id": default_id,

--- a/code/web/routes/api_v1/builds.py
+++ b/code/web/routes/api_v1/builds.py
@@ -32,6 +32,7 @@ from ...services import api_build_store as build_store
 from ...services import orchestrator as orch
 from ...services.build_utils import owned_names as owned_names_helper
 from ...utils.api_response import err, ok
+from ...app import ENABLE_PARTNER_MECHANICS
 from ..decks import _deck_dir
 from .auth import get_api_user
 
@@ -64,6 +65,13 @@ class CreateBuildRequest(BaseModel):
     ideal_counts: Optional[Dict[str, int]] = None
     include_cards: Optional[List[str]] = None
     exclude_cards: Optional[List[str]] = None
+    # Partner/background pairing (see GET /commanders/{name}/partners and
+    # GET /commanders/backgrounds for valid `secondary_commander`/`background`
+    # values for a given primary commander). Ignored server-side unless the
+    # ENABLE_PARTNER_MECHANICS feature flag is on.
+    partner_enabled: bool = False
+    secondary_commander: Optional[str] = None
+    background: Optional[str] = None
 
 
 class ReplaceCardRequest(BaseModel):
@@ -74,6 +82,11 @@ class ReplaceCardRequest(BaseModel):
 class SetPrintingRequest(BaseModel):
     name: str
     scryfall_id: Optional[str] = None
+
+
+class SetFoilRequest(BaseModel):
+    name: str
+    foil: bool = False
 
 
 class RemoveCardRequest(BaseModel):
@@ -171,6 +184,9 @@ async def create_build(body: CreateBuildRequest, request: Request, user: User = 
             multi_copy=body.multi_copy,
             include_cards=body.include_cards,
             exclude_cards=body.exclude_cards,
+            partner_feature_enabled=ENABLE_PARTNER_MECHANICS and body.partner_enabled,
+            secondary_commander=body.secondary_commander,
+            background_commander=body.background,
         )
     except ValueError as exc:
         return err(str(exc), "INVALID_BUILD_REQUEST", 400, _rid(request))
@@ -544,6 +560,36 @@ async def set_build_card_printing(
     if not found:
         return err(f"'{body.name}' is not in the deck.", "CARD_NOT_IN_DECK", 404, _rid(request))
     return ok({"name": body.name, "scryfall_id": (body.scryfall_id or None)}, _rid(request))
+
+
+@router.post("/{build_id}/foil", summary="Set a card's foil finish (guided mode)")
+async def set_build_card_foil(
+    build_id: str, body: SetFoilRequest, request: Request, user: User = Depends(get_api_user)
+):
+    """Choose (or clear) the foil finish for a card already in a guided
+    build's deck-in-progress. Baked directly onto the card's `card_library`
+    entry (see `builder_utils.set_card_foil`), so it's written into the
+    exported deck's CSV `Foil` column and reflected in `build_deck_summary()`.
+    """
+    build = _guided_build_or_none(build_id, user["id"])
+    if build is None:
+        return err("Guided build not found.", "BUILD_NOT_FOUND", 404, _rid(request))
+    ctx = build_store.get_ctx(build_id)
+    lock = build_store.get_stage_lock(build_id)
+    if ctx is None or lock is None:
+        return err("Build session expired.", "BUILD_SESSION_EXPIRED", 410, _rid(request))
+    b = ctx.get("builder")
+    if b is None:
+        return err("Build session expired.", "BUILD_SESSION_EXPIRED", 410, _rid(request))
+
+    def _run() -> bool:
+        with lock:
+            return bu.set_card_foil(getattr(b, "card_library", {}) or {}, body.name, body.foil)
+
+    found = await asyncio.to_thread(_run)
+    if not found:
+        return err(f"'{body.name}' is not in the deck.", "CARD_NOT_IN_DECK", 404, _rid(request))
+    return ok({"name": body.name, "foil": body.foil}, _rid(request))
 
 
 def _remove_card_sync(ctx: Dict[str, Any], name: str) -> Dict[str, Any]:

--- a/code/web/routes/api_v1/cards.py
+++ b/code/web/routes/api_v1/cards.py
@@ -152,7 +152,7 @@ def _get_raw_faces_df() -> Optional[pd.DataFrame]:
         if not _RAW_CARDS_PATH.exists():
             return None
         cols = [
-            "name", "faceName", "side", "type", "text", "faceManaValue", "power", "toughness",
+            "name", "faceName", "side", "type", "text", "faceManaValue", "manaCost", "power", "toughness",
             "colorIdentity",
         ]
         try:
@@ -186,6 +186,7 @@ def _get_card_faces(name: str) -> List[Dict[str, Any]]:
                 "type": _json_safe(row.get("type")) or None,
                 "text": _json_safe(row.get("text")) or None,
                 "manaValue": _json_safe(row.get("faceManaValue")),
+                "manaCost": _json_safe(row.get("manaCost")) or None,
                 "power": _json_safe(row.get("power")) or None,
                 "toughness": _json_safe(row.get("toughness")) or None,
                 "colorIdentity": _json_safe(row.get("colorIdentity")) or None,

--- a/code/web/routes/api_v1/commanders.py
+++ b/code/web/routes/api_v1/commanders.py
@@ -137,6 +137,17 @@ async def get_commander_partners(name: str, request: Request):
     return ok({"variant": variant, "options": jsonable_encoder(options)}, _rid(request))
 
 
+@router.get("/backgrounds", summary="List available Background cards")
+async def list_backgrounds(request: Request):
+    """All 'Background' enchantment cards usable with a 'Choose a Background'
+    commander (reuses build_partners.py; unlike partner suggestions, this
+    list doesn't depend on the primary commander)."""
+    from ...routes.build_partners import _build_background_options
+
+    options = _build_background_options()
+    return ok({"options": jsonable_encoder(options)}, _rid(request))
+
+
 @router.get("/{name}", summary="Get commander detail")
 async def get_commander_detail(name: str, request: Request):
     """Commander detail."""

--- a/code/web/routes/api_v1/decks.py
+++ b/code/web/routes/api_v1/decks.py
@@ -98,6 +98,7 @@ def _parse_deck_cards(csv_path: Path) -> List[Dict[str, Any]]:
                     "tags": tags,
                     "layout": None,
                     "scryfall_id": col(row, "ScryfallID") or None,
+                    "is_foil": col(row, "Foil").strip().lower() in ("true", "1", "y", "yes"),
                 }
             )
 
@@ -129,6 +130,14 @@ def _set_deck_card_printing(csv_path: Path, name: str, scryfall_id: Optional[str
     saved-deck view's own printing picker, so both clients stay in sync).
     """
     return bu.set_card_printing_csv(csv_path, name, scryfall_id)
+
+
+def _set_deck_card_foil(csv_path: Path, name: str, foil: bool) -> bool:
+    """Set (or clear) a saved deck's per-card `Foil` column. Thin wrapper
+    around `builder_utils.set_card_foil_csv()` (also used by the web saved-
+    deck view's own foil toggle, so both clients stay in sync).
+    """
+    return bu.set_card_foil_csv(csv_path, name, foil)
 
 
 @router.get("", summary="List saved decks")
@@ -259,6 +268,27 @@ async def set_deck_card_printing(
     return ok({"name": body.name, "scryfall_id": (body.scryfall_id or None)}, _rid(request))
 
 
+class SetDeckFoilRequest(BaseModel):
+    name: str
+    foil: bool = False
+
+
+@router.post("/{filename}/foil", summary="Set a saved deck's card foil finish")
+async def set_deck_card_foil(
+    filename: str, body: SetDeckFoilRequest, request: Request, user: User = Depends(get_api_user)
+):
+    """Choose (or clear) the foil finish for a card already in a saved
+    deck, baked directly into the deck's CSV `Foil` column.
+    """
+    p = _resolve_deck_path(str(user["id"]), filename)
+    if p is None:
+        return err("Deck not found.", "DECK_NOT_FOUND", 404, _rid(request))
+    found = _set_deck_card_foil(p, body.name, body.foil)
+    if not found:
+        return err(f"'{body.name}' is not in this deck.", "CARD_NOT_IN_DECK", 404, _rid(request))
+    return ok({"name": body.name, "foil": body.foil}, _rid(request))
+
+
 @router.get("/{filename}/analysis", summary="Get deck mana analysis")
 async def get_deck_analysis(filename: str, request: Request, user: User = Depends(get_api_user)):
     """Commander, mana curve, pip distribution, mana sources, land summary
@@ -311,7 +341,12 @@ async def get_deck_analysis(filename: str, request: Request, user: User = Depend
             for c in cards
             if c.get("scryfall_id") and c["name"] != commander
         }
-        prices = get_price_service().get_prices_batch(names, printing_map=printing_map or None)
+        foil_map = {
+            c["name"].lower(): True
+            for c in cards
+            if c.get("is_foil") and c["name"] != commander
+        }
+        prices = get_price_service().get_prices_batch(names, printing_map=printing_map or None, foil_map=foil_map or None)
         found = [prices[name] * next(c["count"] for c in cards if c["name"] == name) for name in prices if prices[name] is not None]
         if found:
             total_price = round(sum(found), 2)

--- a/code/web/routes/build_multicopy.py
+++ b/code/web/routes/build_multicopy.py
@@ -69,6 +69,7 @@ def _rebuild_ctx_with_multicopy(sess: dict) -> None:
             combo_target_count=int(sess.get("combo_target_count", 2)),
             combo_balance=str(sess.get("combo_balance", "mix")),
             swap_mdfc_basics=bool(sess.get("swap_mdfc_basics")),
+            printings=dict(sess.get("printings") or {}),
         )
     except Exception:
         # If rebuild fails (e.g., commander not found in test), fall back to injecting

--- a/code/web/routes/build_newflow.py
+++ b/code/web/routes/build_newflow.py
@@ -252,6 +252,8 @@ async def build_new_inspect(request: Request, name: str = Query(...)) -> HTMLRes
         is_gc = bool(info["name"] in getattr(bc, 'GAME_CHANGERS', []))
     except Exception:
         is_gc = False
+    sid = request.cookies.get("sid") or new_sid()
+    sess = get_session(sid)
     ctx = {
         "request": request,
         "commander": {"name": info["name"], "exclusion": exclusion_detail},
@@ -263,6 +265,8 @@ async def build_new_inspect(request: Request, name: str = Query(...)) -> HTMLRes
         "recommended_sections": recommended_sections,  # R21: Sectioned recommendations
         "recommended_reasons": recommended_reasons,
         "gc_commander": is_gc,
+        "printings": dict(sess.get("printings") or {}),
+        "foils": dict(sess.get("foils") or {}),
         "brackets": orch.bracket_options(),
     }
     
@@ -312,7 +316,10 @@ async def build_new_inspect(request: Request, name: str = Query(...)) -> HTMLRes
             if tag not in reason_map:
                 reason_map[tag] = "Synergizes with partner pairing"
         ctx["recommended_reasons"] = reason_map
-    return templates.TemplateResponse("build/_new_deck_tags.html", ctx)
+    resp = templates.TemplateResponse("build/_new_deck_tags.html", ctx)
+    if not request.cookies.get("sid"):
+        resp.set_cookie("sid", sid, httponly=True, samesite="lax")
+    return resp
 
 
 # ==============================================================================
@@ -657,6 +664,8 @@ async def build_new_submit(
             "recommended_reasons": recommended_reasons,
             "gc_commander": is_gc,
             "brackets": orch.bracket_options(),
+            "printings": dict(sess.get("printings") or {}),
+            "foils": dict(sess.get("foils") or {}),
         }
         inspect_ctx.update(
             _partner_ui_context(

--- a/code/web/routes/build_permalinks.py
+++ b/code/web/routes/build_permalinks.py
@@ -36,17 +36,33 @@ def _render_card_img_html(name: str, idx: str, scryfall_id: str, *, oob: bool = 
     sized for the tile's on-page dimensions (which caused the low-res image
     to stick after a printing change even though it visually renders larger
     via CSS).
+
+    For double-faced/split/flip/meld cards (`name` containing " // "), also
+    re-emits the `data-front-src`/`data-back-src`/`data-current-face`
+    attributes the card detail page's Transform button relies on (see
+    `detail.html`), each pointed at the newly-selected printing -- otherwise
+    this OOB swap would wipe those attributes and leave the back face stuck
+    on the previous (default) printing's image.
     """
     display_name = name.split(" // ")[0].strip() if " // " in name else name
     q = quote(display_name)
     suffix = f"?printing={quote(scryfall_id)}" if scryfall_id else ""
     normal_url = f"/api/images/normal/{q}{suffix}"
     oob_attr = ' hx-swap-oob="true"' if oob else ""
+    dfc_attrs = ""
+    if " // " in name:
+        back_name = name.split(" // ")[1].strip()
+        back_suffix = f"&printing={quote(scryfall_id)}" if scryfall_id else ""
+        back_url = f"/api/images/normal/{quote(back_name)}?face=back{back_suffix}"
+        dfc_attrs = (
+            f' data-front-src="{_esc(normal_url)}" data-back-src="{_esc(back_url)}" '
+            f'data-current-face="front"'
+        )
     base_attrs = (
         f'class="card-thumb" id="card-img-{_esc(idx)}"{oob_attr} '
         f'alt="{_esc(name)} image" data-card-name="{_esc(name)}" '
         f'data-printing-id="{_esc(scryfall_id)}" '
-        f'loading="lazy" decoding="async" data-lqip="1"'
+        f'loading="lazy" decoding="async" data-lqip="1"{dfc_attrs}'
     )
     return f'<img {base_attrs} src="{_esc(normal_url)}" />'
 
@@ -202,16 +218,43 @@ async def build_printing_picker(
         thumb = f"/api/images/normal/{quote(face_name)}?printing={quote(sfid)}"
         is_sel = " selected" if sfid == selected else ""
         title = f"{set_name} — {label}" if set_name else label
+
+        finishes = {str(f).lower() for f in (p.get("finishes") or [])}
+        has_foil = "foil" in finishes or "etched" in finishes
+        # Older printings index entries (or unusual Scryfall data) may have
+        # an empty finishes list -- treat that as "nonfoil, unknown" rather
+        # than "foil-only" so existing behavior for those is unchanged.
+        has_nonfoil = "nonfoil" in finishes or not finishes
+        foil_only = has_foil and not has_nonfoil
+
         try:
-            price = price_svc.get_price(face_name, scryfall_id=sfid)
+            nonfoil_price = price_svc.get_price(face_name, scryfall_id=sfid) if has_nonfoil else None
         except Exception:
-            price = None
-        price_html = f'<span class="printing-option-price">${price:.2f}</span>' if price is not None else ""
+            nonfoil_price = None
+        foil_price = None
+        if has_foil:
+            try:
+                foil_price = price_svc.get_price(face_name, foil=True, scryfall_id=sfid)
+            except Exception:
+                foil_price = None
+
+        price_bits = []
+        if nonfoil_price is not None:
+            price_bits.append(f'<span class="printing-option-price">${nonfoil_price:.2f}</span>')
+        if foil_price is not None and (nonfoil_price is None or foil_price != nonfoil_price):
+            price_bits.append(
+                f'<span class="printing-option-price-foil" title="Foil price">&#10024; ${foil_price:.2f}</span>'
+            )
+        price_html = "".join(price_bits)
+        foil_badge = '<span class="printing-option-foil-badge">FOIL</span>' if foil_only else ""
         parts.append(
             f'<button type="button" class="printing-option{is_sel}" title="{_esc(title)}" '
             f'hx-post="{post_target}" hx-swap="none" '
             f'hx-vals=\'{{"name":"{_esc(name)}","scryfall_id":"{_esc(sfid)}","idx":"{_esc(idx)}"{deck_val}}}\'>'
+            f'<span class="printing-option-thumb-wrap">'
             f'<img src="{_esc(thumb)}" alt="{_esc(title)}" loading="lazy" width="110" />'
+            f"{foil_badge}"
+            f"</span>"
             f'<span class="printing-option-label">{_esc(label)}</span>'
             f"{price_html}"
             f"</button>"
@@ -260,12 +303,66 @@ async def build_printing(
         pass
 
     img_html = _render_card_img_html(name, idx, scryfall_id, oob=True)
+    is_foil = bool((sess.get("foils") or {}).get(name_l))
     price_oob = (
         f'<div id="price-overlay-{_esc(idx)}" class="card-price-overlay" hx-swap-oob="true" '
-        f'data-price-for="{_esc(name)}" data-printing-id="{_esc(scryfall_id)}" aria-hidden="true"></div>'
+        f'data-price-for="{_esc(name)}" data-printing-id="{_esc(scryfall_id)}" '
+        f'data-foil="{"1" if is_foil else "0"}" aria-hidden="true"></div>'
     )
     panel_oob = '<div id="printing-modal-root" class="printing-panel" hx-swap-oob="true"></div>'
     return HTMLResponse(img_html + price_oob + panel_oob)
+
+
+@router.post("/foil")
+async def build_foil(
+    request: Request,
+    name: str = Form(...),
+    idx: str = Form(...),
+    foil: int = Form(...),
+    compact: str = Form("0"),
+) -> HTMLResponse:
+    """Toggle whether a card should use its foil price/finish (HTMX-based).
+
+    Mirrors `/build/printing`'s persistence pattern: a session-scoped
+    `foils` map (`{name_lower: True}`, restores the toggle's state while the
+    wizard is still open) and, if a build is in progress, directly onto the
+    matching `card_library` entry via `set_card_foil()`, so the choice is
+    baked into the deck itself (CSV `Foil` column) at export time instead of
+    only living in the ephemeral session.
+
+    Returns the new toggle `<button>` (this element is the hx-target, via
+    `hx-swap="outerHTML"`) plus an OOB update for the price overlay's
+    `data-foil` attribute -- the existing `data-price-for`/`data-printing-id`
+    on that overlay are preserved so an already-chosen printing isn't lost.
+    """
+    sid = request.cookies.get("sid") or new_sid()
+    sess = get_session(sid)
+    name_l = str(name).strip().lower()
+    is_foil = bool(int(foil or 0))
+    foils = dict(sess.get("foils") or {})
+    if is_foil:
+        foils[name_l] = True
+    else:
+        foils.pop(name_l, None)
+    sess["foils"] = foils
+
+    try:
+        ctx = sess.get("build_ctx") or {}
+        builder = ctx.get("builder") if isinstance(ctx, dict) else None
+        if builder is not None:
+            bu.set_card_foil(builder.card_library, name, is_foil)
+    except Exception:
+        pass
+
+    scryfall_id = str((sess.get("printings") or {}).get(name_l, ""))
+    macros = templates.env.get_template("partials/_macros.html").module
+    btn_html = macros.foil_toggle_button(name, idx, is_foil, compact == "1")
+    price_oob = (
+        f'<div id="price-overlay-{_esc(idx)}" class="card-price-overlay" hx-swap-oob="true" '
+        f'data-price-for="{_esc(name)}" data-printing-id="{_esc(scryfall_id)}" '
+        f'data-foil="{"1" if is_foil else "0"}" aria-hidden="true"></div>'
+    )
+    return HTMLResponse(str(btn_html) + price_oob)
 
 
 @router.get("/permalink")

--- a/code/web/routes/card_browser.py
+++ b/code/web/routes/card_browser.py
@@ -22,11 +22,15 @@ from ..services.tasks import get_session, new_sid
 try:
     from code.services.all_cards_loader import AllCardsLoader
     from code.deck_builder.builder_utils import parse_theme_tags
+    from code.deck_builder.color_identity_utils import canon_color_code, color_identity_badges, color_label_from_code
     from code.settings import ENABLE_CARD_DETAILS
+    from code.web.routes.api_v1.cards import _get_card_faces
 except ImportError:
     from services.all_cards_loader import AllCardsLoader
     from deck_builder.builder_utils import parse_theme_tags
+    from deck_builder.color_identity_utils import canon_color_code, color_identity_badges, color_label_from_code
     from settings import ENABLE_CARD_DETAILS
+    from web.routes.api_v1.cards import _get_card_faces
 
 if TYPE_CHECKING:
     from code.web.services.card_similarity import CardSimilarity
@@ -50,6 +54,113 @@ def get_loader() -> AllCardsLoader:
     return _loader
 
 
+def _color_code_for_filter(raw: object) -> str:
+    """Order-independent color-identity comparison key for the `color`
+    filter param.
+
+    Tolerant of the raw data's exact stored string format (e.g. "G, U" for
+    Simic, "['W', 'U']", or a bare "W") as well as simpler codes the UI can
+    link to directly (e.g. "WUG"), so filtering doesn't depend on matching
+    a specific color ordering. The literal word "Colorless" (and NaN/empty)
+    map to "C"; `canon_color_code` can't be used directly on that word since
+    it would misread stray "C"/"R" letters out of "COLORLESS".
+    """
+    if raw is None:
+        return ""
+    text = str(raw).strip()
+    if not text or text.lower() == "colorless":
+        return "C"
+    return canon_color_code(text)
+
+
+_COLOR_BITS = {"W": 1, "U": 2, "B": 4, "R": 8, "G": 16}
+
+
+def _mask_from_code(code: str) -> int:
+    """Bitmask (WUBRG) for a canonical color code string; "C"/empty -> 0."""
+    if not code or code == "C":
+        return 0
+    return sum(_COLOR_BITS.get(ch, 0) for ch in code)
+
+
+def _ensure_color_code_column(df: "pd.DataFrame") -> None:
+    """Add cached `_color_code` (order-independent WUBRG code) and
+    `_color_mask` (WUBRG bitmask, for inclusive/subset filtering) columns
+    to the shared cards DataFrame, computed once and reused across requests
+    so the `color` filter's comparison doesn't re-parse 26k+ rows every time.
+    """
+    if "_color_code" not in df.columns:
+        df["_color_code"] = df["colorIdentity"].apply(_color_code_for_filter)
+    if "_color_mask" not in df.columns:
+        df["_color_mask"] = df["_color_code"].apply(_mask_from_code)
+
+
+def _apply_color_filter(filtered_df: "pd.DataFrame", color: str, color_mode: str) -> "pd.DataFrame":
+    """Apply the `color` filter, either as an exact color-identity match
+    (default) or an inclusive/subset match ("contains at least these
+    colors", e.g. searching "WU" also matches Bant/Esper/Jeskai/etc.).
+    Colorless always uses exact matching in either mode since "inclusive
+    of no colors" would trivially match everything.
+    """
+    target_code = _color_code_for_filter(color)
+    if color_mode == "inclusive" and target_code != "C":
+        target_mask = _mask_from_code(target_code)
+        return filtered_df[(filtered_df["_color_mask"] & target_mask) == target_mask]
+    return filtered_df[filtered_df["_color_code"] == target_code]
+
+
+_WUBRG_SORT_INDEX = {"W": 0, "U": 1, "B": 2, "R": 3, "G": 4}
+
+
+def _dropdown_color_label(code: str) -> str:
+    """Short display label for a canonical color code in the `color`
+    filter dropdown: bare letter(s) for colorless/mono, guild/shard/wedge/
+    nephilim name (without the "(CODE)" suffix) for 2+ colors.
+    """
+    if code == "C" or len(code) == 1:
+        return code
+    label = color_label_from_code(code)
+    suffix = f" ({code})"
+    if label.endswith(suffix):
+        return label[: -len(suffix)]
+    return label
+
+
+def _build_color_dropdown_groups(df: "pd.DataFrame") -> list[tuple[str, list[tuple[str, str]]]]:
+    """Build the `color` filter dropdown's grouped options directly from
+    the canonical WUBRG codes actually present in the data, so every
+    combination present shows up (previously a hardcoded list of literal
+    raw-string tuples silently dropped any combo whose stored letter order
+    didn't match, e.g. only 5 of the 10 two-color guilds ever appeared).
+    Each option's value is the same canonical WUBRG code used everywhere
+    else (badges, mana-dot links), so the current `color` filter is always
+    correctly pre-selected regardless of how it was set (dropdown, badge
+    click, or a hand-typed/bookmarked URL).
+    """
+    present = sorted(
+        {c for c in df["_color_code"].dropna().unique().tolist() if c},
+        key=lambda c: tuple(_WUBRG_SORT_INDEX.get(ch, 9) for ch in c),
+    )
+    groups: dict[str, list[tuple[str, str]]] = {
+        "Colorless": [], "Mono-Color": [], "Two-Color": [],
+        "Three-Color": [], "Four-Color": [], "Five-Color": [],
+    }
+    for code in present:
+        if code == "C":
+            groups["Colorless"].append((code, _dropdown_color_label(code)))
+        elif len(code) == 1:
+            groups["Mono-Color"].append((code, _dropdown_color_label(code)))
+        elif len(code) == 2:
+            groups["Two-Color"].append((code, _dropdown_color_label(code)))
+        elif len(code) == 3:
+            groups["Three-Color"].append((code, _dropdown_color_label(code)))
+        elif len(code) == 4:
+            groups["Four-Color"].append((code, _dropdown_color_label(code)))
+        elif code == "WUBRG":
+            groups["Five-Color"].append((code, _dropdown_color_label(code)))
+    return [(name, opts) for name, opts in groups.items() if opts]
+
+
 def _printings_context(request: Request) -> tuple[dict[str, str], str, bool]:
     """Return (selected-printings dict, sid, had_cookie) for the printing picker.
 
@@ -61,6 +172,18 @@ def _printings_context(request: Request) -> tuple[dict[str, str], str, bool]:
     had_cookie = bool(request.cookies.get("sid"))
     sid = request.cookies.get("sid") or new_sid()
     return dict(get_session(sid).get("printings") or {}), sid, had_cookie
+
+
+def _foils_context(request: Request, sid: str | None = None) -> dict[str, bool]:
+    """Return the selected-foils dict for the foil toggle button.
+
+    Session-scoped and shared with the build wizard's `sess["foils"]`
+    (see `code/web/routes/build_permalinks.py`); mirrors `_printings_context`.
+    Pass the `sid` already resolved by `_printings_context` to avoid
+    generating a second, unused session id on a cookie-less first request.
+    """
+    sid = sid or request.cookies.get("sid") or new_sid()
+    return dict(get_session(sid).get("foils") or {})
 
 
 def get_similarity() -> "CardSimilarity":
@@ -182,6 +305,7 @@ async def card_browser_index(
     search: str = Query("", description="Card name search query"),
     themes: list[str] = Query([], description="Theme tag filters (AND logic)"),
     color: str = Query("", description="Color identity filter"),
+    color_mode: str = Query("exact", description="Color filter mode: 'exact' or 'inclusive' (contains at least these colors)"),
     card_type: str = Query("", description="Card type filter"),
     rarity: str = Query("", description="Rarity filter"),
     sort: str = Query("name_asc", description="Sort order"),
@@ -203,6 +327,8 @@ async def card_browser_index(
     try:
         loader = get_loader()
         df = loader.load()
+        _ensure_color_code_column(df)
+        color = _color_code_for_filter(color) if color else ""
         
         # Apply filters
         filtered_df = df.copy()
@@ -310,9 +436,7 @@ async def card_browser_index(
                     filtered_df = filtered_df.iloc[0:0]
 
         if color:
-            filtered_df = filtered_df[
-                filtered_df['colorIdentity'] == color
-            ]
+            filtered_df = _apply_color_filter(filtered_df, color, color_mode)
         
         if card_type:
             filtered_df = filtered_df[
@@ -449,66 +573,17 @@ async def card_browser_index(
             elif not raw_color:
                 card['colorIdentity'] = []
             card['is_colorless'] = is_colorless
+            card['color_badges'] = color_identity_badges(card['colorIdentity'])
             # TODO: Add owned card checking when integrated
             card['is_owned'] = False
         
         # Get unique values for filters
-        # Build structured color identity list with proper names
-        unique_color_ids = df['colorIdentity'].dropna().unique().tolist()
-        
-        # Define color identity groups with proper names
-        color_groups = {
-            'Colorless': ['Colorless'],
-            'Mono-Color': ['W', 'U', 'B', 'R', 'G'],
-            'Two-Color': [
-                ('W, U', 'Azorius'),
-                ('U, B', 'Dimir'),
-                ('B, R', 'Rakdos'),
-                ('R, G', 'Gruul'),
-                ('G, W', 'Selesnya'),
-                ('W, B', 'Orzhov'),
-                ('U, R', 'Izzet'),
-                ('B, G', 'Golgari'),
-                ('R, W', 'Boros'),
-                ('G, U', 'Simic'),
-            ],
-            'Three-Color': [
-                ('B, G, U', 'Sultai'),
-                ('G, U, W', 'Bant'),
-                ('B, U, W', 'Esper'),
-                ('B, R, U', 'Grixis'),
-                ('B, G, R', 'Jund'),
-                ('G, R, W', 'Naya'),
-                ('B, G, W', 'Abzan'),
-                ('R, U, W', 'Jeskai'),
-                ('B, R, W', 'Mardu'),
-                ('G, R, U', 'Temur'),
-            ],
-            'Four-Color': [
-                ('B, G, R, U', 'Non-White'),
-                ('B, G, R, W', 'Non-Blue'),
-                ('B, G, U, W', 'Non-Red'),
-                ('B, R, U, W', 'Non-Green'),
-                ('G, R, U, W', 'Non-Black'),
-            ],
-            'Five-Color': ['B, G, R, U, W'],
-        }
-        
-        # Flatten and filter to only include combinations present in data
-        all_colors = []
-        for group_name, entries in color_groups.items():
-            group_colors = []
-            for entry in entries:
-                if isinstance(entry, tuple):
-                    color_id, display_name = entry
-                    if color_id in unique_color_ids:
-                        group_colors.append((color_id, display_name))
-                else:
-                    color_id = entry
-                    if color_id in unique_color_ids:
-                        group_colors.append((color_id, color_id))
-            if group_colors:
-                all_colors.append((group_name, group_colors))
+        # Build structured color identity dropdown groups (guild/shard/wedge/
+        # nephilim names) directly from the canonical WUBRG codes present in
+        # the data, keyed by the same codes used everywhere else in the UI
+        # (badges, mana-dot links) so the current filter is always correctly
+        # pre-selected.
+        all_colors = _build_color_dropdown_groups(df)
         
         all_types = sorted(
             set(
@@ -531,6 +606,7 @@ async def card_browser_index(
         last_card_name = cards_list[-1]['name'] if cards_list else ""
         
         printings, sid, had_cookie = _printings_context(request)
+        foils = _foils_context(request, sid)
         resp = templates.TemplateResponse(
             "browse/cards/index.html",
             {
@@ -543,6 +619,7 @@ async def card_browser_index(
                 "search": search,
                 "themes": themes,
                 "color": color,
+                "color_mode": color_mode,
                 "card_type": card_type,
                 "rarity": rarity,
                 "sort": sort,
@@ -562,6 +639,7 @@ async def card_browser_index(
                 "total_pages": total_pages,
                 "enable_card_details": ENABLE_CARD_DETAILS,
                 "printings": printings,
+                "foils": foils,
             },
         )
         if not had_cookie:
@@ -624,6 +702,7 @@ async def card_browser_grid(
     search: str = Query("", description="Card name search query"),
     themes: list[str] = Query([], description="Theme tag filters (AND logic)"),
     color: str = Query("", description="Color identity filter"),
+    color_mode: str = Query("exact", description="Color filter mode: 'exact' or 'inclusive' (contains at least these colors)"),
     card_type: str = Query("", description="Card type filter"),
     rarity: str = Query("", description="Rarity filter"),
     sort: str = Query("name_asc", description="Sort order"),
@@ -645,6 +724,8 @@ async def card_browser_grid(
     try:
         loader = get_loader()
         df = loader.load()
+        _ensure_color_code_column(df)
+        color = _color_code_for_filter(color) if color else ""
         
         # Apply filters
         filtered_df = df.copy()
@@ -752,9 +833,7 @@ async def card_browser_grid(
                     filtered_df = filtered_df.iloc[0:0]
         
         if color:
-            filtered_df = filtered_df[
-                filtered_df['colorIdentity'] == color
-            ]
+            filtered_df = _apply_color_filter(filtered_df, color, color_mode)
         
         if card_type:
             filtered_df = filtered_df[
@@ -891,12 +970,14 @@ async def card_browser_grid(
             elif not raw_color:
                 card['colorIdentity'] = []
             card['is_colorless'] = is_colorless
+            card['color_badges'] = color_identity_badges(card['colorIdentity'])
             card['is_owned'] = False  # TODO: Add owned card checking
         
         has_next = len(filtered_df) > per_page
         last_card_name = cards_list[-1]['name'] if cards_list else ""
         
         printings, sid, had_cookie = _printings_context(request)
+        foils = _foils_context(request, sid)
         resp = templates.TemplateResponse(
             "browse/cards/_card_grid.html",
             {
@@ -907,6 +988,7 @@ async def card_browser_grid(
                 "search": search,
                 "themes": themes,
                 "color": color,
+                "color_mode": color_mode,
                 "card_type": card_type,
                 "rarity": rarity,
                 "sort": sort,
@@ -920,6 +1002,7 @@ async def card_browser_grid(
                 "set_code": set_code,
                 "enable_card_details": ENABLE_CARD_DETAILS,
                 "printings": printings,
+                "foils": foils,
             },
         )
         if not had_cookie:
@@ -1417,11 +1500,24 @@ async def card_detail(request: Request, card_name: str, ref: str = Query("", des
         back_text = "Back to Owned Library" if _ref == "owned" else "Back to Card Browser"
 
         printings, sid, had_cookie = _printings_context(request)
+        foils = _foils_context(request, sid)
+
+        # Per-face details (type/text/mana value/power/toughness) for the
+        # "Transform" flip button on double-faced/split/flip/meld cards --
+        # the tagged dataset collapses multi-face cards to a single
+        # primary-face row, so the back face's text/stats have to be
+        # recovered from the raw MTGJSON data (see _get_card_faces()).
+        try:
+            faces = _get_card_faces(card_name)
+        except Exception:
+            faces = []
+
         resp = templates.TemplateResponse(
             "browse/cards/detail.html",
             {
                 "request": request,
                 "card": card,
+                "faces": faces,
                 "similar_cards": similar_cards,
                 "main_card_tags": main_card_tags,
                 "rulings": rulings,
@@ -1430,6 +1526,7 @@ async def card_detail(request: Request, card_name: str, ref: str = Query("", des
                 "back_url": back_url,
                 "back_text": back_text,
                 "printings": printings,
+                "foils": foils,
             }
         )
         if not had_cookie:

--- a/code/web/routes/commanders.py
+++ b/code/web/routes/commanders.py
@@ -15,6 +15,7 @@ from ..app import templates
 from ..services.commander_catalog_loader import CommanderCatalog, CommanderRecord, load_commander_catalog
 from ..services.theme_catalog_loader import load_index, slugify
 from ..services.telemetry import log_commander_page_view
+from ..services.tasks import get_session, new_sid
 
 router = APIRouter(prefix="/commanders", tags=["commanders"])
 
@@ -699,6 +700,11 @@ async def commanders_index(
         "error": error,
         "return_url": return_url,
     }
+    had_sid_cookie = bool(request.cookies.get("sid"))
+    sid = request.cookies.get("sid") or new_sid()
+    sess = get_session(sid)
+    context["printings"] = dict(sess.get("printings") or {})
+    context["foils"] = dict(sess.get("foils") or {})
     template_name = "commanders/list_fragment.html" if _is_htmx(request) else "commanders/index.html"
     try:
         log_commander_page_view(
@@ -710,7 +716,13 @@ async def commanders_index(
         )
     except Exception:
         pass
-    return templates.TemplateResponse(template_name, context)
+    resp = templates.TemplateResponse(template_name, context)
+    if not had_sid_cookie:
+        try:
+            resp.set_cookie("sid", sid, max_age=60 * 60 * 8, httponly=True, samesite="lax")
+        except Exception:
+            pass
+    return resp
 
 @router.get("", response_class=HTMLResponse)
 async def commanders_index_alias(

--- a/code/web/routes/decks.py
+++ b/code/web/routes/decks.py
@@ -542,9 +542,11 @@ async def decks_set_printing(
         pass
 
     img_html = _render_card_img_html(name, idx, scryfall_id, oob=True)
+    is_foil = name.strip().lower() in bu.read_foil_overrides_from_csv(p)
     price_oob = (
         f'<div id="price-overlay-{_esc(idx)}" class="card-price-overlay" hx-swap-oob="true" '
-        f'data-price-for="{_esc(name)}" data-printing-id="{_esc(scryfall_id)}" aria-hidden="true"></div>'
+        f'data-price-for="{_esc(name)}" data-printing-id="{_esc(scryfall_id)}" '
+        f'data-foil="{"1" if is_foil else "0"}" aria-hidden="true"></div>'
     )
     panel_oob = '<div id="printing-modal-root" class="printing-panel" hx-swap-oob="true"></div>'
     badge_html = ""
@@ -554,6 +556,56 @@ async def decks_set_printing(
             f'<div id="budget-badge-wrap" hx-swap-oob="true">{badge_resp.body.decode("utf-8")}</div>'
         )
     return HTMLResponse(img_html + price_oob + panel_oob + badge_html)
+
+
+@router.post("/foil", response_class=HTMLResponse)
+async def decks_set_foil(
+    request: Request,
+    deck: str = Form(...),
+    name: str = Form(...),
+    idx: str = Form(...),
+    foil: int = Form(...),
+    compact: str = Form("0"),
+) -> HTMLResponse:
+    """Persist a card's "use the foil printing" preference onto a saved
+    deck's CSV. Saved-deck counterpart to the build wizard's session-scoped
+    `/build/foil`, writing straight to the deck's `Foil` column so it
+    survives page reloads and is visible to every viewer. Only the deck's
+    own owner may call this.
+    """
+    uid = _user_id(request)
+    if uid == "guest":
+        return HTMLResponse("", status_code=404)
+    base = _deck_dir(uid)
+    p = (base / deck).resolve()
+    if not _safe_within(base, p) or not (p.exists() and p.is_file() and p.suffix.lower() == ".csv"):
+        return HTMLResponse("", status_code=404)
+
+    from html import escape as _esc
+
+    is_foil = bool(int(foil or 0))
+    bu.set_card_foil_csv(p, name, is_foil)
+    try:
+        invalidate_fragment_cache("partials/deck_summary.html", f"{p.name}:owner")
+        invalidate_fragment_cache("partials/deck_summary.html", f"{p.name}:guest")
+    except Exception:
+        pass
+
+    scryfall_id = bu.read_printing_overrides_from_csv(p).get(name.strip().lower(), "")
+    macros = templates.env.get_template("partials/_macros.html").module
+    btn_html = macros.foil_toggle_button(name, idx, is_foil, compact == "1", deck)
+    price_oob = (
+        f'<div id="price-overlay-{_esc(idx)}" class="card-price-overlay" hx-swap-oob="true" '
+        f'data-price-for="{_esc(name)}" data-printing-id="{_esc(scryfall_id)}" '
+        f'data-foil="{"1" if is_foil else "0"}" aria-hidden="true"></div>'
+    )
+    badge_html = ""
+    badge_resp = _compute_budget_badge(p)
+    if badge_resp is not None:
+        badge_html = (
+            f'<div id="budget-badge-wrap" hx-swap-oob="true">{badge_resp.body.decode("utf-8")}</div>'
+        )
+    return HTMLResponse(str(btn_html) + price_oob + badge_html)
 
 
 @router.get("/", response_class=HTMLResponse)
@@ -647,6 +699,7 @@ def _render_deck_view(
     had_sid_cookie = bool(request.cookies.get("sid"))
     sid = request.cookies.get("sid") or new_sid()
     selected_printings = dict(get_session(sid).get("printings") or {})
+    selected_foils = dict(get_session(sid).get("foils") or {})
 
     # Try to load sidecar summary JSON first
     summary = None
@@ -682,8 +735,10 @@ def _render_deck_view(
     # Overlay it onto the loaded summary so a printing changed by either
     # client is reflected here regardless of which path produced `summary`.
     csv_overrides: Dict[str, str] = {}
+    csv_foil_overrides: Dict[str, bool] = {}
     try:
         csv_overrides = bu.read_printing_overrides_from_csv(p)
+        csv_foil_overrides = bu.read_foil_overrides_from_csv(p)
         if csv_overrides and isinstance(summary, dict):
             for clist in ((summary.get('type_breakdown') or {}).get('cards') or {}).values():
                 for entry in (clist or []):
@@ -692,6 +747,8 @@ def _render_deck_view(
                     nm = str(entry.get('name') or '').strip().lower()
                     if nm in csv_overrides:
                         entry['scryfall_id'] = csv_overrides[nm]
+                    if nm in csv_foil_overrides:
+                        entry['is_foil'] = True
     except Exception:
         pass
     stem = p.stem
@@ -716,6 +773,9 @@ def _render_deck_view(
         "visibility_options": VALID_VISIBILITIES,
         "share_url": f"/decks/{owner_username}/{p.name}" if owner_username else None,
         "printings": selected_printings,
+        "foils": selected_foils,
+        "commander_scryfall_id": csv_overrides.get(commander_name.strip().lower()) if csv_overrides else None,
+        "commander_is_foil": commander_name.strip().lower() in csv_foil_overrides,
         "deck_edit_ctx": {"deck": p.name} if is_owner else None,
     }
     ctx.update(summary_ctx(summary=summary, commander=commander_name, tags=tags, meta=meta_info))
@@ -1117,7 +1177,8 @@ def _build_csv_download_response(p: Path) -> Response:
     try:
         from ..services.price_service import get_price_service
         printing_map = bu.read_printing_overrides_from_csv(p)
-        prices_map = get_price_service().get_prices_batch(card_names, printing_map=printing_map or None) or {}
+        foil_map = bu.read_foil_overrides_from_csv(p)
+        prices_map = get_price_service().get_prices_batch(card_names, printing_map=printing_map or None, foil_map=foil_map or None) or {}
     except Exception:
         pass
 

--- a/code/web/routes/owned.py
+++ b/code/web/routes/owned.py
@@ -6,6 +6,11 @@ from ..app import templates
 from ..services import owned_store as store
 from ..services.tasks import get_session, new_sid
 
+try:
+    from code.deck_builder.color_identity_utils import color_identity_badges
+except ImportError:
+    from deck_builder.color_identity_utils import color_identity_badges
+
 
 router = APIRouter(prefix="/owned")
 
@@ -31,6 +36,16 @@ def _canon_color_code(seq: list[str] | tuple[str, ...]) -> str:
     uniq.sort(key=lambda x: order[x])
     code = ''.join([c for c in uniq if c != 'C'])
     return code or ('C' if 'C' in seen else '')
+
+
+_COLOR_BITS = {'W': 1, 'U': 2, 'B': 4, 'R': 8, 'G': 16}
+
+
+def _mask_from_code(code: str) -> int:
+    """Bitmask (WUBRG) for a canonical color code string; "C"/empty -> 0."""
+    if not code or code == 'C':
+        return 0
+    return sum(_COLOR_BITS.get(ch, 0) for ch in code)
 
 
 def _color_combo_label(code: str) -> str:
@@ -91,6 +106,9 @@ def _build_owned_context(request: Request, notice: str | None = None, error: str
     all_colors = ['W','U','B','R','G','C']
     # Build color combos displayed in the filter
     combos = _build_color_combos(names_sorted, colors_by_name)
+    # Per-card guild/shard/wedge/nephilim name badges + WUBRG dots, for the
+    # same clickable color-identity badges shown on the card browser.
+    badges_by_name = {n: color_identity_badges(colors_by_name.get(n) or []) for n in names_sorted}
     ctx = {
         "request": request,
         "names": names_sorted,
@@ -102,12 +120,14 @@ def _build_owned_context(request: Request, notice: str | None = None, error: str
         "all_tags": all_tags,
         "all_colors": all_colors,
     "color_combos": combos,
+    "badges_by_name": badges_by_name,
     "added_at_map": added_at_map,
     }
     # Session-scoped printing selection (cosmetic only; does not affect
     # owned-card matching/filtering). Mirrors the build wizard's picker.
     sid = request.cookies.get("sid") or new_sid()
     ctx["printings"] = dict(get_session(sid).get("printings") or {})
+    ctx["foils"] = dict(get_session(sid).get("foils") or {})
     ctx["_sid"] = sid
     if notice:
         ctx["notice"] = notice
@@ -124,6 +144,7 @@ async def owned_index(
     filter_type: str = Query(""),
     filter_tags: list[str] = Query([]),
     filter_color: str = Query(""),
+    color_mode: str = Query("exact", description="Color filter mode: 'exact' or 'inclusive' (contains at least these colors)"),
     cmc_min: str = Query(""),
     cmc_max: str = Query(""),
     power_min: str = Query(""),
@@ -158,7 +179,14 @@ async def owned_index(
     # Color filter
     if filter_color:
         fcode = _canon_color_code(list(filter_color.upper()))
-        names = [n for n in names if _canon_color_code(colors_by_name.get(n) or []) == fcode]
+        if color_mode == "inclusive" and fcode != "C":
+            fmask = _mask_from_code(fcode)
+            names = [
+                n for n in names
+                if (_mask_from_code(_canon_color_code(colors_by_name.get(n) or [])) & fmask) == fmask
+            ]
+        else:
+            names = [n for n in names if _canon_color_code(colors_by_name.get(n) or []) == fcode]
 
     # CMC / Power / Toughness range filters
     if cmc_min or cmc_max or power_min or power_max or tough_min or tough_max:
@@ -218,6 +246,7 @@ async def owned_index(
         "filter_type": filter_type,
         "filter_tags": filter_tags,
         "filter_color": filter_color,
+        "color_mode": color_mode,
         "cmc_min": cmc_min,
         "cmc_max": cmc_max,
         "power_min": power_min,

--- a/code/web/routes/price.py
+++ b/code/web/routes/price.py
@@ -66,18 +66,20 @@ async def get_card_price(
 
     Returns:
         JSON with ``card_name``, ``price`` (float or null), ``region``,
-        ``foil``, ``found`` (bool).
+        ``foil`` (whether the returned ``price`` is actually a foil price --
+        may differ from the requested *foil* flag for a foil-only printing),
+        ``found`` (bool).
     """
     name = unquote(card_name).strip()
     svc = get_price_service()
-    price = svc.get_price(name, region=region, foil=foil, scryfall_id=printing or None)
+    price, actual_foil = svc.get_price_detail(name, region=region, foil=foil, scryfall_id=printing or None)
     ck_price = svc.get_ck_price(name)
     return JSONResponse({
         "card_name": name,
         "price": price,
         "ck_price": ck_price,
         "region": region,
-        "foil": foil,
+        "foil": actual_foil,
         "found": price is not None,
     })
 
@@ -88,6 +90,7 @@ async def get_card_price(
 async def get_prices_batch(
     card_names: List[str] = Body(..., embed=True, max_length=100),
     printing_map: Optional[Dict[str, str]] = Body(default=None, embed=True),
+    foil_map: Optional[Dict[str, bool]] = Body(default=None, embed=True),
     region: str = Query("usd", pattern="^(usd|eur)$"),
     foil: bool = Query(False),
 ):
@@ -100,15 +103,18 @@ async def get_prices_batch(
         printing_map: Optional ``{name.lower(): scryfall_id}`` overrides so
             a card with a chosen alternate printing is priced using that
             printing instead of the cheapest-by-name default.
+        foil_map: Optional ``{name.lower(): bool}`` per-card foil overrides
+            so a card's own foil choice is used instead of the global
+            *foil* flag below.
         region: Price region — ``usd`` or ``eur``.
-        foil: If true, return foil prices.
+        foil: If true, return foil prices (for any name not in *foil_map*).
 
     Returns:
         JSON with ``prices`` (dict name→{price, ck_price}) and ``missing``
         (list of names with no TCG price data).
     """
     svc = get_price_service()
-    tcg_prices = svc.get_prices_batch(card_names, region=region, foil=foil, printing_map=printing_map)
+    tcg_prices = svc.get_prices_batch(card_names, region=region, foil=foil, printing_map=printing_map, foil_map=foil_map)
     ck_prices = svc.get_ck_prices_batch(card_names)
     missing = [n for n, p in tcg_prices.items() if p is None]
     prices = {

--- a/code/web/services/build_utils.py
+++ b/code/web/services/build_utils.py
@@ -89,6 +89,7 @@ def step5_base_ctx(request: Request, sess: dict, *, include_name: bool = True, i
     if include_locks:
         ctx["locks"] = list(sess.get("locks", []))
         ctx["printings"] = dict(sess.get("printings") or {})
+        ctx["foils"] = dict(sess.get("foils") or {})
     try:
         ctx["summary_token"] = int(sess.get("step5_summary_token", 0))
     except Exception:
@@ -194,6 +195,7 @@ def start_ctx_from_session(sess: dict, *, set_on_session: bool = True, deck_dir:
         background_commander=background_choice,
         budget_config=sess.get("budget_config"),
         deck_visibility=sess.get("deck_visibility"),
+        printings=dict(sess.get("printings") or {}),
     )
     if set_on_session:
         sess["build_ctx"] = ctx

--- a/code/web/services/orchestrator.py
+++ b/code/web/services/orchestrator.py
@@ -2588,6 +2588,7 @@ def start_build_ctx(
     background_commander: str | None = None,
     budget_config: Dict[str, Any] | None = None,
     deck_visibility: str | None = None,
+    printings: Dict[str, str] | None = None,
 ) -> Dict[str, Any]:
     logs: List[str] = []
 
@@ -2635,6 +2636,19 @@ def start_build_ctx(
             if combined_partner is not None:
                 _apply_combined_commander_to_builder(b, combined_partner)
                 _add_secondary_commander_card(b, df, combined_partner)
+    # Carry over any printing chosen before the build session existed (e.g. from
+    # the commander browser or the still-open wizard's session `printings` map)
+    # onto the commander/partner card_library entries that were just created.
+    if printings:
+        try:
+            from deck_builder import builder_utils as _bu
+
+            for card_name in list(b.card_library.keys()):
+                sid = printings.get(str(card_name).strip().lower())
+                if sid:
+                    _bu.set_card_printing(b.card_library, card_name, sid)
+        except Exception:
+            pass
     # Tags (explicit + supplemental applied upstream)
     b.selected_tags = list(tags or [])
     b.primary_tag = b.selected_tags[0] if len(b.selected_tags) > 0 else None

--- a/code/web/services/price_service.py
+++ b/code/web/services/price_service.py
@@ -91,6 +91,72 @@ class PriceService(BaseService):
     # Public API
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _resolve_printing_price(
+        printing_entry: Dict[str, float],
+        region: str,
+        foil: bool,
+    ) -> tuple[Optional[float], Optional[bool]]:
+        """Return ``(price, actual_foil)`` for a single printing's price entry.
+
+        Prefers the requested finish (``foil``); if that finish has no price
+        data for *this specific printing* (e.g. a foil-only promo has no
+        ``usd`` price, only ``usd_foil``), falls back to the printing's
+        *other* finish rather than letting the caller fall through to a
+        completely different (cheapest-by-name) printing's price, which
+        would be misleading. Returns ``(None, None)`` if the printing has no
+        price data for either finish.
+        """
+        primary_key = region + ("_foil" if foil else "")
+        price = printing_entry.get(primary_key)
+        if price is not None:
+            return price, foil
+        alt_key = region + ("" if foil else "_foil")
+        alt_price = printing_entry.get(alt_key)
+        if alt_price is not None:
+            return alt_price, not foil
+        return None, None
+
+    def get_price_detail(
+        self,
+        card_name: str,
+        region: str = "usd",
+        foil: bool = False,
+        scryfall_id: Optional[str] = None,
+    ) -> tuple[Optional[float], bool]:
+        """Return ``(price, actual_foil)`` for *card_name*.
+
+        Same lookup rules as :meth:`get_price`, but also reports whether the
+        returned price is actually a foil price -- which can differ from the
+        requested *foil* flag when a specific printing only has data for the
+        other finish (see :meth:`_resolve_printing_price`).
+        """
+        self._ensure_loaded()
+        if scryfall_id:
+            printing_entry = self._price_by_printing_id.get(scryfall_id)
+            if printing_entry is not None:
+                price, actual_foil = self._resolve_printing_price(printing_entry, region, foil)
+                if price is not None:
+                    with self._lock:
+                        self._hit_count += 1
+                    return price, bool(actual_foil)
+        price_key = region + ("_foil" if foil else "")
+        entry = self._cache.get(card_name.lower().strip())
+        self.queue_lazy_refresh(card_name)
+        with self._lock:
+            if entry is not None:
+                self._hit_count += 1
+                if entry.get(price_key) is not None:
+                    return entry.get(price_key), foil
+                # The cached (cheapest-by-name) printing has no price for the
+                # requested finish -- e.g. every known printing of this card
+                # is foil-only. Fall back to its other finish rather than a
+                # blank price.
+                price, actual_foil = self._resolve_printing_price(entry, region, foil)
+                return price, bool(actual_foil) if price is not None else foil
+            self._miss_count += 1
+        return None, foil
+
     def get_price(
         self,
         card_name: str,
@@ -106,28 +172,14 @@ class PriceService(BaseService):
             foil: If ``True`` return foil price.
             scryfall_id: Optional specific printing to price instead of the
                 cheapest-by-name default. Falls back to the cheapest-by-name
-                price if this printing has no price data (never a hard miss
-                just because one printing is unpriced).
+                price if this printing has no price data at all (never a
+                hard miss just because one printing is unpriced).
 
         Returns:
             Price as float or ``None`` when missing / card unknown.
         """
-        self._ensure_loaded()
-        price_key = region + ("_foil" if foil else "")
-        if scryfall_id:
-            printing_entry = self._price_by_printing_id.get(scryfall_id)
-            if printing_entry is not None and printing_entry.get(price_key) is not None:
-                with self._lock:
-                    self._hit_count += 1
-                return printing_entry.get(price_key)
-        entry = self._cache.get(card_name.lower().strip())
-        self.queue_lazy_refresh(card_name)
-        with self._lock:
-            if entry is not None:
-                self._hit_count += 1
-                return entry.get(price_key)
-            self._miss_count += 1
-        return None
+        price, _actual_foil = self.get_price_detail(card_name, region=region, foil=foil, scryfall_id=scryfall_id)
+        return price
 
     def get_prices_batch(
         self,
@@ -135,6 +187,7 @@ class PriceService(BaseService):
         region: str = "usd",
         foil: bool = False,
         printing_map: Optional[Dict[str, str]] = None,
+        foil_map: Optional[Dict[str, bool]] = None,
     ) -> Dict[str, Optional[float]]:
         """Return a mapping of card name → price for all requested cards.
 
@@ -144,29 +197,39 @@ class PriceService(BaseService):
         Args:
             card_names: List of card names to look up.
             region: Price region - ``"usd"`` or ``"eur"``.
-            foil: If ``True`` return foil prices.
+            foil: If ``True`` return foil prices (the default for any name
+                not present in *foil_map*).
             printing_map: Optional ``{name.lower(): scryfall_id}`` overrides --
                 for any name present here, price that specific printing
                 instead of the cheapest-by-name default (falling back to the
                 default if that printing has no price data).
+            foil_map: Optional ``{name.lower(): bool}`` per-card foil
+                overrides -- for any name present here, use that finish
+                instead of the global *foil* flag (mirrors *printing_map*'s
+                per-name override pattern).
 
         Returns:
             Dict mapping each input name to its price (or ``None``).
         """
         self._ensure_loaded()
-        price_key = region + ("_foil" if foil else "")
         result: Dict[str, Optional[float]] = {}
         hits = 0
         misses = 0
         for name in card_names:
             key = name.lower().strip()
+            card_foil = foil_map.get(key, foil) if foil_map else foil
+            price_key = region + ("_foil" if card_foil else "")
             price: Optional[float] = None
             if printing_map:
                 scryfall_id = printing_map.get(key)
                 if scryfall_id:
                     printing_entry = self._price_by_printing_id.get(scryfall_id)
                     if printing_entry is not None:
-                        price = printing_entry.get(price_key)
+                        # Prefer this printing's OTHER finish over falling
+                        # through to a different (cheapest-by-name) printing
+                        # -- e.g. a foil-only promo has no "usd" price, only
+                        # "usd_foil".
+                        price, _actual_foil = self._resolve_printing_price(printing_entry, region, card_foil)
             if price is None:
                 entry = self._cache.get(key)
                 if entry is not None:

--- a/code/web/static/styles.css
+++ b/code/web/static/styles.css
@@ -3299,6 +3299,62 @@ img.lqip.loaded {
   white-space: nowrap;
 }
 
+.tag-clickable {
+  text-decoration: none;
+  cursor: pointer;
+}
+
+.tag-clickable:hover {
+  background: rgba(148, 163, 184, 0.3);
+}
+
+/* Wraps a `.mana` pip in an `<a>` so color dots stay clickable filters
+   without disturbing the existing dot styling/sizing. */
+
+.mana-link {
+  display: inline-flex;
+  text-decoration: none;
+  cursor: pointer;
+}
+
+/* Guild/shard/wedge/nephilim name badges shown alongside the mana pips
+   on card browser and owned library tiles; clicking applies a color filter. */
+
+.tile-color-names {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  margin-top: 0.15rem;
+}
+
+.tile-color-name-badge {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.35rem;
+  border-radius: 3px;
+  text-decoration: none;
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.tile-color-name-primary {
+  background: rgba(59, 130, 246, 0.15);
+  color: var(--primary);
+  font-weight: 500;
+}
+
+.tile-color-name-primary:hover {
+  background: rgba(59, 130, 246, 0.3);
+}
+
+.tile-color-name-sub {
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--muted);
+}
+
+.tile-color-name-sub:hover {
+  background: rgba(148, 163, 184, 0.25);
+}
+
 /* Card Details button on tiles */
 
 .card-details-btn {
@@ -3329,16 +3385,9 @@ img.lqip.loaded {
   flex-shrink: 0;
 }
 
-/* Printing picker row on browse tiles */
-
-.card-tile-printing-row {
-  margin-top: 0.35rem;
-}
-
-.card-tile-printing-row .btn-printing {
-  font-size: 0.8rem;
-  padding: 0.35rem 0.6rem;
-}
+/* Printing picker row on browse tiles -- overlaid on the card image itself
+   (see the tile templates' inline position:absolute), not a flow row below
+   it, so both buttons stay compact icons rather than full-width labels. */
 
 .card-detail-printing-row {
   margin-top: 0.6rem;
@@ -4114,6 +4163,55 @@ img.lqip.loaded {
   width: 100%;
   height: auto;
   border-radius: 12px;
+}
+
+/* Wraps only the card detail page's main <img> (not the printing/foil
+   buttons row below it), so the `.card-foil-shine::after` overlay -- which
+   fills its host's full bounds -- can't bleed onto those buttons. */
+
+.card-image-shine-wrap {
+  border-radius: 12px;
+}
+
+/* Opt-in marker for "this element safely wraps ONLY a card image (and its
+   overlaid badges/buttons), nothing else" -- see base.html's foil-shimmer
+   pass, which toggles `.card-foil-shine` on the nearest ancestor carrying
+   this class. Every card thumbnail/preview across the site that supports
+   the foil toggle should carry it, so the shimmer works everywhere a card
+   can be marked foil. A sensible default radius so the shine's rounded
+   corners (border-radius: inherit) look right even on hosts that don't set
+   their own; hosts that already do (e.g. `.stack-card`) are unaffected. */
+
+.foil-shine-target {
+  border-radius: 8px;
+}
+
+/* Diagonal rainbow overlay shown on a card image (browser detail page,
+   saved-deck view commander/card thumbnails) while its foil finish is the
+   effective one (toggled on, or forced for a foil-only printing) -- a
+   lightweight, static CSS approximation of a foil card's rainbow sheen,
+   since Scryfall doesn't serve a visually distinct image for foil prints.
+   Intentionally NOT animated: an earlier animated version visibly
+   jump-cut back to its start position at the end of every loop.
+   `border-radius: inherit` so it matches whatever host element it's
+   toggled onto (card-image-shine-wrap, commander-card, stack-card, etc.)
+   instead of a single hardcoded radius. */
+
+.card-foil-shine::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  border-radius: inherit;
+  background: repeating-linear-gradient(115deg,
+		rgba(255, 90, 130, .12) 0px,
+		rgba(255, 200, 70, .1) 20px,
+		rgba(140, 255, 120, .1) 40px,
+		rgba(80, 210, 255, .11) 60px,
+		rgba(160, 110, 255, .12) 80px,
+		rgba(255, 100, 200, .11) 100px,
+		rgba(255, 90, 130, .12) 120px);
+  mix-blend-mode: overlay;
 }
 
 /* ============================================
@@ -7041,6 +7139,18 @@ footer.site-footer {
   display: none;
 }
 
+/* Small sparkle tag appended to a price when it's actually a foil price
+   (either the user explicitly requested foil, or a specific foil-only
+   printing has no nonfoil price to fall back to). */
+
+.price-foil-tag {
+  background: linear-gradient(135deg, #f0abfc, #60a5fa, #facc15);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  font-weight: 700;
+}
+
 /* "Owned" badge on card thumbnails — top-right, green pill */
 
 .card-owned-badge {
@@ -7607,6 +7717,42 @@ footer.site-footer {
   display: none;
 }
 
+/* Foil toggle button (mirrors .btn-printing sizing/placement) */
+
+.btn-foil-toggle {
+  background: rgba(15, 17, 21, .8);
+  border: 1px solid var(--border, #333);
+  color: var(--muted, #b6b8bd);
+}
+
+.btn-foil-toggle:hover {
+  border-color: #facc15;
+  color: #facc15;
+}
+
+.btn-foil-toggle.active {
+  border-color: #facc15;
+  background: linear-gradient(135deg, rgba(240, 171, 252, .25), rgba(96, 165, 250, .25), rgba(250, 204, 21, .25));
+  color: #facc15;
+}
+
+.btn-foil-toggle:disabled {
+  cursor: default;
+  opacity: 0.9;
+}
+
+.btn-foil-toggle-compact {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  line-height: 1;
+}
+
 /* Rendered as a centered modal (shown/hidden via the shared backdrop in
    base.html) rather than anchored to the triggering button, so it's never
    squished/clipped by narrow card tiles or the Finished Decks stacked
@@ -7617,7 +7763,9 @@ footer.site-footer {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: 301;
+  /* Must stay above .modal (z-index: 1000) so the picker still shows in
+     front when opened from inside the New Deck modal / builder modals. */
+  z-index: 1101;
   background: var(--panel, #1a1f2e);
   border: 1px solid var(--border, #333);
   border-radius: 10px;
@@ -7632,7 +7780,7 @@ footer.site-footer {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, .6);
-  z-index: 300;
+  z-index: 1100;
 }
 
 body.printing-modal-open .printing-modal-backdrop {
@@ -7702,6 +7850,25 @@ body.printing-modal-open .printing-modal-backdrop {
   display: block;
 }
 
+.printing-option-thumb-wrap {
+  position: relative;
+  display: block;
+}
+
+.printing-option-foil-badge {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  background: linear-gradient(135deg, #f0abfc, #60a5fa, #facc15);
+  color: #0f1115;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: .03em;
+  padding: 1px 5px;
+  border-radius: 4px;
+  line-height: 1.3;
+}
+
 .printing-option-label {
   font-size: 10px;
   color: var(--muted, #94a3b8);
@@ -7713,6 +7880,15 @@ body.printing-modal-open .printing-modal-backdrop {
   font-size: 11px;
   font-weight: 600;
   color: var(--text);
+}
+
+.printing-option-price-foil {
+  font-size: 10px;
+  font-weight: 600;
+  background: linear-gradient(135deg, #f0abfc, #60a5fa, #facc15);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
 }
 
 .printing-option-default {

--- a/code/web/static/tailwind.css
+++ b/code/web/static/tailwind.css
@@ -1108,6 +1108,60 @@ img.lqip.loaded { filter: blur(0); opacity: 1; }
 	white-space: nowrap;
 }
 
+.tag-clickable {
+	text-decoration: none;
+	cursor: pointer;
+}
+
+.tag-clickable:hover {
+	background: rgba(148, 163, 184, 0.3);
+}
+
+/* Wraps a `.mana` pip in an `<a>` so color dots stay clickable filters
+   without disturbing the existing dot styling/sizing. */
+.mana-link {
+	display: inline-flex;
+	text-decoration: none;
+	cursor: pointer;
+}
+
+/* Guild/shard/wedge/nephilim name badges shown alongside the mana pips
+   on card browser and owned library tiles; clicking applies a color filter. */
+.tile-color-names {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 0.25rem;
+	margin-top: 0.15rem;
+}
+
+.tile-color-name-badge {
+	font-size: 0.7rem;
+	padding: 0.1rem 0.35rem;
+	border-radius: 3px;
+	text-decoration: none;
+	white-space: nowrap;
+	cursor: pointer;
+}
+
+.tile-color-name-primary {
+	background: rgba(59, 130, 246, 0.15);
+	color: var(--primary);
+	font-weight: 500;
+}
+
+.tile-color-name-primary:hover {
+	background: rgba(59, 130, 246, 0.3);
+}
+
+.tile-color-name-sub {
+	background: rgba(148, 163, 184, 0.12);
+	color: var(--muted);
+}
+
+.tile-color-name-sub:hover {
+	background: rgba(148, 163, 184, 0.25);
+}
+
 /* Card Details button on tiles */
 .card-details-btn {
 	display: inline-flex;
@@ -1137,16 +1191,9 @@ img.lqip.loaded { filter: blur(0); opacity: 1; }
 	flex-shrink: 0;
 }
 
-/* Printing picker row on browse tiles */
-.card-tile-printing-row {
-	margin-top: 0.35rem;
-}
-
-.card-tile-printing-row .btn-printing {
-	font-size: 0.8rem;
-	padding: 0.35rem 0.6rem;
-}
-
+/* Printing picker row on browse tiles -- overlaid on the card image itself
+   (see the tile templates' inline position:absolute), not a flow row below
+   it, so both buttons stay compact icons rather than full-width labels. */
 .card-detail-printing-row {
 	margin-top: 0.6rem;
 	text-align: center;
@@ -1796,6 +1843,52 @@ img.lqip.loaded { filter: blur(0); opacity: 1; }
 	width: 100%;
 	height: auto;
 	border-radius: 12px;
+}
+
+/* Wraps only the card detail page's main <img> (not the printing/foil
+   buttons row below it), so the `.card-foil-shine::after` overlay -- which
+   fills its host's full bounds -- can't bleed onto those buttons. */
+.card-image-shine-wrap {
+	border-radius: 12px;
+}
+
+/* Opt-in marker for "this element safely wraps ONLY a card image (and its
+   overlaid badges/buttons), nothing else" -- see base.html's foil-shimmer
+   pass, which toggles `.card-foil-shine` on the nearest ancestor carrying
+   this class. Every card thumbnail/preview across the site that supports
+   the foil toggle should carry it, so the shimmer works everywhere a card
+   can be marked foil. A sensible default radius so the shine's rounded
+   corners (border-radius: inherit) look right even on hosts that don't set
+   their own; hosts that already do (e.g. `.stack-card`) are unaffected. */
+.foil-shine-target {
+	border-radius: 8px;
+}
+
+/* Diagonal rainbow overlay shown on a card image (browser detail page,
+   saved-deck view commander/card thumbnails) while its foil finish is the
+   effective one (toggled on, or forced for a foil-only printing) -- a
+   lightweight, static CSS approximation of a foil card's rainbow sheen,
+   since Scryfall doesn't serve a visually distinct image for foil prints.
+   Intentionally NOT animated: an earlier animated version visibly
+   jump-cut back to its start position at the end of every loop.
+   `border-radius: inherit` so it matches whatever host element it's
+   toggled onto (card-image-shine-wrap, commander-card, stack-card, etc.)
+   instead of a single hardcoded radius. */
+.card-foil-shine::after {
+	content: '';
+	position: absolute;
+	inset: 0;
+	pointer-events: none;
+	border-radius: inherit;
+	background: repeating-linear-gradient(115deg,
+		rgba(255, 90, 130, .12) 0px,
+		rgba(255, 200, 70, .1) 20px,
+		rgba(140, 255, 120, .1) 40px,
+		rgba(80, 210, 255, .11) 60px,
+		rgba(160, 110, 255, .12) 80px,
+		rgba(255, 100, 200, .11) 100px,
+		rgba(255, 90, 130, .12) 120px);
+	mix-blend-mode: overlay;
 }
 
 /* ============================================
@@ -4524,6 +4617,17 @@ footer.site-footer {
 }
 .card-price-overlay:empty { display: none; }
 
+/* Small sparkle tag appended to a price when it's actually a foil price
+   (either the user explicitly requested foil, or a specific foil-only
+   printing has no nonfoil price to fall back to). */
+.price-foil-tag {
+  background: linear-gradient(135deg, #f0abfc, #60a5fa, #facc15);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  font-weight: 700;
+}
+
 /* "Owned" badge on card thumbnails — top-right, green pill */
 .card-owned-badge {
   position: absolute;
@@ -4903,6 +5007,36 @@ footer.site-footer {
   background: rgba(15, 17, 21, .8);
 }
 .printing-panel:empty { display: none; }
+/* Foil toggle button (mirrors .btn-printing sizing/placement) */
+.btn-foil-toggle {
+  background: rgba(15, 17, 21, .8);
+  border: 1px solid var(--border, #333);
+  color: var(--muted, #b6b8bd);
+}
+.btn-foil-toggle:hover {
+  border-color: #facc15;
+  color: #facc15;
+}
+.btn-foil-toggle.active {
+  border-color: #facc15;
+  background: linear-gradient(135deg, rgba(240, 171, 252, .25), rgba(96, 165, 250, .25), rgba(250, 204, 21, .25));
+  color: #facc15;
+}
+.btn-foil-toggle:disabled {
+  cursor: default;
+  opacity: 0.9;
+}
+.btn-foil-toggle-compact {
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  line-height: 1;
+}
 /* Rendered as a centered modal (shown/hidden via the shared backdrop in
    base.html) rather than anchored to the triggering button, so it's never
    squished/clipped by narrow card tiles or the Finished Decks stacked
@@ -4912,7 +5046,9 @@ footer.site-footer {
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  z-index: 301;
+  /* Must stay above .modal (z-index: 1000) so the picker still shows in
+     front when opened from inside the New Deck modal / builder modals. */
+  z-index: 1101;
   background: var(--panel, #1a1f2e);
   border: 1px solid var(--border, #333);
   border-radius: 10px;
@@ -4926,7 +5062,7 @@ footer.site-footer {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, .6);
-  z-index: 300;
+  z-index: 1100;
 }
 body.printing-modal-open .printing-modal-backdrop { display: block; }
 .printing-picker-header {
@@ -4969,6 +5105,20 @@ body.printing-modal-open .printing-modal-backdrop { display: block; }
 .printing-option:hover { border-color: var(--blue-main, #3b82f6); }
 .printing-option.selected { border-color: #34d399; box-shadow: 0 0 0 1px #34d399 inset; }
 .printing-option img { width: 110px; border-radius: 4px; display: block; }
+.printing-option-thumb-wrap { position: relative; display: block; }
+.printing-option-foil-badge {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  background: linear-gradient(135deg, #f0abfc, #60a5fa, #facc15);
+  color: #0f1115;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: .03em;
+  padding: 1px 5px;
+  border-radius: 4px;
+  line-height: 1.3;
+}
 .printing-option-label {
   font-size: 10px;
   color: var(--muted, #94a3b8);
@@ -4979,6 +5129,14 @@ body.printing-modal-open .printing-modal-backdrop { display: block; }
   font-size: 11px;
   font-weight: 600;
   color: var(--text);
+}
+.printing-option-price-foil {
+  font-size: 10px;
+  font-weight: 600;
+  background: linear-gradient(135deg, #f0abfc, #60a5fa, #facc15);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
 }
 .printing-option-default {
   justify-content: center;

--- a/code/web/templates/base.html
+++ b/code/web/templates/base.html
@@ -482,20 +482,27 @@
     window._priceNum = _priceNum;  // expose for cardHover.js
     var _deckPrices = {}; // accumulated across build stages: card name -> float
     var _buildToken = null;
-    function _fetchNum(name, printingId) {
-      var key = printingId ? (name + '::' + printingId) : name;
+    function _priceKey(name, printingId, foil) {
+      return name + '::' + (printingId || '') + '::' + (foil ? '1' : '0');
+    }
+    function _fetchNum(name, printingId, foil) {
+      var key = _priceKey(name, printingId, foil);
       if (_priceNum.hasOwnProperty(key)) return Promise.resolve(_priceNum[key]);
       var url = '/api/price/' + encodeURIComponent(name);
-      if (printingId) url += '?printing=' + encodeURIComponent(printingId);
+      var params = [];
+      if (printingId) params.push('printing=' + encodeURIComponent(printingId));
+      if (foil) params.push('foil=1');
+      if (params.length) url += '?' + params.join('&');
       return fetch(url)
         .then(function(r){ return r.ok ? r.json() : null; })
         .then(function(d){
           var obj = {
             tcg: (d && d.found && d.price != null) ? parseFloat(d.price) : null,
             ck: (d && d.ck_price != null) ? parseFloat(d.ck_price) : null,
+            foil: !!(d && d.foil),
           };
           _priceNum[key] = obj; return obj;
-        }).catch(function(){ var obj = {tcg:null,ck:null}; _priceNum[key] = obj; return obj; });
+        }).catch(function(){ var obj = {tcg:null,ck:null,foil:false}; _priceNum[key] = obj; return obj; });
     }
     function _getBuildToken() {
       var el = document.querySelector('[data-build-id]');
@@ -528,13 +535,28 @@
 
       var overlays = document.querySelectorAll('.card-price-overlay[data-price-for]');
       var inlines = document.querySelectorAll('.card-price-inline[data-price-for]');
-      var toFetch = new Map(); // fetchKey -> {name, printingId}
+      // Foil shimmer: mirrors each foil-toggle button's own `data-is-foil`
+      // state onto the nearest `.foil-shine-target`-marked image wrapper
+      // (opted into explicitly per-template, since a shine host must wrap
+      // ONLY the card image -- never anything else -- to avoid the effect
+      // bleeding onto sibling buttons/text) via `.card-foil-shine`. Driven
+      // by the button rather than the price overlay so this also covers
+      // spots with no price display at all (e.g. the owned library). The
+      // card detail page's image wrapper toggles this class itself (needs
+      // extra has-foil-printing gating this generic pass doesn't do), so
+      // it deliberately isn't marked `.foil-shine-target`.
+      document.querySelectorAll('.btn-foil-toggle[data-is-foil]').forEach(function(btn){
+        var shineHost = btn.closest('.foil-shine-target');
+        if (shineHost) shineHost.classList.toggle('card-foil-shine', btn.dataset.isFoil === '1');
+      });
+      var toFetch = new Map(); // fetchKey -> {name, printingId, foil}
       function _queue(el){
         var n = el.dataset.priceFor;
         if (!n || BASIC_LANDS.has(n)) return;
         var pid = el.dataset.printingId || '';
-        var fetchKey = pid ? (n + '::' + pid) : n;
-        toFetch.set(fetchKey, {name: n, printingId: pid});
+        var foil = el.dataset.foil === '1';
+        var fetchKey = _priceKey(n, pid, foil);
+        toFetch.set(fetchKey, {name: n, printingId: pid, foil: foil});
       }
       overlays.forEach(_queue);
       inlines.forEach(_queue);
@@ -545,7 +567,7 @@
 
       var prevTotal = Object.values(_deckPrices).reduce(function(s,p){ return s + (p||0); }, 0);
       var promises = [];
-      toFetch.forEach(function(entry, fetchKey){ promises.push(_fetchNum(entry.name, entry.printingId).then(function(obj){ return {fetchKey:fetchKey,name:entry.name,price:obj}; })); });
+      toFetch.forEach(function(entry, fetchKey){ promises.push(_fetchNum(entry.name, entry.printingId, entry.foil).then(function(obj){ return {fetchKey:fetchKey,name:entry.name,price:obj}; })); });
       Promise.all(promises).then(function(results){
         var map = {};
         var prevTotal2 = Object.values(_deckPrices).reduce(function(s,p){ return s + (p||0); }, 0);
@@ -554,12 +576,13 @@
           var name = el.dataset.priceFor;
           if (!name || BASIC_LANDS.has(name)) { el.style.display='none'; return; }
           var pid = el.dataset.printingId || '';
-          var obj = map[pid ? (name + '::' + pid) : name];
+          var obj = map[_priceKey(name, pid, el.dataset.foil === '1')];
           var tcg = obj ? obj.tcg : null;
           var ck = obj ? obj.ck : null;
+          var foilTag = (obj && obj.foil) ? ' <span class="price-foil-tag" title="Foil price">&#10024;</span>' : '';
           if (tcg !== null || ck !== null) {
             var parts = [];
-            if (tcg !== null) parts.push('<span class="price-src-label">TCG</span> $' + tcg.toFixed(2));
+            if (tcg !== null) parts.push('<span class="price-src-label">TCG</span> $' + tcg.toFixed(2) + foilTag);
             if (ck !== null) parts.push('<span class="price-src-label">CK</span> $' + ck.toFixed(2));
             el.innerHTML = parts.join('<br>');
           } else { el.innerHTML = ''; }
@@ -572,12 +595,13 @@
           var name = el.dataset.priceFor;
           if (!name || BASIC_LANDS.has(name)) { el.style.display='none'; return; }
           var pid = el.dataset.printingId || '';
-          var obj = map[pid ? (name + '::' + pid) : name];
+          var obj = map[_priceKey(name, pid, el.dataset.foil === '1')];
           var tcg = obj ? obj.tcg : null;
           var ck = obj ? obj.ck : null;
+          var foilTag = (obj && obj.foil) ? ' <span class="price-foil-tag" title="Foil price">&#10024;</span>' : '';
           if (tcg !== null || ck !== null) {
             var parts = [];
-            if (tcg !== null) parts.push('<span class="price-src-label">TCG</span> $' + tcg.toFixed(2));
+            if (tcg !== null) parts.push('<span class="price-src-label">TCG</span> $' + tcg.toFixed(2) + foilTag);
             if (ck !== null) parts.push('<span class="price-src-label">CK</span> $' + ck.toFixed(2));
             el.innerHTML = parts.join(' <span class="price-sep">·</span> ');
           } else { el.innerHTML = ''; }
@@ -598,7 +622,7 @@
             if (n && !BASIC_LANDS.has(n) && !allNames.has(n)) {
               allNames.add(n);
               var pid = el.dataset.printingId || '';
-              var obj = map[pid ? (n + '::' + pid) : n];
+              var obj = map[_priceKey(n, pid, el.dataset.foil === '1')];
               sumTotal += (obj ? (obj.tcg || 0) : 0);
             }
           });

--- a/code/web/templates/browse/cards/_card_grid.html
+++ b/code/web/templates/browse/cards/_card_grid.html
@@ -9,7 +9,7 @@
   <button 
     type="button"
     class="btn"
-    hx-get="/cards/grid?cursor={{ last_card|urlencode }}{% if search %}&search={{ search|urlencode }}{% endif %}{% for theme in themes %}&themes={{ theme|urlencode }}{% endfor %}{% if color %}&color={{ color|urlencode }}{% endif %}{% if card_type %}&card_type={{ card_type|urlencode }}{% endif %}{% if rarity %}&rarity={{ rarity|urlencode }}{% endif %}{% if sort and sort != 'name_asc' %}&sort={{ sort|urlencode }}{% endif %}{% if cmc_min %}&cmc_min={{ cmc_min }}{% endif %}{% if cmc_max %}&cmc_max={{ cmc_max }}{% endif %}{% if power_min %}&power_min={{ power_min }}{% endif %}{% if power_max %}&power_max={{ power_max }}{% endif %}{% if tough_min %}&tough_min={{ tough_min }}{% endif %}{% if tough_max %}&tough_max={{ tough_max }}{% endif %}"
+    hx-get="/cards/grid?cursor={{ last_card|urlencode }}{% if search %}&search={{ search|urlencode }}{% endif %}{% for theme in themes %}&themes={{ theme|urlencode }}{% endfor %}{% if color %}&color={{ color|urlencode }}{% endif %}{% if color_mode == 'inclusive' %}&color_mode=inclusive{% endif %}{% if card_type %}&card_type={{ card_type|urlencode }}{% endif %}{% if rarity %}&rarity={{ rarity|urlencode }}{% endif %}{% if sort and sort != 'name_asc' %}&sort={{ sort|urlencode }}{% endif %}{% if cmc_min %}&cmc_min={{ cmc_min }}{% endif %}{% if cmc_max %}&cmc_max={{ cmc_max }}{% endif %}{% if power_min %}&power_min={{ power_min }}{% endif %}{% if power_max %}&power_max={{ power_max }}{% endif %}{% if tough_min %}&tough_min={{ tough_min }}{% endif %}{% if tough_max %}&tough_max={{ tough_max }}{% endif %}"
     hx-target="#card-grid"
     hx-swap="beforeend"
     hx-indicator="#load-indicator">

--- a/code/web/templates/browse/cards/_card_tile.html
+++ b/code/web/templates/browse/cards/_card_tile.html
@@ -1,13 +1,19 @@
 {# Single card tile for grid display #}
-{% from 'partials/_macros.html' import printing_button %}
+{% from 'partials/_macros.html' import printing_button, foil_toggle_button %}
 {% set sel_printing = (printings.get(card.name.lower(), '') if printings is defined else '') %}
+{% set is_foil = (foils.get(card.name.lower(), False) if foils is defined else False) %}
 {% set card_idx = card.name|slugify %}
 <div class="card-browser-tile card-tile" 
      data-card-name="{{ card.name }}" 
      data-tags="{{ card.themeTags_parsed|join(', ') if card.themeTags_parsed else '' }}"
-     {% if card.layout %}data-layout="{{ card.layout }}"{% endif %}>
+     {% if card.layout %}data-layout="{{ card.layout }}"{% endif %}
+     {% if enable_card_details %}
+     role="button" tabindex="0"
+     onclick="window.location.href='/cards/{{ card.name|urlencode }}';"
+     onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault(); window.location.href='/cards/{{ card.name|urlencode }}';}"
+     {% endif %}>
   {# Card image (uses hover system for preview) #}
-  <div class="card-browser-tile-image">
+  <div class="card-browser-tile-image foil-shine-target{% if is_foil %} card-foil-shine{% endif %}">
     <img 
       id="card-img-{{ card_idx }}"
       loading="lazy" 
@@ -24,7 +30,7 @@
     </div>
     
     {# Price overlay #}
-    <div class="card-price-overlay" id="price-overlay-{{ card_idx }}" data-price-for="{{ card.name }}" data-printing-id="{{ sel_printing }}" aria-hidden="true"></div>
+    <div class="card-price-overlay" id="price-overlay-{{ card_idx }}" data-price-for="{{ card.name }}" data-printing-id="{{ sel_printing }}" data-foil="{{ '1' if is_foil else '0' }}" aria-hidden="true"></div>
 
     {# Reprint badge — lower-right; shifts up when New badge is also present #}
     {% if card.isReprint %}
@@ -40,6 +46,15 @@
     {% if card.is_owned %}
     <div class="card-owned-badge">✓ Owned</div>
     {% endif %}
+
+    {# Printing/foil controls — overlaid on the image itself (bottom-left)
+       so the foil-shine toggle JS (which looks for the nearest
+       `.foil-shine-target` ancestor) can find this wrapper, and for visual
+       consistency with every other card surface's on-image controls. #}
+    <div class="card-tile-printing-row" style="position:absolute; bottom:4px; left:4px; z-index:5;" onclick="event.stopPropagation()">
+      {{ printing_button(card.name, card_idx, sel_printing, compact=True) }}
+      {{ foil_toggle_button(card.name, card_idx, is_foil, compact=True) }}
+    </div>
   </div>
 
   {# Card info #}
@@ -64,36 +79,42 @@
       
       {% if card.is_colorless %}
       <div class="tile-pips">
-        <span class="mana mana-C" title="Colorless"></span>
+        <a href="/cards?color=C" class="mana-link" onclick="event.stopPropagation()" title="Colorless">
+          <span class="mana mana-C"></span>
+        </a>
       </div>
       {% elif card.colorIdentity %}
       <div class="tile-pips">
-        {% set ci_list = card.colorIdentity.replace(' ', '').split(',') if card.colorIdentity is string else card.colorIdentity %}
-        {% for c in ci_list %}{% if c %}<span class="mana mana-{{ c }}" title="{{ c }}"></span>{% endif %}{% endfor %}
+        {% set ci_list = card.color_badges.dots if card.color_badges is defined and card.color_badges.dots else (card.colorIdentity.replace(' ', '').split(',') if card.colorIdentity is string else card.colorIdentity) %}
+        {% for c in ci_list %}{% if c %}<a href="/cards?color={{ c }}{% if color_mode == 'inclusive' %}&color_mode=inclusive{% endif %}" class="mana-link" onclick="event.stopPropagation()" title="{{ c }}"><span class="mana mana-{{ c }}"></span></a>{% endif %}{% endfor %}
       </div>
       {% endif %}
     </div>
 
-    {# Card Details button (only show if feature enabled) #}
-    {% if enable_card_details %}
-    <a href="/cards/{{ card.name|urlencode }}" class="card-details-btn" onclick="event.stopPropagation()">
-      Card Details
-      <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
-        <path d="M8.707 3.293a1 1 0 010 1.414L5.414 8l3.293 3.293a1 1 0 01-1.414 1.414l-4-4a1 1 0 010-1.414l4-4a1 1 0 011.414 0z" transform="rotate(180 8 8)"/>
-      </svg>
-    </a>
+    {# Color identity name(s) — guild/shard/wedge/nephilim, clickable filters.
+       Cards with sub-badges (3-color shards/wedges) default their badge
+       clicks to inclusive matching, since an exact click otherwise excludes
+       the very card being clicked from the results (e.g. "Azorius" on a
+       Bant card wouldn't show Bant cards under exact WU matching). #}
+    {% if card.color_badges is defined and (card.color_badges.primary or card.color_badges.subs) %}
+    {% set badge_inclusive = color_mode == 'inclusive' or (card.color_badges.subs and card.color_badges.subs|length > 0) %}
+    <div class="tile-color-names">
+      {% if card.color_badges.primary %}
+      <a href="/cards?color={{ card.color_badges.primary.filter }}{% if badge_inclusive %}&color_mode=inclusive{% endif %}" class="tile-color-name-badge tile-color-name-primary" onclick="event.stopPropagation()">{{ card.color_badges.primary.name }}</a>
+      {% endif %}
+      {% for sub in card.color_badges.subs %}
+      <a href="/cards?color={{ sub.filter }}{% if badge_inclusive %}&color_mode=inclusive{% endif %}" class="tile-color-name-badge tile-color-name-sub" onclick="event.stopPropagation()">{{ sub.name }}</a>
+      {% endfor %}
+    </div>
     {% endif %}
 
-    {# Printing picker #}
-    <div class="card-tile-printing-row" onclick="event.stopPropagation()">
-      {{ printing_button(card.name, card_idx, sel_printing) }}
-    </div>
+
 
     {# Theme tags (show all tags, not truncated) #}
     {% if card.themeTags_parsed and card.themeTags_parsed|length > 0 %}
     <div class="card-browser-tile-tags">
       {% for tag in card.themeTags_parsed %}
-      <span class="tag">{{ tag }}</span>
+      <a href="/cards?themes={{ tag|urlencode }}" class="tag tag-clickable" onclick="event.stopPropagation()">{{ tag }}</a>
       {% endfor %}
     </div>
     {% endif %}

--- a/code/web/templates/browse/cards/detail.html
+++ b/code/web/templates/browse/cards/detail.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% from 'partials/_macros.html' import printing_button %}
+{% from 'partials/_macros.html' import printing_button, foil_toggle_button %}
 
 {% block title %}{{ card.name }} - Card Details{% endblock %}
 
@@ -18,22 +18,34 @@
 
         <!-- ── LEFT TOP: Card Image ───────────────────────────── -->
         {% set sel_printing = (printings.get(card.name.lower(), '') if printings is defined else '') %}
+        {% set is_foil = (foils.get(card.name.lower(), False) if foils is defined else False) %}
         {% set card_idx = card.name|slugify %}
+        {% set has_faces = faces is defined and faces and faces|length > 1 %}
+        {% set back_face = faces[1] if has_faces else None %}
         <div class="card-area-image card-image-large" style="position:relative;">
-            <img id="card-img-{{ card_idx }}"
-                 src="{{ card.name|card_image('normal', sel_printing) }}"
-                 alt="{{ card.name }}"
-                 loading="lazy"
-                 onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
-            <div style="display:none; width:100%; height:500px; align-items:center; justify-content:center; background:#1a1d24; color:#9ca3af; font-size:18px; padding:2rem; text-align:center; border-radius:12px;">
-                {{ card.name }}
+            <div class="card-image-shine-wrap" style="position:relative;">
+                <img id="card-img-{{ card_idx }}"
+                     src="{{ card.name|card_image('normal', sel_printing) }}"
+                     alt="{{ card.name }}"
+                     loading="lazy"
+                     data-current-face="front"
+                     data-front-src="{{ card.name|card_image('normal', sel_printing) }}"
+                     {% if has_faces %}data-back-src="/api/images/normal/{{ back_face.name|urlencode }}?face=back{% if sel_printing %}&printing={{ sel_printing }}{% endif %}"{% endif %}
+                     onerror="this.style.display='none'; this.nextElementSibling.style.display='flex';">
+                <div style="display:none; width:100%; height:500px; align-items:center; justify-content:center; background:#1a1d24; color:#9ca3af; font-size:18px; padding:2rem; text-align:center; border-radius:12px;">
+                    {{ card.name }}
+                </div>
+                {% if show_new_badge and card.isNew %}
+                <div class="card-new-badge" title="Recently Released" aria-hidden="true">New</div>
+                {% endif %}
+                <div id="price-overlay-{{ card_idx }}" class="card-price-overlay" data-price-for="{{ card.name }}" data-printing-id="{{ sel_printing }}" data-foil="{{ '1' if is_foil else '0' }}" style="display:none" aria-hidden="true"></div>
             </div>
-            {% if show_new_badge and card.isNew %}
-            <div class="card-new-badge" title="Recently Released" aria-hidden="true">New</div>
-            {% endif %}
-            <div id="price-overlay-{{ card_idx }}" class="card-price-overlay" data-price-for="{{ card.name }}" data-printing-id="{{ sel_printing }}" style="display:none" aria-hidden="true"></div>
             <div class="card-detail-printing-row">
               {{ printing_button(card.name, card_idx, sel_printing) }}
+              {{ foil_toggle_button(card.name, card_idx, is_foil) }}
+              {% if has_faces %}
+              <button type="button" id="dfc-transform-btn" class="ext-link-btn" onclick="dfcToggleFace()" aria-pressed="false">⥮ Transform</button>
+              {% endif %}
             </div>
         </div>
 
@@ -106,6 +118,35 @@
             <div class="card-text" style="white-space: pre-line;">{{ card.text | replace('\\n', '\n') }}</div>
             {% endif %}
 
+            {% if has_faces %}
+            {% set back_type_parts = back_face.type.split(' — ') if back_face.type else [] %}
+            <p class="cd-section-heading" style="margin-top:1rem;">Back Face: {{ back_face.name }}</p>
+            {% if back_face.manaCost %}
+            <div class="card-mana-cost">{{ back_face.manaCost }}</div>
+            {% endif %}
+            <table class="card-stats-table">
+                {% if back_type_parts|length > 1 %}
+                <tr>
+                    <th>{{ back_type_parts[0] }}</th>
+                    <td>{{ back_type_parts[1] }}</td>
+                </tr>
+                {% elif back_face.type %}
+                <tr>
+                    <th colspan="2">{{ back_face.type }}</th>
+                </tr>
+                {% endif %}
+                {% if back_face.power is not none and back_face.power|string != '' and back_face.power|string != 'nan' %}
+                <tr>
+                    <th>Power / Toughness</th>
+                    <td>{{ back_face.power }} / {{ back_face.toughness }}</td>
+                </tr>
+                {% endif %}
+            </table>
+            {% if back_face.text %}
+            <div class="card-text" style="white-space: pre-line;">{{ back_face.text | replace('\\n', '\n') }}</div>
+            {% endif %}
+            {% endif %}
+
             <!-- Theme Tags -->
             {% if card.themeTags_parsed and card.themeTags_parsed|length > 0 %}
             <p class="cd-section-heading" style="margin-top:1rem;">Themes</p>
@@ -156,44 +197,126 @@
 </div>
 
 <script>
+{% if has_faces %}
+// Double-faced card front/back image toggle ("Transform" button). Both
+// faces' text/stats are always shown below (see the Back Face section),
+// so this only needs to swap the card image itself.
+(function(){
+    window.dfcToggleFace = function(){
+        var img = document.getElementById('card-img-{{ card_idx }}');
+        if (!img) return;
+        var current = img.getAttribute('data-current-face') || 'front';
+        var next = current === 'front' ? 'back' : 'front';
+        var src = next === 'back' ? img.getAttribute('data-back-src') : img.getAttribute('data-front-src');
+        if (!src) return;
+        img.src = src;
+        img.setAttribute('data-current-face', next);
+        var btn = document.getElementById('dfc-transform-btn');
+        if (btn) {
+            btn.setAttribute('aria-pressed', next === 'back' ? 'true' : 'false');
+            btn.setAttribute('aria-label', next === 'back' ? 'Show front face' : 'Show back face');
+        }
+    };
+})();
+{% endif %}
 // Price loader
 (function(){
     var name = {{ card.name | tojson }};
     var overlayId = 'price-overlay-{{ card_idx }}';
-    function loadPrice(printingId){
-        var url = '/api/price/' + encodeURIComponent(name);
-        if (printingId) url += '?printing=' + encodeURIComponent(printingId);
-        fetch(url)
-            .then(function(r){ return r.ok ? r.json() : null; })
-            .then(function(d){
-                var el = document.getElementById('card-price-values');
-                if (!el) return;
-                if (!d || (d.price == null && d.ck_price == null)) {
-                    el.innerHTML = '<span class="card-price-loading">No price data available.</span>';
-                    return;
-                }
-                var html = '';
-                if (d.price != null) {
-                    html += '<div class="card-price-row"><span class="card-price-source">TCG</span><span class="card-price-amount">$' + parseFloat(d.price).toFixed(2) + '</span></div>';
-                }
-                if (d.ck_price != null) {
-                    html += '<div class="card-price-row"><span class="card-price-source">CK</span><span class="card-price-amount">$' + parseFloat(d.ck_price).toFixed(2) + '</span></div>';
-                }
-                el.innerHTML = html;
-            })
-            .catch(function(){
-                var el = document.getElementById('card-price-values');
-                if (el) el.innerHTML = '<span class="card-price-loading">Unavailable.</span>';
-            });
+
+    function foilBtn(){ return document.querySelector('.card-detail-printing-row .btn-foil-toggle'); }
+    function imgWrap(){ return document.querySelector('.card-image-shine-wrap'); }
+
+    // Lightweight CSS shimmer approximating a foil card's shifting sheen
+    // (Scryfall doesn't serve a visually distinct image for foil prints),
+    // shown on the card image while its foil finish is the effective one.
+    function applyShine(active){
+        var wrap = imgWrap();
+        if (wrap) wrap.classList.toggle('card-foil-shine', !!active);
+    }
+
+    // Shows/hides/disables the foil toggle based on whether the currently
+    // selected printing actually has each finish: hidden entirely if it has
+    // no foil version at all, forced-on-and-locked if it's foil-only (no
+    // nonfoil to fall back to), otherwise a normal enabled toggle.
+    function updateFoilAvailability(hasFoil, hasNonfoil, requestedFoil){
+        var btn = foilBtn();
+        if (!btn) return;
+        if (!hasFoil) {
+            btn.style.display = 'none';
+            applyShine(false);
+            return;
+        }
+        btn.style.display = '';
+        if (!hasNonfoil) {
+            btn.disabled = true;
+            btn.classList.add('active');
+            btn.setAttribute('aria-pressed', 'true');
+            btn.title = 'This printing is only available in foil.';
+            applyShine(true);
+        } else {
+            btn.disabled = false;
+            btn.title = requestedFoil ? 'Use the nonfoil price/finish' : 'Use the foil price/finish';
+            applyShine(requestedFoil);
+        }
+    }
+
+    function loadPrice(printingId, requestedFoil){
+        var base = '/api/price/' + encodeURIComponent(name);
+        var qp = printingId ? ('printing=' + encodeURIComponent(printingId)) : '';
+        var nonfoilUrl = base + (qp ? '?' + qp : '');
+        var foilUrl = base + '?' + (qp ? qp + '&' : '') + 'foil=1';
+        Promise.all([
+            fetch(nonfoilUrl).then(function(r){ return r.ok ? r.json() : null; }).catch(function(){ return null; }),
+            fetch(foilUrl).then(function(r){ return r.ok ? r.json() : null; }).catch(function(){ return null; }),
+        ]).then(function(results){
+            var dNonfoil = results[0], dFoil = results[1];
+            // The API always falls back to whichever finish the printing
+            // actually has price data for, and reports that in `foil` --
+            // so comparing the two responses' `foil` flags tells us which
+            // finish(es) genuinely exist for this printing.
+            var hasNonfoil = !!(dNonfoil && dNonfoil.price != null && dNonfoil.foil === false);
+            var hasFoil = !!(dFoil && dFoil.price != null && dFoil.foil === true);
+            var nonfoilPrice = hasNonfoil ? dNonfoil.price : null;
+            var foilPrice = hasFoil ? dFoil.price : null;
+            var ckPrice = (dNonfoil && dNonfoil.ck_price != null) ? dNonfoil.ck_price
+                : (dFoil && dFoil.ck_price != null ? dFoil.ck_price : null);
+
+            updateFoilAvailability(hasFoil, hasNonfoil, !!requestedFoil);
+
+            var el = document.getElementById('card-price-values');
+            if (!el) return;
+            if (nonfoilPrice == null && foilPrice == null && ckPrice == null) {
+                el.innerHTML = '<span class="card-price-loading">No price data available.</span>';
+                return;
+            }
+            var html = '';
+            if (nonfoilPrice != null || foilPrice != null) {
+                var tcgParts = [];
+                if (nonfoilPrice != null) tcgParts.push('$' + parseFloat(nonfoilPrice).toFixed(2));
+                if (foilPrice != null) tcgParts.push('<span class="price-foil-tag" title="Foil price">&#10024;</span> $' + parseFloat(foilPrice).toFixed(2));
+                html += '<div class="card-price-row"><span class="card-price-source">TCG</span><span class="card-price-amount">' + tcgParts.join(' <span class="price-sep">/</span> ') + '</span></div>';
+            }
+            if (ckPrice != null) {
+                html += '<div class="card-price-row"><span class="card-price-source">CK</span><span class="card-price-amount">$' + parseFloat(ckPrice).toFixed(2) + '</span></div>';
+            }
+            el.innerHTML = html;
+        })
+        .catch(function(){
+            var el = document.getElementById('card-price-values');
+            if (el) el.innerHTML = '<span class="card-price-loading">Unavailable.</span>';
+        });
     }
     var overlayEl = document.getElementById(overlayId);
-    loadPrice(overlayEl ? overlayEl.dataset.printingId : '');
+    loadPrice(overlayEl ? overlayEl.dataset.printingId : '', overlayEl && overlayEl.dataset.foil === '1');
     // The printing picker's OOB response updates #price-overlay-{idx}'s
-    // data-printing-id when a different printing is chosen; refresh this
-    // page's price panel to match instead of the generic overlay markup.
+    // data-printing-id when a different printing is chosen (and the foil
+    // toggle's OOB response updates its data-foil when toggled); refresh
+    // this page's price panel and foil UI to match instead of the generic
+    // overlay markup.
     document.body.addEventListener('htmx:afterSwap', function(ev){
         if (ev.target && ev.target.id === overlayId) {
-            loadPrice(ev.target.dataset.printingId || '');
+            loadPrice(ev.target.dataset.printingId || '', ev.target.dataset.foil === '1');
         }
     });
 })();

--- a/code/web/templates/browse/cards/index.html
+++ b/code/web/templates/browse/cards/index.html
@@ -196,6 +196,11 @@
             </optgroup>
           {% endfor %}
         </select>
+        <label style="display:flex; align-items:center; gap:0.35rem; cursor:pointer; white-space:nowrap; font-size:0.85rem;" title="Exact: only that color combination. Inclusive: also matches cards with additional colors (e.g. WU also matches Bant, Esper, Jeskai).">
+          <input type="checkbox" id="filter-color-inclusive" onchange="applyFilter()"
+                 {% if color_mode == 'inclusive' %}checked{% endif %} />
+          Inclusive match
+        </label>
         {% endif %}
 
         {# Type filter #}
@@ -374,7 +379,7 @@
     <button 
       type="button"
       class="btn"
-      hx-get="/cards/grid?cursor={{ last_card|urlencode }}{% if search %}&search={{ search|urlencode }}{% endif %}{% for theme in themes %}&themes={{ theme|urlencode }}{% endfor %}{% if color %}&color={{ color|urlencode }}{% endif %}{% if card_type %}&card_type={{ card_type|urlencode }}{% endif %}{% if rarity %}&rarity={{ rarity|urlencode }}{% endif %}{% if sort and sort != 'name_asc' %}&sort={{ sort|urlencode }}{% endif %}{% if cmc_min %}&cmc_min={{ cmc_min }}{% endif %}{% if cmc_max %}&cmc_max={{ cmc_max }}{% endif %}{% if power_min %}&power_min={{ power_min }}{% endif %}{% if power_max %}&power_max={{ power_max }}{% endif %}{% if tough_min %}&tough_min={{ tough_min }}{% endif %}{% if tough_max %}&tough_max={{ tough_max }}{% endif %}{% if is_new %}&is_new=true{% endif %}{% if set_code %}&set_code={{ set_code|urlencode }}{% endif %}"
+      hx-get="/cards/grid?cursor={{ last_card|urlencode }}{% if search %}&search={{ search|urlencode }}{% endif %}{% for theme in themes %}&themes={{ theme|urlencode }}{% endfor %}{% if color %}&color={{ color|urlencode }}{% endif %}{% if color_mode == 'inclusive' %}&color_mode=inclusive{% endif %}{% if card_type %}&card_type={{ card_type|urlencode }}{% endif %}{% if rarity %}&rarity={{ rarity|urlencode }}{% endif %}{% if sort and sort != 'name_asc' %}&sort={{ sort|urlencode }}{% endif %}{% if cmc_min %}&cmc_min={{ cmc_min }}{% endif %}{% if cmc_max %}&cmc_max={{ cmc_max }}{% endif %}{% if power_min %}&power_min={{ power_min }}{% endif %}{% if power_max %}&power_max={{ power_max }}{% endif %}{% if tough_min %}&tough_min={{ tough_min }}{% endif %}{% if tough_max %}&tough_max={{ tough_max }}{% endif %}{% if is_new %}&is_new=true{% endif %}{% if set_code %}&set_code={{ set_code|urlencode }}{% endif %}"
       hx-target="#card-grid"
       hx-swap="beforeend"
       hx-indicator="#load-indicator">
@@ -478,6 +483,7 @@ document.addEventListener('click', (e) => {
 
 function applyFilter() {
   const color = document.getElementById('filter-color')?.value || '';
+  const colorInclusive = document.getElementById('filter-color-inclusive')?.checked || false;
   const type = document.getElementById('filter-type')?.value || '';
   const rarity = document.getElementById('filter-rarity')?.value || '';
   const search = document.getElementById('search-input')?.value || '';
@@ -498,6 +504,7 @@ function applyFilter() {
   const params = new URLSearchParams();
   if (search) params.set('search', search);
   if (color) params.set('color', color);
+  if (color && colorInclusive) params.set('color_mode', 'inclusive');
   if (type) params.set('card_type', type);
   if (rarity) params.set('rarity', rarity);
   // Add themes as multiple params (themes=t1&themes=t2&themes=t3)

--- a/code/web/templates/build/_new_deck_tags.html
+++ b/code/web/templates/build/_new_deck_tags.html
@@ -1,5 +1,7 @@
-{% from 'partials/_macros.html' import color_identity %}
+{% from 'partials/_macros.html' import color_identity, printing_button, foil_toggle_button %}
 {% set pname = commander.name %}
+{% set sel_printing = (printings.get(pname.lower(), '') if printings is defined else '') %}
+{% set is_foil_commander = (foils.get(pname.lower(), False) if foils is defined else False) %}
 {% set partner_preview_payload = partner_preview if partner_preview else None %}
 {% set preview_colors = partner_preview_payload.color_identity if partner_preview_payload else [] %}
 {% if preview_colors is none %}
@@ -13,27 +15,41 @@
   {% set preview_label = 'Colorless (C)' %}
 {% endif %}
 <div id="newdeck-commander-slot" hx-swap-oob="true" style="max-width:230px;">
-  <aside class="card-preview" data-card-name="{{ pname }}" style="max-width: 230px;">
+  <aside class="card-preview foil-shine-target{% if is_foil_commander %} card-foil-shine{% endif %}" data-card-name="{{ pname }}" style="max-width: 230px; position:relative;">
     <a href="https://scryfall.com/search?q={{ pname|urlencode }}" target="_blank" rel="noopener">
-      <img src="{{ pname|card_image('normal') }}" alt="{{ pname }} card image" data-card-name="{{ pname }}" style="width:200px; height:auto; display:block; border-radius:6px;" />
+      <img id="card-img-modal-commander" src="{{ pname|card_image('normal', sel_printing) }}" alt="{{ pname }} card image" data-card-name="{{ pname }}" data-printing-id="{{ sel_printing }}" style="width:200px; height:auto; display:block; border-radius:6px;" />
     </a>
+    <div id="price-overlay-modal-commander" class="card-price-overlay" data-price-for="{{ pname }}" data-printing-id="{{ sel_printing }}" data-foil="{{ '1' if is_foil_commander else '0' }}" aria-hidden="true"></div>
+    <div class="commander-printing-btn" style="position:absolute; bottom:4px; right:4px; z-index:3;">
+      {{ printing_button(pname, 'modal-commander', sel_printing, compact=True) }}
+      {{ foil_toggle_button(pname, 'modal-commander', is_foil_commander, compact=True) }}
+    </div>
   </aside>
   <div class="muted" style="font-size:12px; margin-top:.25rem; max-width: 230px; word-wrap:break-word; overflow-wrap:break-word;">{{ pname }}</div>
   {% if partner_preview_payload %}
   {% set partner_secondary_name = partner_preview_payload.secondary_name %}
+  {% set sel_partner_printing = (printings.get(partner_secondary_name.lower(), '') if (printings is defined and partner_secondary_name) else '') %}
+  {% set is_foil_partner = (foils.get(partner_secondary_name.lower(), False) if (foils is defined and partner_secondary_name) else False) %}
   {% set partner_image_url = partner_preview_payload.secondary_image_url or partner_preview_payload.image_url %}
   {% if not partner_image_url and partner_secondary_name %}
-    {% set partner_image_url = partner_secondary_name|card_image('normal') %}
+    {% set partner_image_url = partner_secondary_name|card_image('normal', sel_partner_printing) %}
   {% endif %}
   {% set partner_href = partner_preview_payload.secondary_scryfall_url or partner_preview_payload.scryfall_url %}
   {% if not partner_href and partner_secondary_name %}
     {% set partner_href = 'https://scryfall.com/search?q=' ~ partner_secondary_name|urlencode %}
   {% endif %}
   {% if partner_image_url %}
-  <aside class="card-preview partner-card-preview" style="max-width: 230px; margin-top:.75rem;">
+  <aside class="card-preview partner-card-preview foil-shine-target{% if is_foil_partner %} card-foil-shine{% endif %}" style="max-width: 230px; margin-top:.75rem; position:relative;">
     {% if partner_href %}<a href="{{ partner_href }}" target="_blank" rel="noopener">{% endif %}
-    <img src="{{ partner_image_url }}" alt="{{ (partner_secondary_name or 'Selected card') ~ ' card image' }}" data-card-name="{{ partner_secondary_name or '' }}" style="width:200px; height:auto; display:block; border-radius:6px;" loading="lazy" decoding="async" />
+    <img id="card-img-modal-partner" src="{{ partner_image_url }}" alt="{{ (partner_secondary_name or 'Selected card') ~ ' card image' }}" data-card-name="{{ partner_secondary_name or '' }}" data-printing-id="{{ sel_partner_printing }}" style="width:200px; height:auto; display:block; border-radius:6px;" loading="lazy" decoding="async" />
     {% if partner_href %}</a>{% endif %}
+    {% if partner_secondary_name %}
+    <div id="price-overlay-modal-partner" class="card-price-overlay" data-price-for="{{ partner_secondary_name }}" data-printing-id="{{ sel_partner_printing }}" data-foil="{{ '1' if is_foil_partner else '0' }}" aria-hidden="true"></div>
+    <div class="commander-printing-btn" style="position:absolute; bottom:4px; right:4px; z-index:3;">
+      {{ printing_button(partner_secondary_name, 'modal-partner', sel_partner_printing, compact=True) }}
+      {{ foil_toggle_button(partner_secondary_name, 'modal-partner', is_foil_partner, compact=True) }}
+    </div>
+    {% endif %}
   </aside>
   {% endif %}
   {% if partner_secondary_name %}

--- a/code/web/templates/build/_partner_controls.html
+++ b/code/web/templates/build/_partner_controls.html
@@ -1,3 +1,4 @@
+{% from 'partials/_macros.html' import printing_button, foil_toggle_button %}
 {% set prefix = partner_id_prefix if partner_id_prefix is defined else 'partner' %}
 {% set feature_available = partner_feature_available if partner_feature_available is defined else False %}
 {% set partner_capable = partner_capable if partner_capable is defined else False %}
@@ -105,25 +106,33 @@
       <div class="partner-preview" data-partner-preview="{{ prefix }}" {% if partner_preview %}data-preview-json='{{ partner_preview | tojson }}'{% else %}hidden{% endif %}>
         {% if partner_preview %}
           {% set preview_image = partner_preview.secondary_image_url or partner_preview.image_url %}
-          {% if not preview_image and partner_preview.secondary_name %}
-            {% set preview_image = partner_preview.secondary_name|card_image('normal') %}
+          {% set preview_secondary = partner_preview.secondary_name %}
+          {% set sel_preview_printing = (printings.get(preview_secondary.lower(), '') if (printings is defined and preview_secondary) else '') %}
+          {% set is_foil_preview = (foils.get(preview_secondary.lower(), False) if (foils is defined and preview_secondary) else False) %}          {% if not preview_image and preview_secondary %}
+            {% set preview_image = preview_secondary|card_image('normal', sel_preview_printing) %}
           {% endif %}
           {% set preview_href = partner_preview.secondary_scryfall_url or partner_preview.scryfall_url %}
-          {% if not preview_href and partner_preview.secondary_name %}
-            {% set preview_href = 'https://scryfall.com/search?q=' ~ partner_preview.secondary_name|urlencode %}
+          {% if not preview_href and preview_secondary %}
+            {% set preview_href = 'https://scryfall.com/search?q=' ~ preview_secondary|urlencode %}
           {% endif %}
           {% set preview_role = partner_preview.secondary_role_label or partner_preview.role_label %}
           {% set preview_primary = partner_preview.primary_name or primary_commander_display %}
-          {% set preview_secondary = partner_preview.secondary_name %}
           {% set preview_themes = partner_preview.theme_tags %}
           {% set preview_mode_label = partner_preview.partner_mode_label %}
           {% set preview_color_label = partner_preview.color_label %}
           <div class="partner-preview__layout">
             {% if preview_image %}
-              <div class="partner-preview__art">
+              <div class="partner-preview__art foil-shine-target{% if is_foil_preview %} card-foil-shine{% endif %}" style="position:relative;">
                 {% if preview_href %}<a href="{{ preview_href }}" target="_blank" rel="noopener">{% endif %}
-                <img src="{{ preview_image }}" alt="{{ (preview_secondary or 'Selected card') ~ ' card image' }}" loading="lazy" decoding="async" />
+                <img id="card-img-{{ prefix }}-partner" src="{{ preview_image }}" alt="{{ (preview_secondary or 'Selected card') ~ ' card image' }}" data-printing-id="{{ sel_preview_printing }}" loading="lazy" decoding="async" />
                 {% if preview_href %}</a>{% endif %}
+                {% if preview_secondary %}
+                <div id="price-overlay-{{ prefix }}-partner" class="card-price-overlay" data-price-for="{{ preview_secondary }}" data-printing-id="{{ sel_preview_printing }}" data-foil="{{ '1' if is_foil_preview else '0' }}" aria-hidden="true"></div>
+                <div class="commander-printing-btn" style="position:absolute; bottom:4px; right:4px; z-index:3;">
+                  {{ printing_button(preview_secondary, prefix ~ '-partner', sel_preview_printing, compact=True) }}
+                  {{ foil_toggle_button(preview_secondary, prefix ~ '-partner', is_foil_preview, compact=True) }}
+                </div>
+                {% endif %}
               </div>
             {% endif %}
             <div class="partner-preview__details">
@@ -557,16 +566,26 @@
             attrParts.push('data-tags="' + escapeHtml(tagString) + '"');
             attrParts.push('data-overlaps="' + escapeHtml(tagString) + '"');
           }
-          html += '<div class="partner-preview__art card-preview"' + (attrParts.length ? ' ' + attrParts.join(' ') : '') + '>';
+          html += '<div class="partner-preview__art card-preview" style="position:relative;"' + (attrParts.length ? ' ' + attrParts.join(' ') : '') + '>';
           if (scryfallUrl){
             html += '<a href="' + escapeHtml(scryfallUrl) + '" target="_blank" rel="noopener">';
           }
-          html += '<img src="' + escapeHtml(imageUrl) + '" alt="' + escapeHtml((secondaryName || 'Selected card') + ' card image') + '" loading="lazy" decoding="async" data-card-name="' + escapeHtml(secondaryName || '') + '"';
+          html += '<img id="card-img-' + escapeHtml(prefix) + '-partner" src="' + escapeHtml(imageUrl) + '" alt="' + escapeHtml((secondaryName || 'Selected card') + ' card image') + '" loading="lazy" decoding="async" data-card-name="' + escapeHtml(secondaryName || '') + '"';
           if (roleLabel){ html += ' data-role="' + escapeHtml(roleLabel) + '"'; }
           if (tagString){ html += ' data-tags="' + escapeHtml(tagString) + '" data-overlaps="' + escapeHtml(tagString) + '"'; }
           html += ' />';
           if (scryfallUrl){
             html += '</a>';
+          }
+          if (secondaryName){
+            var partnerIdx = prefix + '-partner';
+            html += '<div id="price-overlay-' + escapeHtml(partnerIdx) + '" class="card-price-overlay" data-price-for="' + escapeHtml(secondaryName) + '" aria-hidden="true"></div>';
+            html += '<div class="commander-printing-btn" style="position:absolute; bottom:4px; right:4px; z-index:3;">';
+            html += '<button type="button" class="btn btn-printing btn-printing-compact" title="Choose a specific printing (art/set)" ' +
+              'aria-expanded="false" aria-label="Choose printing" data-has-selection="0" ' +
+              'hx-get="/build/printing-picker" hx-target="#printing-modal-root" hx-swap="innerHTML" ' +
+              'hx-vals=\'{"name": "' + escapeHtml(secondaryName) + '", "idx": "' + escapeHtml(partnerIdx) + '"}\'>&#128444;</button>';
+            html += '</div>';
           }
           html += '</div>';
         }
@@ -588,6 +607,9 @@
         html += '</div></div>';
         previewBox.innerHTML = html;
         previewBox.hidden = false;
+        if (window.htmx && typeof window.htmx.process === 'function'){
+          window.htmx.process(previewBox);
+        }
         markSuggestionActive();
       }
 

--- a/code/web/templates/build/_step5.html
+++ b/code/web/templates/build/_step5.html
@@ -1,4 +1,4 @@
-{% from 'partials/_macros.html' import color_identity %}
+{% from 'partials/_macros.html' import color_identity, printing_button, foil_toggle_button %}
 {% set combined = combined_commander if combined_commander else {} %}
 {% set display_commander_name = commander_display_name or commander %}
 {% if not display_commander_name %}
@@ -27,7 +27,9 @@
   {# Strip synergy annotation for Scryfall search #}
   {% if commander %}
   {% set commander_base = (commander.split(' - Synergy (')[0] if ' - Synergy (' in commander else commander) %}
-  <div class="commander-card" tabindex="0"
+  {% set sel_printing = (printings.get(commander_base.lower(), '') if printings is defined else '') %}
+  {% set is_foil_commander = (foils.get(commander_base.lower(), False) if foils is defined else False) %}
+  <div class="commander-card foil-shine-target{% if is_foil_commander %} card-foil-shine{% endif %}" tabindex="0"
     data-card-name="{{ commander_base }}"
     data-original-name="{{ commander }}"
     data-role="{{ commander_role_label or 'Commander' }}"
@@ -35,19 +37,24 @@
     {% if commander_tag_slugs %}data-tags-slug="{{ commander_tag_slugs|join(' ') }}"{% endif %}
     {% if commander_overlap_tags %}data-overlaps="{{ commander_overlap_tags|join(', ') }}"{% endif %}
     {% if commander_reason_text %}data-reasons="{{ commander_reason_text|e }}"{% endif %}>
-  <img src="{{ commander_base|card_image('normal') }}" alt="{{ commander }} card image"
+  <img id="card-img-commander" src="{{ commander_base|card_image('normal', sel_printing) }}" alt="{{ commander }} card image"
          width="320"
          data-card-name="{{ commander_base }}"
          data-original-name="{{ commander }}"
          data-role="{{ commander_role_label or 'Commander' }}"
+         data-printing-id="{{ sel_printing }}"
      {% if hover_tags_joined %}data-tags="{{ hover_tags_joined }}"{% endif %}
      {% if commander_tag_slugs %}data-tags-slug="{{ commander_tag_slugs|join(' ') }}"{% endif %}
      {% if commander_overlap_tags %}data-overlaps="{{ commander_overlap_tags|join(', ') }}"{% endif %}
    {% if commander_reason_text %}data-reasons="{{ commander_reason_text|e }}"{% endif %}
          loading="lazy" decoding="async" data-lqip="1"
-         srcset="{{ commander_base|card_image('small') }} 160w, {{ commander_base|card_image('normal') }} 488w"
+         srcset="{{ commander_base|card_image('small', sel_printing) }} 160w, {{ commander_base|card_image('normal', sel_printing) }} 488w"
          sizes="(max-width: 900px) 100vw, 320px" />
-  <div class="card-price-overlay" data-price-for="{{ commander_base }}" aria-hidden="true"></div>
+  <div id="price-overlay-commander" class="card-price-overlay" data-price-for="{{ commander_base }}" data-printing-id="{{ sel_printing }}" data-foil="{{ '1' if is_foil_commander else '0' }}" aria-hidden="true"></div>
+  <div class="commander-printing-btn" style="position:absolute; bottom:6px; right:6px; z-index:3;">
+    {{ printing_button(commander_base, 'commander', sel_printing, compact=True) }}
+    {{ foil_toggle_button(commander_base, 'commander', is_foil_commander, compact=True) }}
+  </div>
   {% if show_new_badge and commander_base in new_card_names %}<div class="card-new-badge" title="Recently Released" aria-hidden="true">New</div>{% endif %}
   </div>
   <div class="muted mt-1">
@@ -74,26 +81,35 @@
   {% if not partner_href and partner_name_base %}
     {% set partner_href = 'https://scryfall.com/search?q=' ~ partner_name_base|urlencode %}
   {% endif %}
-  <div class="commander-card partner-card" tabindex="0"
+  {% set sel_partner_printing = (printings.get(partner_name_base.lower(), '') if (printings is defined and partner_name_base) else '') %}
+  {% set is_foil_partner = (foils.get(partner_name_base.lower(), False) if (foils is defined and partner_name_base) else False) %}  <div class="commander-card partner-card foil-shine-target{% if is_foil_partner %} card-foil-shine{% endif %}" tabindex="0"
     data-card-name="{{ partner_name_base }}"
     data-original-name="{{ partner_secondary_name }}"
     data-role="{{ partner_role_label }}"
     {% if partner_tags_joined %}data-tags="{{ partner_tags_joined }}" data-overlaps="{{ partner_tags_joined }}"{% endif %}>
     {% if partner_href %}<a href="{{ partner_href }}" target="_blank" rel="noopener">{% endif %}
     {% if partner_name_base %}
-    <img src="{{ partner_name_base|card_image('normal') }}" alt="{{ (partner_secondary_name or 'Selected card') ~ ' card image' }}"
+    <img id="card-img-partner" src="{{ partner_name_base|card_image('normal', sel_partner_printing) }}" alt="{{ (partner_secondary_name or 'Selected card') ~ ' card image' }}"
          width="320"
          data-card-name="{{ partner_name_base }}"
          data-original-name="{{ partner_secondary_name }}"
          data-role="{{ partner_role_label }}"
+         data-printing-id="{{ sel_partner_printing }}"
          {% if partner_tags_joined %}data-tags="{{ partner_tags_joined }}" data-overlaps="{{ partner_tags_joined }}"{% endif %}
          loading="lazy" decoding="async" data-lqip="1"
-         srcset="{{ partner_name_base|card_image('small') }} 160w, {{ partner_name_base|card_image('normal') }} 488w"
+         srcset="{{ partner_name_base|card_image('small', sel_partner_printing) }} 160w, {{ partner_name_base|card_image('normal', sel_partner_printing) }} 488w"
          sizes="(max-width: 900px) 100vw, 320px" />
     {% else %}
     <img src="{{ combined.secondary_image_url or combined.image_url }}" alt="{{ (partner_secondary_name or 'Selected card') ~ ' card image' }}" loading="lazy" decoding="async" width="320" />
     {% endif %}
     {% if partner_href %}</a>{% endif %}
+    {% if partner_name_base %}
+    <div id="price-overlay-partner" class="card-price-overlay" data-price-for="{{ partner_name_base }}" data-printing-id="{{ sel_partner_printing }}" data-foil="{{ '1' if is_foil_partner else '0' }}" aria-hidden="true"></div>
+    <div class="commander-printing-btn" style="position:absolute; bottom:6px; right:6px; z-index:3;">
+      {{ printing_button(partner_name_base, 'partner', sel_partner_printing, compact=True) }}
+      {{ foil_toggle_button(partner_name_base, 'partner', is_foil_partner, compact=True) }}
+    </div>
+    {% endif %}
   </div>
   <div class="muted partner-label mt-1.5">
     {{ partner_role_label }}:
@@ -439,25 +455,29 @@
             {% set is_locked = (locks is defined and (c.name|lower in locks)) %}
             {% set card_idx = group_idx ~ '-' ~ loop.index0 %}
             {% set sel_printing = (printings.get(c.name.lower(), '') if printings is defined else '') %}
+            {% set is_foil = (foils.get(c.name.lower(), False) if foils is defined else False) %}
   <div class="card-tile{% if game_changers and (c.name in game_changers) %} game-changer{% endif %}{% if is_locked %} locked{% endif %}{% if c.must_include %} must-include{% endif %}{% if c.must_exclude %} must-exclude{% endif %}"
     data-card-name="{{ c.name }}" data-role="{{ c.role or c.sub_role or '' }}" data-tags="{{ (c.tags|join(', ')) if c.tags else '' }}" data-tags-slug="{{ (c.tags_slug|join(', ')) if c.tags_slug else '' }}" data-owned="{{ '1' if owned else '0' }}"{% if c.reason %} data-reasons="{{ c.reason|e }}"{% endif %}
     data-must-include="{{ '1' if c.must_include else '0' }}" data-must-exclude="{{ '1' if c.must_exclude else '0' }}"
     data-price="{{ (price_cache or {}).get(c.name.lower(), {}).get('usd') or '' }}"
     data-stale="{% if stale_prices is defined and c.name|lower in stale_prices %}1{% else %}0{% endif %}">
-  <div class="img-btn" role="button" tabindex="0" title="Tap or click to view {{ c.name }}" aria-label="View {{ c.name }} details">
+  <div class="img-btn foil-shine-target{% if is_foil %} card-foil-shine{% endif %}" role="button" tabindex="0" title="Tap or click to view {{ c.name }}" aria-label="View {{ c.name }} details">
                 <img class="card-thumb" id="card-img-{{ card_idx }}" src="{{ c.name|card_image('normal', sel_printing) }}" alt="{{ c.name }} image" width="160" data-card-name="{{ c.name }}" loading="lazy" decoding="async" data-lqip="1"
                   srcset="{{ c.name|card_image('small', sel_printing) }} 160w, {{ c.name|card_image('normal', sel_printing) }} 488w"
                   sizes="160px" />
-              <div class="card-price-overlay" id="price-overlay-{{ card_idx }}" data-price-for="{{ c.name }}" data-printing-id="{{ sel_printing }}" aria-hidden="true"></div>
+              <div class="card-price-overlay" id="price-overlay-{{ card_idx }}" data-price-for="{{ c.name }}" data-printing-id="{{ sel_printing }}" data-foil="{{ '1' if is_foil else '0' }}" aria-hidden="true"></div>
               {% if show_new_badge and c.name in new_card_names %}<div class="card-new-badge" title="Recently Released" aria-hidden="true">New</div>{% endif %}
+              {% from 'partials/_macros.html' import lock_button, printing_button, foil_toggle_button %}
+              <div class="card-tile-printing-row" style="position:absolute; bottom:4px; left:4px; z-index:5;" onclick="event.stopPropagation()">
+                {{ printing_button(c.name, card_idx, sel_printing, compact=True) }}
+                {{ foil_toggle_button(c.name, card_idx, is_foil, compact=True) }}
+              </div>
       </div>
               <div class="owned-badge" title="{{ 'Owned' if owned else 'Not owned' }}" aria-label="{{ 'Owned' if owned else 'Not owned' }}">{% if owned %}✔{% else %}✖{% endif %}</div>
               {% if stale_prices is defined and c.name|lower in stale_prices %}<div class="stale-price-indicator" title="Price may be outdated (>24h)">&#x23F1;</div>{% endif %}
               <div class="name">{{ c.name|safe }}{% if c.count and c.count > 1 %} ×{{ c.count }}{% endif %}</div>
     <div class="lock-box" id="lock-{{ group_idx }}-{{ loop.index0 }}" class="flex justify-center gap-1 mt-1">
-      {% from 'partials/_macros.html' import lock_button, printing_button %}
       {{ lock_button(c.name, is_locked) }}
-      {{ printing_button(c.name, card_idx, sel_printing) }}
     </div>
     {% if allow_must_haves and show_must_have_buttons %}
     <div class="must-have-controls" role="group" aria-label="Must have controls">
@@ -497,25 +517,29 @@
           {% set is_locked = (locks is defined and (c.name|lower in locks)) %}
           {% set card_idx = loop.index0 %}
           {% set sel_printing = (printings.get(c.name.lower(), '') if printings is defined else '') %}
+          {% set is_foil = (foils.get(c.name.lower(), False) if foils is defined else False) %}
     <div class="card-tile{% if game_changers and (c.name in game_changers) %} game-changer{% endif %}{% if is_locked %} locked{% endif %}{% if c.must_include %} must-include{% endif %}{% if c.must_exclude %} must-exclude{% endif %}"
       data-card-name="{{ c.name }}" data-role="{{ c.role or c.sub_role or '' }}" data-tags="{{ (c.tags|join(', ')) if c.tags else '' }}" data-tags-slug="{{ (c.tags_slug|join(', ')) if c.tags_slug else '' }}" data-owned="{{ '1' if owned else '0' }}"{% if c.reason %} data-reasons="{{ c.reason|e }}"{% endif %}
       data-must-include="{{ '1' if c.must_include else '0' }}" data-must-exclude="{{ '1' if c.must_exclude else '0' }}"
       data-price="{{ (price_cache or {}).get(c.name.lower(), {}).get('usd') or '' }}"
       data-stale="{% if stale_prices is defined and c.name|lower in stale_prices %}1{% else %}0{% endif %}">
-  <div class="img-btn" role="button" tabindex="0" title="Tap or click to view {{ c.name }}" aria-label="View {{ c.name }} details">
+  <div class="img-btn foil-shine-target{% if is_foil %} card-foil-shine{% endif %}" role="button" tabindex="0" title="Tap or click to view {{ c.name }}" aria-label="View {{ c.name }} details">
               <img class="card-thumb" id="card-img-{{ card_idx }}" src="{{ c.name|card_image('normal', sel_printing) }}" alt="{{ c.name }} image" width="160" data-card-name="{{ c.name }}" loading="lazy" decoding="async" data-lqip="1"
                 srcset="{{ c.name|card_image('small', sel_printing) }} 160w, {{ c.name|card_image('normal', sel_printing) }} 488w"
                 sizes="160px" />
-            <div class="card-price-overlay" id="price-overlay-{{ card_idx }}" data-price-for="{{ c.name }}" data-printing-id="{{ sel_printing }}" aria-hidden="true"></div>
+            <div class="card-price-overlay" id="price-overlay-{{ card_idx }}" data-price-for="{{ c.name }}" data-printing-id="{{ sel_printing }}" data-foil="{{ '1' if is_foil else '0' }}" aria-hidden="true"></div>
             {% if show_new_badge and c.name in new_card_names %}<div class="card-new-badge" title="Recently Released" aria-hidden="true">New</div>{% endif %}
+            {% from 'partials/_macros.html' import lock_button, printing_button, foil_toggle_button %}
+            <div class="card-tile-printing-row" style="position:absolute; bottom:4px; left:4px; z-index:5;" onclick="event.stopPropagation()">
+              {{ printing_button(c.name, card_idx, sel_printing, compact=True) }}
+              {{ foil_toggle_button(c.name, card_idx, is_foil, compact=True) }}
+            </div>
             </div>
             <div class="owned-badge" title="{{ 'Owned' if owned else 'Not owned' }}" aria-label="{{ 'Owned' if owned else 'Not owned' }}">{% if owned %}✔{% else %}✖{% endif %}</div>
             {% if stale_prices is defined and c.name|lower in stale_prices %}<div class="stale-price-indicator" title="Price may be outdated (>24h)">&#x23F1;</div>{% endif %}
             <div class="name">{{ c.name|safe }}{% if c.count and c.count > 1 %} ×{{ c.count }}{% endif %}</div>
     <div class="lock-box" id="lock-{{ loop.index0 }}" class="flex justify-center gap-1 mt-1">
-      {% from 'partials/_macros.html' import lock_button, printing_button %}
       {{ lock_button(c.name, is_locked) }}
-      {{ printing_button(c.name, card_idx, sel_printing) }}
     </div>
     {% if allow_must_haves and show_must_have_buttons %}
     <div class="must-have-controls" role="group" aria-label="Must have controls">

--- a/code/web/templates/commanders/index.html
+++ b/code/web/templates/commanders/index.html
@@ -122,6 +122,7 @@
   .commander-thumb { width:160px; flex:0 0 auto; position:relative; }
   .commander-thumb img { width:160px; height:auto; border-radius:10px; border:1px solid var(--border); background:#0b0d12; display:block; }
   .commander-thumb-img.is-placeholder { animation: commander-thumb-pulse 1.2s ease-in-out infinite alternate; }
+  .commander-printing-btn { position:absolute; bottom:4px; right:4px; z-index:3; }
   @keyframes commander-thumb-pulse {
     from { filter:brightness(0.45); }
     to { filter:brightness(0.65); }

--- a/code/web/templates/commanders/row_wireframe.html
+++ b/code/web/templates/commanders/row_wireframe.html
@@ -1,16 +1,20 @@
 {# Commander row partial fed by CommanderView entries #}
-{% from "partials/_macros.html" import color_identity %}
+{% from "partials/_macros.html" import color_identity, printing_button, foil_toggle_button %}
 {% set record = entry.record %}
 {% set display_label = record.name if '//' in record.name else record.display_name %}
 {% set placeholder_pixel = "data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" %}
+{% set commander_idx = record.slug %}
+{% set sel_printing = (printings.get(record.name.lower(), '') if printings is defined else '') %}
+{% set is_foil = (foils.get(record.name.lower(), False) if foils is defined else False) %}
 <article class="commander-row" data-commander-slug="{{ record.slug }}" data-hover-simple="true">
-  <div class="commander-thumb" 
+  <div class="commander-thumb foil-shine-target{% if is_foil %} card-foil-shine{% endif %}" 
        data-card-name="{{ record.name }}"
        data-original-name="{{ record.name }}"
        {% if record.layout %}data-layout="{{ record.layout }}"{% endif %}>
-    {% set small = record.display_name|card_image('small') %}
-    {% set normal = record.display_name|card_image('normal') %}
+    {% set small = record.display_name|card_image('small', sel_printing) %}
+    {% set normal = record.display_name|card_image('normal', sel_printing) %}
     <img
+      id="card-img-{{ commander_idx }}"
       src="{{ small }}"
       srcset="{{ small }} 160w, {{ normal }} 488w"
       sizes="(max-width: 900px) 60vw, 160px"
@@ -21,12 +25,17 @@
       height="223"
       data-card-name="{{ record.name }}"
       data-original-name="{{ record.name }}"
+      data-printing-id="{{ sel_printing }}"
       {% if record.layout %}data-layout="{{ record.layout }}"{% endif %}
       data-hover-simple="true"
       class="commander-thumb-img"
     />
-    <div class="card-price-overlay" data-price-for="{{ record.name }}" aria-hidden="true"></div>
+    <div id="price-overlay-{{ commander_idx }}" class="card-price-overlay" data-price-for="{{ record.name }}" data-printing-id="{{ sel_printing }}" data-foil="{{ '1' if is_foil else '0' }}" aria-hidden="true"></div>
     {% if show_new_badge and record.name in new_card_names %}<div class="card-new-badge" title="Recently Released" aria-hidden="true">New</div>{% endif %}
+    <div class="commander-printing-btn">
+      {{ printing_button(record.name, commander_idx, sel_printing, compact=True) }}
+      {{ foil_toggle_button(record.name, commander_idx, is_foil, compact=True) }}
+    </div>
   </div>
   <div class="commander-main">
     <div class="commander-header">

--- a/code/web/templates/decks/view.html
+++ b/code/web/templates/decks/view.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% from 'partials/_macros.html' import printing_button, foil_toggle_button %}
 {% block banner_subtitle %}Finished Decks{% endblock %}
 {% block content %}
 <h2>Finished Deck</h2>
@@ -25,7 +26,9 @@
     {% if commander %}
     {# Strip synergy annotation for Scryfall search and image fuzzy param #}
     {% set commander_base = (commander.split(' - Synergy (')[0] if ' - Synergy (' in commander else commander) %}
-    <div class="commander-card"
+    {% set sel_printing = ((printings.get(commander_base.lower(), '') if printings is defined else '') or commander_scryfall_id or '') %}
+    {% set is_foil_commander = ((foils.get(commander_base.lower(), False) if foils is defined else False) or (commander_is_foil is defined and commander_is_foil)) %}
+    <div class="commander-card foil-shine-target{% if is_foil_commander %} card-foil-shine{% endif %}"
       tabindex="0"
       style="display:inline-block; cursor:pointer;"
       data-card-name="{{ commander_base }}"
@@ -35,19 +38,26 @@
       {% if commander_tag_slugs %}data-tags-slug="{{ commander_tag_slugs|join(' ') }}"{% endif %}
       {% if commander_overlap_tags %}data-overlaps="{{ commander_overlap_tags|join(', ') }}"{% endif %}
       {% if commander_reason_text %}data-reasons="{{ commander_reason_text|e }}"{% endif %}>
-      <img src="{{ commander_base|card_image('normal') }}"
+      <img id="card-img-commander" src="{{ commander_base|card_image('normal', sel_printing) }}"
            alt="{{ commander }} card image"
            data-card-name="{{ commander_base }}"
            data-original-name="{{ commander }}"
            data-role="{{ commander_role_label }}"
+           data-printing-id="{{ sel_printing }}"
     {% if hover_tags_joined %}data-tags="{{ hover_tags_joined }}"{% endif %}
        {% if commander_tag_slugs %}data-tags-slug="{{ commander_tag_slugs|join(' ') }}"{% endif %}
        {% if commander_overlap_tags %}data-overlaps="{{ commander_overlap_tags|join(', ') }}"{% endif %}
      {% if commander_reason_text %}data-reasons="{{ commander_reason_text|e }}"{% endif %}
            width="320" />
       {# Price overlay — ensures commander price is loaded into window._priceNum for the hover panel #}
-      <div class="card-price-overlay" data-price-for="{{ commander_base }}" aria-hidden="true"></div>
+      <div id="price-overlay-commander" class="card-price-overlay" data-price-for="{{ commander_base }}" data-printing-id="{{ sel_printing }}" data-foil="{{ '1' if is_foil_commander else '0' }}" aria-hidden="true"></div>
       {% if show_new_badge and commander_base in new_card_names %}<div class="card-new-badge" title="Recently Released" aria-hidden="true">New</div>{% endif %}
+      {% if deck_edit_ctx %}
+      <div class="commander-printing-btn" style="position:absolute; bottom:6px; right:6px; z-index:3;">
+        {{ printing_button(commander_base, 'commander', sel_printing, compact=True, deck=deck_edit_ctx.deck) }}
+        {{ foil_toggle_button(commander_base, 'commander', is_foil_commander, compact=True, deck=deck_edit_ctx.deck) }}
+      </div>
+      {% endif %}
     </div>
     <div class="muted" style="margin-top:.25rem;">Commander: <span data-card-name="{{ commander }}"
     data-original-name="{{ commander }}"

--- a/code/web/templates/owned/index.html
+++ b/code/web/templates/owned/index.html
@@ -117,6 +117,11 @@
           {% for code, label in color_combos %}<option value="{{ code }}" {% if filter_color == code %}selected{% endif %}>{{ label }}</option>{% endfor %}
           {% endif %}
         </select>
+        <label style="display:flex; align-items:center; gap:0.35rem; cursor:pointer; white-space:nowrap; font-size:0.85rem;" title="Exact: only that color combination. Inclusive: also matches cards with additional colors (e.g. WU also matches Bant, Esper, Jeskai).">
+          <input type="checkbox" id="filter-color-inclusive" onchange="applyFilter()"
+                 {% if color_mode == 'inclusive' %}checked{% endif %} />
+          Inclusive match
+        </label>
         {% endif %}
 
         {% if all_types %}
@@ -190,7 +195,7 @@
   </div>
 
   {# Card grid — full-page scroll, no scroll-box wrapper #}
-  {% from 'partials/_macros.html' import printing_button %}
+  {% from 'partials/_macros.html' import printing_button, foil_toggle_button %}
   <ul id="owned-grid" class="owned-card-grid">
     {% for n in names %}
     {% set tags = (tags_by_name.get(n, []) if tags_by_name else []) %}
@@ -198,28 +203,54 @@
     {% set cols = (colors_by_name.get(n, []) if colors_by_name else []) %}
     {% set added_ts = (added_at_map.get(n) if added_at_map else None) %}
     {% set sel_printing = (printings.get(n.lower(), '') if printings is defined else '') %}
+    {% set is_foil = (foils.get(n.lower(), False) if foils is defined else False) %}
     {% set card_idx = n|slugify %}
+    {% set badges = (badges_by_name.get(n) if badges_by_name else None) %}
     <li data-type="{{ tline }}" data-tags="{{ (tags or [])|join('|') }}" data-colors="{{ (cols or [])|join('') }}" data-added="{{ added_ts if added_ts else '' }}">
       <label class="owned-row" tabindex="0" data-card-name="{{ n }}" data-original-name="{{ n }}">
         <input type="checkbox" class="sel sr-only" aria-label="Select {{ n }}" />
         <div class="owned-vstack">
+          <div class="foil-shine-target{% if is_foil %} card-foil-shine{% endif %}" style="position:relative; display:inline-block; cursor:pointer;"
+               role="button" tabindex="0"
+               onclick="event.stopPropagation(); window.location.href='/cards/{{ n|urlencode }}?ref=owned';"
+               onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault(); event.stopPropagation(); window.location.href='/cards/{{ n|urlencode }}?ref=owned';}">
           <img class="card-thumb" id="card-img-{{ card_idx }}" loading="lazy" decoding="async" alt="{{ n }} image"
             src="{{ n|card_image('small', sel_printing) }}"
             data-card-name="{{ n }}" data-lqip="1"
             {% if tags %}data-tags="{{ (tags or [])|join(', ') }}"{% endif %}
             srcset="{{ n|card_image('small', sel_printing) }} 160w, {{ n|card_image('normal', sel_printing) }} 488w"
             sizes="160px" />
+          <div class="card-tile-printing-row" style="position:absolute; bottom:4px; left:4px; z-index:5;" onclick="event.stopPropagation()">
+            {{ printing_button(n, card_idx, sel_printing, compact=True) }}
+            {{ foil_toggle_button(n, card_idx, is_foil, compact=True) }}
+          </div>
+          </div>
           <span class="card-name"{% if tags %} data-tags="{{ (tags or [])|join(', ') }}"{% endif %}>{{ n }}</span>
           {% if cols and cols|length %}
           <div class="mana-group" aria-hidden="true">
-            {% for c in cols %}<span class="mana mana-{{ c }}" title="{{ c }}"></span>{% endfor %}
+            {% set dots = (badges.dots if badges and badges.dots else cols) %}
+            {% for c in dots %}<a href="/owned?filter_color={{ c }}{% if color_mode == 'inclusive' %}&color_mode=inclusive{% endif %}" class="mana-link" onclick="event.stopPropagation()" title="{{ c }}"><span class="mana mana-{{ c }}"></span></a>{% endfor %}
           </div>
           <span class="sr-only"> Colors: {{ cols|join(', ') }}</span>
           {% endif %}
-          <a href="/cards/{{ n|urlencode }}?ref=owned" class="card-details-btn" onclick="event.stopPropagation()">Card Details</a>
-          <div class="card-tile-printing-row" onclick="event.stopPropagation()">
-            {{ printing_button(n, card_idx, sel_printing) }}
+          {% if badges and (badges.primary or badges.subs) %}
+          {% set badge_inclusive = color_mode == 'inclusive' or (badges.subs and badges.subs|length > 0) %}
+          <div class="tile-color-names">
+            {% if badges.primary %}
+            <a href="/owned?filter_color={{ badges.primary.filter }}{% if badge_inclusive %}&color_mode=inclusive{% endif %}" class="tile-color-name-badge tile-color-name-primary" onclick="event.stopPropagation()">{{ badges.primary.name }}</a>
+            {% endif %}
+            {% for sub in badges.subs %}
+            <a href="/owned?filter_color={{ sub.filter }}{% if badge_inclusive %}&color_mode=inclusive{% endif %}" class="tile-color-name-badge tile-color-name-sub" onclick="event.stopPropagation()">{{ sub.name }}</a>
+            {% endfor %}
           </div>
+          {% endif %}
+          {% if tags and tags|length %}
+          <div class="card-browser-tile-tags">
+            {% for tag in tags %}
+            <a href="/owned?filter_tags={{ tag|urlencode }}" class="tag tag-clickable" onclick="event.stopPropagation()">{{ tag }}</a>
+            {% endfor %}
+          </div>
+          {% endif %}
         </div>
       </label>
     </li>
@@ -237,6 +268,7 @@ function applyFilter() {
   var sort   = (document.getElementById('filter-sort')  || {value:''}).value || '';
   var type   = (document.getElementById('filter-type')  || {value:''}).value || '';
   var color  = (document.getElementById('filter-color') || {value:''}).value || '';
+  var colorInclusive = (document.getElementById('filter-color-inclusive') || {checked:false}).checked || false;
   var cmcMin = (document.getElementById('filter-cmc-min')   || {value:''}).value || '';
   var cmcMax = (document.getElementById('filter-cmc-max')   || {value:''}).value || '';
   var pwMin  = (document.getElementById('filter-power-min') || {value:''}).value || '';
@@ -253,6 +285,7 @@ function applyFilter() {
   if (sort && sort !== 'name') params.set('sort_by', sort);
   if (type)   params.set('filter_type', type);
   if (color)  params.set('filter_color', color);
+  if (color && colorInclusive) params.set('color_mode', 'inclusive');
   if (cmcMin) params.set('cmc_min', cmcMin);
   if (cmcMax) params.set('cmc_max', cmcMax);
   if (pwMin)  params.set('power_min', pwMin);

--- a/code/web/templates/partials/_macros.html
+++ b/code/web/templates/partials/_macros.html
@@ -44,6 +44,21 @@
   </button>
 {%- endmacro %}
 
+{% macro foil_toggle_button(name, idx, is_foil=False, compact=False, deck=None) -%}
+  {# Toggles whether this card should use its foil price/finish in the deck.
+     Mirrors `printing_button()`'s signature and OOB-update pattern.
+     `deck`, when provided (only on the saved-deck view, for its owner),
+     persists the choice to that on-disk deck CSV instead of the build
+     wizard's session-scoped state. #}
+  <button type="button" class="btn btn-foil-toggle{% if compact %} btn-foil-toggle-compact{% endif %}{% if is_foil %} active{% endif %}"
+          title="{{ 'Use the nonfoil price/finish' if is_foil else 'Use the foil price/finish' }}"
+          aria-pressed="{{ 'true' if is_foil else 'false' }}" data-is-foil="{{ '1' if is_foil else '0' }}"
+          hx-post="{{ '/decks/foil' if deck else '/build/foil' }}" hx-target="this" hx-swap="outerHTML"
+          hx-vals='{"name": "{{ name }}", "idx": "{{ idx }}", "foil": "{{ '0' if is_foil else '1' }}", "compact": "{{ '1' if compact else '0' }}"{% if deck %}, "deck": "{{ deck }}"{% endif %}}'>
+    {% if compact %}&#10024;{% else %}{% if is_foil %}Foil &#10024;{% else %}Use Foil{% endif %}{% endif %}
+  </button>
+{%- endmacro %}
+
 {% macro color_identity(colors, is_colorless=False, aria_label='', title_text='') -%}
   <div class="color-identity" role="img"
        aria-label="{{ aria_label }}"

--- a/code/web/templates/partials/deck_summary.html
+++ b/code/web/templates/partials/deck_summary.html
@@ -1,4 +1,4 @@
-{% from 'partials/_macros.html' import printing_button %}
+{% from 'partials/_macros.html' import printing_button, foil_toggle_button %}
 <div id="deck-summary" data-summary>
 {% if budget_config and budget_config.total %}
 <script>window._budgetCfg={"total":{{ budget_config.total|float }},"card_ceiling":{{ budget_config.card_ceiling|float if budget_config.card_ceiling else 'null' }}};</script>
@@ -85,13 +85,15 @@
                 {% set owned = (owned_set is defined and c.name and (c.name|lower in owned_set)) %}
                 {% set list_idx = c.name|slugify ~ '-list' %}
                 {% set sel_printing_list = (printings.get(c.name.lower()) if printings is defined else None) or c.scryfall_id or '' %}
+                {% set is_foil_list = (foils.get(c.name.lower(), False) if foils is defined else False) or (c.is_foil or False) %}
                 <span class="count">{{ cnt }}</span>
                 <span class="times">x</span>
                 <span class="name dfc-anchor" title="{{ c.name }}" data-card-name="{{ c.name }}" data-count="{{ cnt }}" data-role="{{ c.role }}" data-tags="{{ (c.tags|map('trim')|join(', ')) if c.tags else '' }}" data-printing-id="{{ sel_printing_list }}"{% if c.metadata_tags %} data-metadata-tags="{{ (c.metadata_tags|map('trim')|join(', ')) }}"{% endif %}{% if overlaps %} data-overlaps="{{ overlaps|join(', ') }}"{% endif %}>{{ c.name }}</span>
-                <span class="card-price-inline" data-price-for="{{ c.name }}" data-printing-id="{{ sel_printing_list }}"></span>
+                <span class="card-price-inline" data-price-for="{{ c.name }}" data-printing-id="{{ sel_printing_list }}" data-foil="{{ '1' if is_foil_list else '0' }}"></span>
                 <div class="list-row-printing">
                   {{ printing_button(c.name, list_idx, sel_printing_list, compact=True, deck=(deck_edit_ctx.deck if deck_edit_ctx is defined and deck_edit_ctx else None)) }}
-                  <div id="price-overlay-{{ list_idx }}" class="card-price-overlay" data-price-for="{{ c.name }}" data-printing-id="{{ sel_printing_list }}" style="display:none" aria-hidden="true"></div>
+                  {{ foil_toggle_button(c.name, list_idx, is_foil_list, compact=True, deck=(deck_edit_ctx.deck if deck_edit_ctx is defined and deck_edit_ctx else None)) }}
+                  <div id="price-overlay-{{ list_idx }}" class="card-price-overlay" data-price-for="{{ c.name }}" data-printing-id="{{ sel_printing_list }}" data-foil="{{ '1' if is_foil_list else '0' }}" style="display:none" aria-hidden="true"></div>
                 </div>
                 <span class="flip-slot" aria-hidden="true">
                   {% if c.dfc_land %}
@@ -120,6 +122,7 @@
               {% set cnt = c.count if c.count else 1 %}
               {% set owned = (owned_set is defined and c.name and (c.name|lower in owned_set)) %}
               {% set sel_printing = (printings.get(c.name.lower()) if printings is defined else None) or c.scryfall_id or '' %}
+              {% set is_foil = (foils.get(c.name.lower(), False) if foils is defined else False) or (c.is_foil or False) %}
               {% set card_idx = c.name|slugify %}
               {% set overlaps = [] %}
               {% if synergies_norm and c.tags %}
@@ -130,15 +133,15 @@
                   {% endif %}
                 {% endfor %}
               {% endif %}
-              <div class="stack-card {% if (game_changers and (c.name in game_changers)) or ('game_changer' in (c.role or '') or 'Game Changer' in (c.role or '')) %}game-changer{% endif %}">
+              <div class="stack-card foil-shine-target {% if (game_changers and (c.name in game_changers)) or ('game_changer' in (c.role or '') or 'Game Changer' in (c.role or '')) %}game-changer{% endif %}{% if is_foil %} card-foil-shine{% endif %}">
                 <img class="card-thumb" id="card-img-{{ card_idx }}" loading="lazy" decoding="async" src="{{ c.name|card_image('normal', sel_printing) }}" alt="{{ c.name }} image" data-card-name="{{ c.name }}" data-count="{{ cnt }}" data-role="{{ c.role }}" data-tags="{{ (c.tags|map('trim')|join(', ')) if c.tags else '' }}" data-printing-id="{{ sel_printing }}"{% if overlaps %} data-overlaps="{{ overlaps|join(', ') }}"{% endif %}
                      srcset="{{ c.name|card_image('small', sel_printing) }} 160w, {{ c.name|card_image('normal', sel_printing) }} 488w"
                      sizes="(max-width: 1200px) 160px, 240px" />
-                <div class="count-badge">{{ cnt }}x</div>                <div class="card-price-overlay" id="price-overlay-{{ card_idx }}" data-price-for="{{ c.name }}" data-printing-id="{{ sel_printing }}" aria-hidden="true"></div>                {% if show_new_badge and c.isNew %}<div class="card-new-badge" title="Recently Released" aria-hidden="true">New</div>{% endif %}                <div class="owned-badge" title="{{ 'Owned' if owned else 'Not owned' }}" aria-label="{{ 'Owned' if owned else 'Not owned' }}">{% if owned %}✔{% else %}✖{% endif %}</div>
+                <div class="count-badge">{{ cnt }}x</div>                <div class="card-price-overlay" id="price-overlay-{{ card_idx }}" data-price-for="{{ c.name }}" data-printing-id="{{ sel_printing }}" data-foil="{{ '1' if is_foil else '0' }}" aria-hidden="true"></div>                {% if show_new_badge and c.isNew %}<div class="card-new-badge" title="Recently Released" aria-hidden="true">New</div>{% endif %}                <div class="owned-badge" title="{{ 'Owned' if owned else 'Not owned' }}" aria-label="{{ 'Owned' if owned else 'Not owned' }}">{% if owned %}✔{% else %}✖{% endif %}</div>
                 {% if c.dfc_land %}
                   <div class="dfc-thumb-badge {% if c.dfc_adds_extra_land %}extra{% else %}counts{% endif %}" title="{{ c.dfc_note or 'Modal double-faced land' }}">DFC{% if c.dfc_adds_extra_land %}+1{% endif %}</div>
                 {% endif %}
-                <div class="printing-btn-overlay">{{ printing_button(c.name, card_idx, sel_printing, compact=True, deck=(deck_edit_ctx.deck if deck_edit_ctx is defined and deck_edit_ctx else None)) }}</div>
+                <div class="printing-btn-overlay">{{ printing_button(c.name, card_idx, sel_printing, compact=True, deck=(deck_edit_ctx.deck if deck_edit_ctx is defined and deck_edit_ctx else None)) }}{{ foil_toggle_button(c.name, card_idx, is_foil, compact=True, deck=(deck_edit_ctx.deck if deck_edit_ctx is defined and deck_edit_ctx else None)) }}</div>
               </div>
             {% endfor %}
             </div>


### PR DESCRIPTION
## Summary
- Foil finish selection/pricing across build/deck/price APIs and the web UI (card detail, saved decks, builder wizard, owned library, card browser)
- Card browser/owned library clickable color-identity names and an Inclusive Match color filter toggle
- Card detail page: 'Transform' button for double-faced/split/flip/meld cards, showing both faces' type/mana cost/power-toughness/oracle text
- Bug fixes: color filter letter-order matching, back-face image not updating on printing change, and /api/printings/{card_name} returning empty for DFC names

See CHANGELOG.md / RELEASE_NOTES_TEMPLATE.md Unreleased section for full details.

## Testing
- \pytest -q code/tests/test_api_v1_decks.py code/tests/test_price_service.py\ (pass)
- Manually verified DFC Transform button, back-face image printing sync, and \/api/printings\ fix via Docker rebuild + curl