### PR TITLE
Creature count min/max/on-theme targeting with legacy fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ This format follows Keep a Changelog principles and aims for Semantic Versioning
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- Ideal creature counts now support a minimum, a maximum, and an "on-theme" target (with a tolerance percentage, capped at 15%), instead of a single number, so decks can guarantee a creature floor while still weighting toward your chosen themes
+- The creature maximum is now enforced across every phase that can add a creature (ramp, removal, board wipes, card advantage, protection), not just creature selection, so decks reliably stop at the requested count instead of overshooting it
+- A "Legacy Creature Allocation" option is available in the CLI and web build wizard for anyone who prefers the original single-target behavior
+- The wizard's ideal-counts fieldset gained a "Reset to Defaults" button and a short note explaining how the min/max/on-theme/tolerance controls interact
+- Legacy-only fields (min, on-theme, tolerance) are now hidden rather than just greyed out when legacy mode is enabled
 
 ### Changed
 _No unreleased changes yet_

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -2,7 +2,10 @@
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- New creature count controls: set a minimum, a maximum, and how many should match your deck's themes, instead of just one number
+- The maximum is now reliably respected across the whole build, so decks stop overshooting your requested creature count
+- Prefer the old behavior? A "Legacy Creature Allocation" toggle is available in the CLI and web build wizard
+- A "Reset to Defaults" button and a short explainer note were also added to the wizard
 
 ### Changed
 _No unreleased changes yet_

--- a/code/deck_builder/builder.py
+++ b/code/deck_builder/builder.py
@@ -207,6 +207,7 @@ class DeckBuilder(
                 self.add_creatures_phase()
             if hasattr(self, 'add_spells_phase'):
                 self.add_spells_phase()
+            self._backfill_creature_floor()
             if hasattr(self, 'post_spell_land_adjust'):
                 self.post_spell_land_adjust()
             # Modular reporting phase
@@ -610,6 +611,65 @@ class DeckBuilder(
                 else:
                     break  # No removable non-land found; stop backfilling
         self.output_func(f"  Land Count Now : {self._current_land_count()} / {land_target} ({added} added)")
+
+    def _backfill_creature_floor(self) -> None:
+        """Add on-theme creatures to reach ideal_counts['creatures_min'] if the build fell short.
+
+        Modern mode only (roadmap 33); no-op in legacy mode or when creatures_min is 0/unset.
+        """
+        if getattr(self, 'creature_builder_mode', 'modern') != 'modern':
+            return
+        ic = getattr(self, 'ideal_counts', None) or {}
+        floor = int(ic.get('creatures_min', 0) or 0)
+        if floor <= 0:
+            return
+        count_fn = getattr(self, '_creature_count_in_library', None)
+        current = count_fn() if callable(count_fn) else 0
+        shortfall = floor - current
+        if shortfall <= 0:
+            return
+        prepare_fn = getattr(self, '_prepare_creature_pool', None)
+        pool = prepare_fn() if callable(prepare_fn) else None
+        existing_names = set(self.card_library.keys())
+        if pool is not None and not pool.empty:
+            pool = pool[~pool['name'].isin(existing_names)]
+        if pool is None or pool.empty:
+            self.output_func(f"\nCreature Floor Backfill: need {shortfall} more creature(s) to reach the minimum of {floor}, but no candidates remain.")
+            return
+        sort_cols: List[str] = []
+        asc: List[bool] = []
+        if '_multiMatch' in pool.columns:
+            # Prefer on-theme creatures first, falling back to off-theme if not enough remain.
+            sort_cols.append('_multiMatch')
+            asc.append(False)
+        if 'edhrecRank' in pool.columns:
+            sort_cols.append('edhrecRank')
+            asc.append(True)
+        if 'manaValue' in pool.columns:
+            sort_cols.append('manaValue')
+            asc.append(True)
+        if sort_cols:
+            pool = pool.sort_values(by=sort_cols, ascending=asc, na_position='last')
+        self.output_func(f"\nCreature Floor Backfill: {shortfall} slot(s) below the minimum of {floor}; adding on-theme creatures.")
+        added = 0
+        for _, row in pool.iterrows():
+            if added >= shortfall:
+                break
+            nm = row['name']
+            self.add_card(
+                nm,
+                card_type=row.get('type', 'Creature'),
+                mana_cost=row.get('manaCost', ''),
+                mana_value=row.get('manaValue', row.get('cmc', '')),
+                creature_types=row.get('creatureTypes', []) if isinstance(row.get('creatureTypes', []), list) else [],
+                tags=bu.ensure_theme_tags_list(row.get('themeTags')),
+                role='creature',
+                sub_role='floor_backfill',
+                added_by='creature_floor_backfill'
+            )
+            added += 1
+        new_total = count_fn() if callable(count_fn) else current + added
+        self.output_func(f"  Creature Count Now : {new_total} / {floor} minimum ({added} added)")
 
     def _generate_recommendations(self, base_stem: str, limit: int):
         """Silently build a full (non-owned-filtered) deck with same choices and export top recommendations.
@@ -2219,13 +2279,17 @@ class DeckBuilder(
     # Deck Building Step 2: Ideal Composition Counts
     # ===========================
     ideal_counts: Dict[str, int] = field(default_factory=dict)
+    # 'modern' (default) uses creatures_min/creatures_max/on_theme_creatures; 'legacy' uses
+    # the old single 'creatures' target with no on-theme split (see roadmap 33).
+    creature_builder_mode: str = 'modern'
 
     def run_deck_build_step2(self) -> Dict[str, int]:
         """Determine ideal counts for general card categories (bracket‑agnostic baseline).
 
         Prompts the user (Enter to keep default). Stores results in ideal_counts and returns it.
         Categories:
-          ramp, lands, basic_lands, creatures, removal, wipes, card_advantage, protection
+          ramp, lands, basic_lands, creatures_min, creatures (max), on_theme_creatures,
+          creature_tolerance, removal, wipes, card_advantage, protection
         """
         # Initialize defaults from constants if not already present
         defaults = {
@@ -2233,7 +2297,10 @@ class DeckBuilder(
             'lands': bc.DEFAULT_LAND_COUNT,
             'basic_lands': bc.DEFAULT_BASIC_LAND_COUNT,
             'fetch_lands': getattr(bc, 'FETCH_LAND_DEFAULT_COUNT', 3),
+            'creatures_min': bc.DEFAULT_CREATURE_COUNT_MIN,
             'creatures': bc.DEFAULT_CREATURE_COUNT,
+            'on_theme_creatures': self.ideal_counts.get('on_theme_creatures', bc.DEFAULT_ON_THEME_CREATURE_COUNT),
+            'creature_tolerance_pct': int(round(self.ideal_counts.get('creature_tolerance', bc.DEFAULT_CREATURE_TOLERANCE) * 100)),
             'removal': bc.DEFAULT_REMOVAL_COUNT,
             'wipes': bc.DEFAULT_WIPES_COUNT,
             'card_advantage': bc.DEFAULT_CARD_ADVANTAGE_COUNT,
@@ -2245,16 +2312,36 @@ class DeckBuilder(
             if k not in self.ideal_counts:
                 self.ideal_counts[k] = v
 
+        # Creature allocation mode opt-in (roadmap 33, Milestone 5)
+        self.output_func("\nCreature Allocation Mode:")
+        self.output_func(f"  Legacy Creature Allocation: {bc.LEGACY_CREATURE_MODE_DESCRIPTION}")
+        legacy_raw = self.input_func("Use legacy creature allocation? [y/N]: ").strip().lower()
+        self.creature_builder_mode = 'legacy' if legacy_raw in ('y', 'yes') else 'modern'
+        modern_only_keys = {'creatures_min', 'on_theme_creatures', 'creature_tolerance_pct'}
+
         self.output_func("\nSet Ideal Deck Composition Counts (press Enter to accept default/current):")
         for key, prompt in bc.DECK_COMPOSITION_PROMPTS.items():
             if key not in defaults:  # skip price prompts & others for this step
                 continue
+            if self.creature_builder_mode == 'legacy' and key in modern_only_keys:
+                continue
             current_default = self.ideal_counts[key]
-            value = self._prompt_int_with_default(f"{prompt} ", current_default, minimum=0, maximum=200)
+            if key == 'on_theme_creatures':
+                # Never suggest more on-theme creatures than the max just chosen
+                current_default = min(current_default, self.ideal_counts.get('creatures', current_default))
+            max_bound = int(bc.MAX_CREATURE_TOLERANCE * 100) if key == 'creature_tolerance_pct' else 200
+            value = self._prompt_int_with_default(f"{prompt} ", current_default, minimum=0, maximum=max_bound)
             self.ideal_counts[key] = value
+
+        # Convert the tolerance percent scratch value into a stored 0-1 fraction, then
+        # sync the legacy 'creatures' alias with the new min/max/on-theme keys.
+        if 'creature_tolerance_pct' in self.ideal_counts:
+            self.ideal_counts['creature_tolerance'] = self.ideal_counts.pop('creature_tolerance_pct') / 100.0
+        self._normalize_creature_ideal_keys()
 
         # Smart land analysis — runs after defaults are seeded so env overrides still win
         self.run_land_analysis()
+        self._clamp_creatures_max_to_land_budget()
 
         # Basic validation adjustments
         # Ensure basic_lands <= lands
@@ -2264,6 +2351,39 @@ class DeckBuilder(
 
         self._print_ideal_counts_summary()
         return self.ideal_counts
+
+    def _normalize_creature_ideal_keys(self) -> None:
+        """Keep 'creatures' (legacy alias) and creatures_max/min/on_theme/tolerance in sync.
+
+        'creatures_max' is authoritative going forward; if present it wins and 'creatures'
+        mirrors it, otherwise 'creatures' backfills 'creatures_max' for older callers/configs.
+        """
+        ic = self.ideal_counts
+        if 'creatures_max' in ic:
+            ic['creatures'] = ic['creatures_max']
+        elif 'creatures' in ic:
+            ic['creatures_max'] = ic['creatures']
+        else:
+            ic['creatures'] = ic['creatures_max'] = bc.DEFAULT_CREATURE_COUNT
+        ic.setdefault('creatures_min', bc.DEFAULT_CREATURE_COUNT_MIN)
+        ic.setdefault('on_theme_creatures', ic['creatures_max'])
+        ic.setdefault('creature_tolerance', bc.DEFAULT_CREATURE_TOLERANCE)
+        # Clamp dependent values to the resolved max
+        ic['creatures_min'] = max(0, min(int(ic['creatures_min']), int(ic['creatures_max'])))
+        ic['on_theme_creatures'] = max(0, min(int(ic['on_theme_creatures']), int(ic['creatures_max'])))
+        ic['creature_tolerance'] = max(0.0, min(float(ic['creature_tolerance']), bc.MAX_CREATURE_TOLERANCE))
+
+    def _clamp_creatures_max_to_land_budget(self) -> None:
+        """Cap creatures_max so it can never exceed the non-commander budget minus lands."""
+        ic = self.ideal_counts
+        if 'creatures_max' not in ic and 'creatures' not in ic:
+            return
+        self._normalize_creature_ideal_keys()
+        lands = int(ic.get('lands', bc.DEFAULT_LAND_COUNT))
+        ceiling = max(0, bc.DECK_NON_COMMANDER_SLOTS - lands)
+        if int(ic['creatures_max']) > ceiling:
+            ic['creatures_max'] = ceiling
+            self._normalize_creature_ideal_keys()
 
     # Helper to prompt integer values with default
     def _prompt_int_with_default(self, prompt: str, default: int, minimum: int = 0, maximum: int = 999) -> int:
@@ -2284,14 +2404,19 @@ class DeckBuilder(
             ('lands', 'Total Lands'),
             ('basic_lands', 'Minimum Basic Lands'),
             ('fetch_lands', 'Fetch Lands'),
-            ('creatures', 'Creatures'),
+            ('creatures_min', 'Creatures (Min)'),
+            ('creatures', 'Creatures (Max)'),
+            ('on_theme_creatures', 'On-Theme Creatures'),
             ('removal', 'Spot Removal'),
             ('wipes', 'Board Wipes'),
             ('card_advantage', 'Card Advantage'),
             ('protection', 'Protection')
         ]
         width = max(len(label) for _, label in order)
+        modern_only_keys = {'creatures_min', 'on_theme_creatures'}
         for key, label in order:
+            if self.creature_builder_mode == 'legacy' and key in modern_only_keys:
+                continue
             if key in self.ideal_counts:
                 self.output_func(f"  {label.ljust(width)} : {self.ideal_counts[key]}")
 
@@ -2307,14 +2432,19 @@ class DeckBuilder(
             ('lands', 'Total Lands'),
             ('basic_lands', 'Basic Lands (Min)'),
             ('fetch_lands', 'Fetch Lands'),
-            ('creatures', 'Creatures'),
+            ('creatures_min', 'Creatures (Min)'),
+            ('creatures', 'Creatures (Max)'),
+            ('on_theme_creatures', 'On-Theme Creatures'),
             ('removal', 'Spot Removal'),
             ('wipes', 'Board Wipes'),
             ('card_advantage', 'Card Advantage'),
             ('protection', 'Protection')
         ]
         width = max(len(label) for _, label in order)
+        modern_only_keys = {'creatures_min', 'on_theme_creatures'}
         for key, label in order:
+            if self.creature_builder_mode == 'legacy' and key in modern_only_keys:
+                continue
             if key in self.ideal_counts:
                 self.output_func(f"  {label.ljust(width)} : {self.ideal_counts[key]}")
 

--- a/code/deck_builder/builder_constants.py
+++ b/code/deck_builder/builder_constants.py
@@ -470,12 +470,25 @@ LAND_REMOVAL_MAX_ATTEMPTS: Final[int] = 3
 PROTECTED_LANDS: Final[List[str]] = BASIC_LANDS + KINDRED_LAND_NAMES
 
 # Other defaults
-DEFAULT_CREATURE_COUNT: Final[int] = 25  # Default number of creatures
+DEFAULT_CREATURE_COUNT: Final[int] = 28  # Default hard cap on creatures (ideal_counts['creatures_max'])
+DEFAULT_CREATURE_COUNT_MIN: Final[int] = 0  # Default hard floor on creatures (ideal_counts['creatures_min'])
+DEFAULT_ON_THEME_CREATURE_COUNT: Final[int] = 20  # Default on-theme creature target for fresh sessions (ideal_counts['on_theme_creatures'])
+DEFAULT_CREATURE_TOLERANCE: Final[float] = 0.10  # Default +/- grace on the creature cap, mirrors BUDGET_POOL_TOLERANCE
+MAX_CREATURE_TOLERANCE: Final[float] = 0.15  # Hard ceiling on the +/- grace (ideal_counts['creature_tolerance']); 30% felt excessive
 DEFAULT_REMOVAL_COUNT: Final[int] = 10  # Default number of spot removal spells
 DEFAULT_WIPES_COUNT: Final[int] = 2  # Default number of board wipes
 
 DEFAULT_CARD_ADVANTAGE_COUNT: Final[int] = 10  # Default number of card advantage pieces
 DEFAULT_PROTECTION_COUNT: Final[int] = 8  # Default number of protective effects (hexproof, indestructible, protection, ward, etc.)
+
+# Non-commander deck slots (99 = 100-card deck minus the commander's own slot)
+DECK_NON_COMMANDER_SLOTS: Final[int] = 99
+
+# Shared short description for the legacy creature allocation toggle (CLI prompt + web UI checkbox)
+LEGACY_CREATURE_MODE_DESCRIPTION: Final[str] = (
+    "Uses the original method: one creature target, filled by theme weight, "
+    "backfilled with any on-theme creature if short. Ignores min/on-theme sliders below."
+)
 
 # Deck composition prompts
 DECK_COMPOSITION_PROMPTS: Final[Dict[str, str]] = {
@@ -483,7 +496,10 @@ DECK_COMPOSITION_PROMPTS: Final[Dict[str, str]] = {
     'lands': 'Enter desired number of total lands (default: 35):',
     'basic_lands': 'Enter minimum number of basic lands (default: 15):',
     'fetch_lands': 'Enter desired number of fetch lands (default: 3):',
-    'creatures': 'Enter desired number of creatures (default: 25):',
+    'creatures_min': 'Enter minimum number of creatures, hard floor (default: 0):',
+    'creatures': 'Enter desired maximum number of creatures (default: 28):',
+    'on_theme_creatures': 'Enter desired number of on-theme (theme-matched) creatures (default: 20):',
+    'creature_tolerance_pct': 'Enter creature count tolerance percent, +/- (default: 10):',
     'removal': 'Enter desired number of spot removal spells (default: 10):',
     'wipes': 'Enter desired number of board wipes (default: 2):',
     'card_advantage': 'Enter desired number of card advantage pieces (default: 10):',

--- a/code/deck_builder/builder_utils.py
+++ b/code/deck_builder/builder_utils.py
@@ -1740,3 +1740,34 @@ def enforce_land_cap(builder, step_label: str = ""):
 	if removed:
 		builder.output_func(f"Trimmed {removed} basic land(s). New land count: {current_land}/{land_target}. Basic total now {count_basic_lands(builder.card_library)} (floor {floor_basics}).")
 
+
+def is_creature_row(row) -> bool:
+	"""True if a card pool row's type line indicates a Creature (case-insensitive)."""
+	try:
+		return 'creature' in str(row.get('type', '') or '').lower()
+	except Exception:
+		return False
+
+
+def creature_cap_with_tolerance(builder) -> int:
+	"""Effective creature cap: creatures_max plus its +/- tolerance grace, floored (roadmap 33)."""
+	ic = getattr(builder, 'ideal_counts', None) or {}
+	cap = ic.get('creatures_max', ic.get('creatures'))
+	if cap is None:
+		return 10 ** 9  # no cap configured; treat as unlimited
+	tolerance = float(ic.get('creature_tolerance', 0.0) or 0.0)
+	return int(math.floor(int(cap) * (1.0 + tolerance)))
+
+
+def creature_room_remaining(builder) -> int:
+	"""How many more creature-typed cards can be added before hitting the tolerant cap.
+
+	Legacy mode has no cross-phase cap enforcement (roadmap 33); returns unlimited room.
+	"""
+	if getattr(builder, 'creature_builder_mode', 'modern') != 'modern':
+		return 10 ** 9
+	cap = creature_cap_with_tolerance(builder)
+	count_fn = getattr(builder, '_creature_count_in_library', None)
+	current = count_fn() if callable(count_fn) else 0
+	return max(0, cap - current)
+

--- a/code/deck_builder/phases/phase2_lands_analysis.py
+++ b/code/deck_builder/phases/phase2_lands_analysis.py
@@ -201,7 +201,11 @@ class LandAnalysisMixin:
         This ensures the spell phases never consume the slots reserved for lands,
         making backfill unnecessary in the normal case.
         """
-        NON_LAND_KEYS = ['creatures', 'ramp', 'removal', 'wipes', 'card_advantage', 'protection']
+        # Ensure creatures_max exists (and mirrors the legacy 'creatures' alias) before scaling.
+        normalize = getattr(self, '_normalize_creature_ideal_keys', None)
+        if callable(normalize):
+            normalize()
+        NON_LAND_KEYS = ['creatures_max', 'ramp', 'removal', 'wipes', 'card_advantage', 'protection']
         # 99 = total deck slots minus commander
         deck_slots = getattr(bc, 'DECK_NON_COMMANDER_SLOTS', 99)
         budget = deck_slots - land_target
@@ -237,6 +241,9 @@ class LandAnalysisMixin:
                 f'  [Smart Lands] Earmarked {land_target} land slots; '
                 f'scaled non-land targets to fit {budget} remaining: {", ".join(adjustments)}'
             )
+        # Re-sync 'creatures' alias and re-clamp creatures_min/on_theme_creatures to the new max.
+        if callable(normalize):
+            normalize()
 
     # ------------------------------------------------------------------
     # Profile determination

--- a/code/deck_builder/phases/phase3_creatures.py
+++ b/code/deck_builder/phases/phase3_creatures.py
@@ -44,7 +44,10 @@ class CreatureAdditionMixin:
         if not themes_ordered or not selected_tags_lower:
             self.output_func("No themes selected; skipping creature addition.")
             return
-        desired_total = (self.ideal_counts.get('creatures') if getattr(self, 'ideal_counts', None) else None) or getattr(bc, 'DEFAULT_CREATURE_COUNT', 25)
+        if self._creature_phase_should_skip():
+            self.output_func("Creature cap (creatures_max) is 0; skipping creature addition.")
+            return
+        desired_total = self._creature_phase_target()
         weights: Dict[str, float] = dict(getattr(context, 'weights', {}))
         creature_df = df[df['type'].str.contains('Creature', case=False, na=False)].copy()
         commander_name = getattr(self, 'commander', None) or getattr(self, 'commander_name', None)
@@ -406,6 +409,24 @@ class CreatureAdditionMixin:
             pass
         return total
 
+    def _creature_phase_target(self) -> int:
+        """Phase 3 creature target: on_theme_creatures (modern mode) or creatures (legacy)."""
+        ic = getattr(self, 'ideal_counts', None) or {}
+        default = getattr(bc, 'DEFAULT_CREATURE_COUNT', 28)
+        if getattr(self, 'creature_builder_mode', 'modern') == 'legacy':
+            return int(ic.get('creatures', default))
+        return int(ic.get('on_theme_creatures', ic.get('creatures', default)))
+
+    def _creature_phase_should_skip(self) -> bool:
+        """True when the hard creature cap (creatures_max) is 0, per roadmap 33."""
+        ic = getattr(self, 'ideal_counts', None) or {}
+        default = getattr(bc, 'DEFAULT_CREATURE_COUNT', 28)
+        cap = ic.get('creatures_max', ic.get('creatures', default))
+        try:
+            return int(cap) <= 0
+        except Exception:
+            return False
+
     def _prepare_creature_pool(self):
         df = getattr(self, '_combined_cards_df', None)
         if df is None or df.empty or 'type' not in df.columns:
@@ -505,7 +526,9 @@ class CreatureAdditionMixin:
         if getattr(self, 'tertiary_tag', None):
             themes_ordered.append(('tertiary', self.tertiary_tag))
         weights = self._theme_weights(themes_ordered)
-        desired_total = (self.ideal_counts.get('creatures') if getattr(self, 'ideal_counts', None) else None) or getattr(bc, 'DEFAULT_CREATURE_COUNT', 25)
+        if self._creature_phase_should_skip():
+            return
+        desired_total = self._creature_phase_target()
         current_added = self._creature_count_in_library()
         remaining = max(0, desired_total - current_added)
         if remaining <= 0:
@@ -564,7 +587,9 @@ class CreatureAdditionMixin:
         self.output_func(f"Added {added} creatures for {role} theme '{tag}' (target {target}).")
 
     def _add_creatures_fill(self):
-        desired_total = (self.ideal_counts.get('creatures') if getattr(self, 'ideal_counts', None) else None) or getattr(bc, 'DEFAULT_CREATURE_COUNT', 25)
+        if self._creature_phase_should_skip():
+            return
+        desired_total = self._creature_phase_target()
         current_added = self._creature_count_in_library()
         need = max(0, desired_total - current_added)
         if need <= 0:
@@ -621,7 +646,9 @@ class CreatureAdditionMixin:
         tags = [t for t in [getattr(self, 'primary_tag', None), getattr(self, 'secondary_tag', None), getattr(self, 'tertiary_tag', None)] if t]
         if combine_mode != 'AND' or len(tags) < 2:
             return
-        desired_total = (self.ideal_counts.get('creatures') if getattr(self, 'ideal_counts', None) else None) or getattr(bc, 'DEFAULT_CREATURE_COUNT', 25)
+        if self._creature_phase_should_skip():
+            return
+        desired_total = self._creature_phase_target()
         current_added = self._creature_count_in_library()
         remaining_capacity = max(0, desired_total - current_added)
         if remaining_capacity <= 0:

--- a/code/deck_builder/phases/phase4_spells.py
+++ b/code/deck_builder/phases/phase4_spells.py
@@ -184,9 +184,13 @@ class SpellAdditionMixin:
 
         def add_from_pool(pool, remaining_needed, added_list, phase_name):
             added_now = 0
+            skipped_cap = 0
             for _, r in pool.iterrows():
                 nm = r['name']
                 if nm.lower() in already:
+                    continue
+                if bu.is_creature_row(r) and bu.creature_room_remaining(self) <= 0:
+                    skipped_cap += 1
                     continue
                 self.add_card(
                     nm,
@@ -205,6 +209,8 @@ class SpellAdditionMixin:
                     break
             if added_now:
                 self.output_func(f"Ramp phase {phase_name}: added {added_now}/{remaining_needed} target.")
+            if skipped_cap:
+                self.output_func(f"Ramp phase {phase_name}: skipped {skipped_cap} creature-typed card(s) at the creature cap.")
             return added_now
 
         rocks_pool = work[work['type'].fillna('').str.contains('Artifact', case=False, na=False)]
@@ -311,11 +317,15 @@ class SpellAdditionMixin:
         target = to_add if existing < target else to_add
         added = 0
         added_names: List[str] = []
+        skipped_cap = 0
         for _, r in pool.iterrows():
             if added >= target:
                 break
             nm = r['name']
             if nm.lower() in already:
+                continue
+            if bu.is_creature_row(r) and bu.creature_room_remaining(self) <= 0:
+                skipped_cap += 1
                 continue
             self.add_card(
                 nm,
@@ -335,6 +345,8 @@ class SpellAdditionMixin:
             self.output_func('Removal Cards Added:')
             for nm in added_names:
                 self.output_func(f"  - {nm}")
+        if skipped_cap:
+            self.output_func(f"Removal: skipped {skipped_cap} creature-typed card(s) at the creature cap.")
 
     # ---------------------------
     # Board Wipes
@@ -388,11 +400,15 @@ class SpellAdditionMixin:
         target = to_add if existing < target else to_add
         added = 0
         added_names: List[str] = []
+        skipped_cap = 0
         for _, r in pool.iterrows():
             if added >= target:
                 break
             nm = r['name']
             if nm.lower() in already:
+                continue
+            if bu.is_creature_row(r) and bu.creature_room_remaining(self) <= 0:
+                skipped_cap += 1
                 continue
             self.add_card(
                 nm,
@@ -412,6 +428,8 @@ class SpellAdditionMixin:
             self.output_func('Board Wipes Added:')
             for nm in added_names:
                 self.output_func(f"  - {nm}")
+        if skipped_cap:
+            self.output_func(f"Board Wipes: skipped {skipped_cap} creature-typed card(s) at the creature cap.")
 
     # ---------------------------
     # Card Advantage
@@ -482,11 +500,15 @@ class SpellAdditionMixin:
                 unconditional_df = bu.prefer_owned_first(unconditional_df, owned_lower)
         added_cond = 0
         added_cond_names: List[str] = []
+        skipped_cap = 0
         for _, r in conditional_df.iterrows():
             if added_cond >= conditional_target:
                 break
             nm = r['name']
             if nm.lower() in already:
+                continue
+            if bu.is_creature_row(r) and bu.creature_room_remaining(self) <= 0:
+                skipped_cap += 1
                 continue
             self.add_card(
                 nm,
@@ -511,6 +533,9 @@ class SpellAdditionMixin:
                 nm = r['name']
                 if nm.lower() in already:
                     continue
+                if bu.is_creature_row(r) and bu.creature_room_remaining(self) <= 0:
+                    skipped_cap += 1
+                    continue
                 self.add_card(
                     nm,
                     card_type=r.get('type',''),
@@ -525,6 +550,8 @@ class SpellAdditionMixin:
                 added_uncond += 1
                 added_uncond_names.append(nm)
         self.output_func(f"Added Card Advantage This Pass: conditional {added_cond}/{conditional_target}, total {(added_cond+added_uncond)}/{total_target}{' (dataset shortfall)' if (added_cond+added_uncond) < total_target else ''}")
+        if skipped_cap:
+            self.output_func(f"Card Advantage: skipped {skipped_cap} creature-typed card(s) at the creature cap.")
         if added_cond_names or added_uncond_names:
             self.output_func('Card Advantage Cards Added:')
             for nm in added_cond_names:
@@ -702,11 +729,15 @@ class SpellAdditionMixin:
             pass
         added = 0
         added_names: List[str] = []
+        skipped_cap = 0
         for _, r in pool.iterrows():
             if added >= target:
                 break
             nm = r['name']
             if nm.lower() in already:
+                continue
+            if bu.is_creature_row(r) and bu.creature_room_remaining(self) <= 0:
+                skipped_cap += 1
                 continue
             self.add_card(
                 nm,
@@ -721,6 +752,8 @@ class SpellAdditionMixin:
             added += 1
             added_names.append(nm)
         self.output_func(f"Added Protection This Pass: {added}/{target}{' (dataset shortfall)' if added < target else ''}")
+        if skipped_cap:
+            self.output_func(f"Protection: skipped {skipped_cap} creature-typed card(s) at the creature cap.")
         if added_names:
             self.output_func('Protection Cards Added:')
             for nm in added_names:

--- a/code/headless_runner.py
+++ b/code/headless_runner.py
@@ -212,6 +212,7 @@ def run(
     secondary_commander: Optional[str] = None,
     background: Optional[str] = None,
     enable_partner_mechanics: bool = False,
+    creature_builder_mode: Optional[str] = None,
 ) -> DeckBuilder:
     """Run a scripted non-interactive deck build and return the DeckBuilder instance.
 
@@ -254,13 +255,18 @@ def run(
     scripted_inputs.extend(owned_prompt_inputs)
     # Bracket (meta power / style) selection; default to 3 if not provided
     scripted_inputs.append(str(bracket_level if isinstance(bracket_level, int) and 1 <= bracket_level <= 5 else 3))
+    # Legacy creature allocation opt-in prompt (roadmap 33, Milestone 5)
+    scripted_inputs.append("y" if creature_builder_mode == "legacy" else "n")
     # Ideal count prompts (press Enter for defaults). Include fetch_lands if present.
     ideal_keys = {
         "ramp",
         "lands",
         "basic_lands",
         "fetch_lands",
+        "creatures_min",
         "creatures",
+        "on_theme_creatures",
+        "creature_tolerance_pct",
         "removal",
         "wipes",
         "card_advantage",
@@ -361,8 +367,15 @@ def run(
                 if iv is None:
                     continue
                 # Only accept known keys
-                if k in {"ramp","lands","basic_lands","creatures","removal","wipes","card_advantage","protection"}:
+                if k in {"ramp","lands","basic_lands","creatures_min","creatures","creatures_max","on_theme_creatures","removal","wipes","card_advantage","protection"}:
                     ic[k] = iv
+            # creature_tolerance is a 0-1 fraction, not an int; pass it through separately
+            tol = ideal_counts.get("creature_tolerance")
+            if tol is not None:
+                try:
+                    ic["creature_tolerance"] = float(tol)
+                except Exception:
+                    pass
             if ic:
                 builder.ideal_counts.update(ic)
         except Exception:
@@ -419,6 +432,11 @@ def run(
                         pass
         
 
+    if hasattr(builder, '_backfill_creature_floor'):
+        try:
+            builder._backfill_creature_floor()
+        except Exception:
+            pass
     builder.post_spell_land_adjust()
     _export_outputs(builder)
     return builder

--- a/code/tests/test_creature_allocation_build_integration.py
+++ b/code/tests/test_creature_allocation_build_integration.py
@@ -1,0 +1,102 @@
+"""Integration-level tests for roadmap 33 creature allocation (modern vs legacy mode).
+
+Full end-to-end deck builds need a rich card pool to exercise theme-based creature
+selection realistically, which the tiny `csv_files/testdata` fixture doesn't provide.
+These tests instead:
+  - Exercise `_backfill_creature_floor()` directly against a synthetic creature pool
+    (the real production method, just fed deterministic data).
+  - Run the full headless pipeline against `csv_files/testdata` to confirm the
+    legacy/modern mode selection actually threads end-to-end through the CLI-scripted
+    input flow (Milestone 5) without depending on pool richness.
+"""
+from __future__ import annotations
+
+import os
+
+import pandas as pd
+import pytest
+
+from code.deck_builder.builder import DeckBuilder
+from code.headless_runner import run
+
+
+def _make_builder(**ideal_overrides) -> DeckBuilder:
+    b = DeckBuilder(output_func=lambda *_: None, input_func=lambda *_: "", headless=True)
+    b.ideal_counts.update(ideal_overrides)
+    b._normalize_creature_ideal_keys()
+    return b
+
+
+def _synthetic_creature_pool(n: int) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "name": [f"Test Creature {i}" for i in range(n)],
+            "type": ["Creature — Test"] * n,
+            "manaCost": ["{1}"] * n,
+            "manaValue": [1] * n,
+            "creatureTypes": [[] for _ in range(n)],
+            "themeTags": [[] for _ in range(n)],
+            "edhrecRank": list(range(n)),
+            "_multiMatch": [0] * n,
+        }
+    )
+
+
+def test_backfill_creature_floor_adds_up_to_shortfall():
+    b = _make_builder(creatures_max=20, creatures_min=5, on_theme_creatures=0)
+    b._prepare_creature_pool = lambda: _synthetic_creature_pool(10)
+    b._backfill_creature_floor()
+    assert b._creature_count_in_library() == 5
+
+
+def test_backfill_creature_floor_noop_when_floor_already_met():
+    b = _make_builder(creatures_max=20, creatures_min=1, on_theme_creatures=0)
+    b.add_card("Existing Creature", card_type="Creature")
+    b._prepare_creature_pool = lambda: _synthetic_creature_pool(10)
+    b._backfill_creature_floor()
+    # Floor of 1 already satisfied by the pre-existing creature; no backfill added.
+    assert b._creature_count_in_library() == 1
+
+
+def test_backfill_creature_floor_noop_in_legacy_mode():
+    b = _make_builder(creatures_max=20, creatures_min=10, on_theme_creatures=0)
+    b.creature_builder_mode = "legacy"
+    b._prepare_creature_pool = lambda: _synthetic_creature_pool(10)
+    b._backfill_creature_floor()
+    assert b._creature_count_in_library() == 0
+
+
+def test_backfill_creature_floor_partial_when_pool_short():
+    b = _make_builder(creatures_max=20, creatures_min=8, on_theme_creatures=0)
+    b._prepare_creature_pool = lambda: _synthetic_creature_pool(3)
+    b._backfill_creature_floor()
+    assert b._creature_count_in_library() == 3
+
+
+@pytest.fixture(autouse=True)
+def _use_testdata(monkeypatch):
+    monkeypatch.setenv("CSV_FILES_DIR", os.path.join("csv_files", "testdata"))
+
+
+def test_headless_legacy_mode_threads_end_to_end():
+    builder = run(
+        command_name="Krenko",
+        seed=42,
+        creature_builder_mode="legacy",
+        ideal_counts={"creatures": 10, "creatures_min": 8, "on_theme_creatures": 2},
+    )
+    assert builder.creature_builder_mode == "legacy"
+    # Modern-only ideal keys are still normalized/stored but ignored by the legacy phase target.
+    assert builder._creature_phase_target() == builder.ideal_counts["creatures"]
+
+
+def test_headless_modern_zero_max_adds_no_creatures():
+    builder = run(
+        command_name="Krenko",
+        seed=42,
+        creature_builder_mode="modern",
+        ideal_counts={"creatures_max": 0},
+    )
+    assert builder.creature_builder_mode == "modern"
+    assert builder._creature_phase_should_skip() is True
+    assert builder._creature_count_in_library() == 0

--- a/code/tests/test_creature_allocation_helpers.py
+++ b/code/tests/test_creature_allocation_helpers.py
@@ -1,0 +1,83 @@
+"""Unit tests for roadmap 33 creature allocation helpers (no full deck build required)."""
+from __future__ import annotations
+
+from code.deck_builder import builder_utils as bu
+from code.deck_builder.builder import DeckBuilder
+
+
+def _make_builder(**ideal_overrides) -> DeckBuilder:
+    b = DeckBuilder(output_func=lambda *_: None, input_func=lambda *_: "", headless=True)
+    b.ideal_counts.update(ideal_overrides)
+    return b
+
+
+def test_normalize_creature_ideal_keys_backfills_max_from_legacy_creatures():
+    b = _make_builder(creatures=25)
+    b._normalize_creature_ideal_keys()
+    assert b.ideal_counts["creatures_max"] == 25
+    assert b.ideal_counts["creatures_min"] == 0
+    assert b.ideal_counts["on_theme_creatures"] == 25
+
+
+def test_normalize_creature_ideal_keys_clamps_min_and_on_theme_to_max():
+    b = _make_builder(creatures_max=10, creatures_min=50, on_theme_creatures=99, creature_tolerance=5.0)
+    b._normalize_creature_ideal_keys()
+    assert b.ideal_counts["creatures_min"] == 10
+    assert b.ideal_counts["on_theme_creatures"] == 10
+    assert b.ideal_counts["creature_tolerance"] == 0.15
+    assert b.ideal_counts["creatures"] == 10
+
+
+def test_creature_phase_target_modern_uses_on_theme_creatures():
+    b = _make_builder(creatures_max=28, on_theme_creatures=20)
+    b.creature_builder_mode = "modern"
+    assert b._creature_phase_target() == 20
+
+
+def test_creature_phase_target_legacy_uses_creatures():
+    b = _make_builder(creatures=28, on_theme_creatures=20)
+    b.creature_builder_mode = "legacy"
+    assert b._creature_phase_target() == 28
+
+
+def test_creature_phase_should_skip_when_max_is_zero():
+    b = _make_builder(creatures_max=0)
+    assert b._creature_phase_should_skip() is True
+
+
+def test_creature_phase_should_not_skip_when_max_positive():
+    b = _make_builder(creatures_max=28)
+    assert b._creature_phase_should_skip() is False
+
+
+def test_creature_cap_with_tolerance_applies_percentage():
+    b = _make_builder(creatures_max=20, creature_tolerance=0.10)
+    assert bu.creature_cap_with_tolerance(b) == 22
+
+
+def test_creature_room_remaining_unlimited_in_legacy_mode():
+    b = _make_builder(creatures_max=5, creature_tolerance=0.0)
+    b.creature_builder_mode = "legacy"
+    b._creature_count_in_library = lambda: 999
+    assert bu.creature_room_remaining(b) == 10 ** 9
+
+
+def test_creature_room_remaining_capped_in_modern_mode():
+    b = _make_builder(creatures_max=5, creature_tolerance=0.0)
+    b.creature_builder_mode = "modern"
+    b._creature_count_in_library = lambda: 3
+    assert bu.creature_room_remaining(b) == 2
+
+
+def test_creature_room_remaining_zero_when_at_or_over_cap():
+    b = _make_builder(creatures_max=5, creature_tolerance=0.0)
+    b.creature_builder_mode = "modern"
+    b._creature_count_in_library = lambda: 5
+    assert bu.creature_room_remaining(b) == 0
+
+
+def test_is_creature_row_case_insensitive():
+    assert bu.is_creature_row({"type": "Legendary Creature — Goblin"}) is True
+    assert bu.is_creature_row({"type": "artifact creature - equipment"}) is True
+    assert bu.is_creature_row({"type": "Instant"}) is False
+    assert bu.is_creature_row({}) is False

--- a/code/web/app.py
+++ b/code/web/app.py
@@ -175,6 +175,10 @@ templates.env.globals["smtp_configured"] = _is_smtp_configured()
 templates.env.globals["WHATS_NEW_ID"] = "user-accounts-deck-visibility"
 templates.env.globals["WHATS_NEW_LABEL"] = "New: User Accounts & Deck Visibility"
 
+# Shared short description for the legacy creature allocation toggle (roadmap 33, Milestone 5)
+from code.deck_builder import builder_constants as _bc
+templates.env.globals["LEGACY_CREATURE_MODE_DESCRIPTION"] = _bc.LEGACY_CREATURE_MODE_DESCRIPTION
+
 # Add custom Jinja2 filter for card image URLs
 def card_image_url(card_name: str, size: str = "normal", printing: str = "") -> str:
     """

--- a/code/web/routes/api_v1/builds.py
+++ b/code/web/routes/api_v1/builds.py
@@ -63,6 +63,16 @@ class CreateBuildRequest(BaseModel):
     # creatures, removal, wipes, card_advantage, protection). Missing keys
     # fall back to the server defaults (see GET /builds/ideal-defaults).
     ideal_counts: Optional[Dict[str, int]] = None
+    # Optional, additive creature-allocation fields (roadmap 33). `creatures`
+    # (via ideal_counts, above) remains the authoritative max and is still
+    # accepted/returned unchanged for existing clients. These fields let a
+    # client opt into the newer min/on-theme/tolerance controls, or opt back
+    # into the original single-target algorithm via creature_builder_mode.
+    creatures_min: Optional[int] = None
+    creatures_max: Optional[int] = None
+    on_theme_creatures: Optional[int] = None
+    creature_tolerance: Optional[float] = None
+    creature_builder_mode: Optional[str] = None
     include_cards: Optional[List[str]] = None
     exclude_cards: Optional[List[str]] = None
     # Partner/background pairing (see GET /commanders/{name}/partners and
@@ -168,6 +178,10 @@ async def create_build(body: CreateBuildRequest, request: Request, user: User = 
     ideals = orch.ideal_defaults()
     if body.ideal_counts:
         ideals.update({k: int(v) for k, v in body.ideal_counts.items()})
+    for key in ("creatures_min", "creatures_max", "on_theme_creatures"):
+        val = getattr(body, key)
+        if val is not None:
+            ideals[key] = int(val)
 
     try:
         ctx = await asyncio.to_thread(
@@ -187,6 +201,8 @@ async def create_build(body: CreateBuildRequest, request: Request, user: User = 
             partner_feature_enabled=ENABLE_PARTNER_MECHANICS and body.partner_enabled,
             secondary_commander=body.secondary_commander,
             background_commander=body.background,
+            creature_builder_mode=body.creature_builder_mode,
+            creature_tolerance=body.creature_tolerance,
         )
     except ValueError as exc:
         return err(str(exc), "INVALID_BUILD_REQUEST", 400, _rid(request))

--- a/code/web/routes/build_multicopy.py
+++ b/code/web/routes/build_multicopy.py
@@ -70,6 +70,8 @@ def _rebuild_ctx_with_multicopy(sess: dict) -> None:
             combo_balance=str(sess.get("combo_balance", "mix")),
             swap_mdfc_basics=bool(sess.get("swap_mdfc_basics")),
             printings=dict(sess.get("printings") or {}),
+            creature_builder_mode=sess.get("creature_builder_mode", "modern"),
+            creature_tolerance=sess.get("creature_tolerance"),
         )
     except Exception:
         # If rebuild fails (e.g., commander not found in test), fall back to injecting

--- a/code/web/routes/build_newflow.py
+++ b/code/web/routes/build_newflow.py
@@ -168,10 +168,17 @@ async def build_new_modal(request: Request, reset: str = Query("")) -> HTMLRespo
             "lands": sess.get("ideals", {}).get("lands"),
             "basic_lands": sess.get("ideals", {}).get("basic_lands"),
             "creatures": sess.get("ideals", {}).get("creatures"),
+            "creatures_min": sess.get("ideals", {}).get("creatures_min"),
+            "creatures_max": sess.get("ideals", {}).get("creatures_max"),
+            "on_theme_creatures": sess.get("ideals", {}).get("on_theme_creatures"),
+            "creature_tolerance_pct": (
+                round(sess["creature_tolerance"] * 100) if sess.get("creature_tolerance") is not None else None
+            ),
             "removal": sess.get("ideals", {}).get("removal"),
             "wipes": sess.get("ideals", {}).get("wipes"),
             "card_advantage": sess.get("ideals", {}).get("card_advantage"),
             "protection": sess.get("ideals", {}).get("protection"),
+            "creature_builder_mode": sess.get("creature_builder_mode", "modern"),
         },
         "tag_slot_html": None,
     }
@@ -450,6 +457,11 @@ async def build_new_submit(
     lands: int = Form(None),
     basic_lands: int = Form(None),
     creatures: int = Form(None),
+    creatures_min: int = Form(None),
+    creatures_max: int = Form(None),
+    on_theme_creatures: int = Form(None),
+    creature_tolerance_pct: int = Form(None),
+    creature_builder_mode: str | None = Form(None),
     removal: int = Form(None),
     wipes: int = Form(None),
     card_advantage: int = Form(None),
@@ -530,6 +542,7 @@ async def build_new_submit(
             "budget_total": budget_total,
             "card_ceiling": card_ceiling,
             "pool_tolerance": pool_tolerance if pool_tolerance is not None else "15",
+            "creature_builder_mode": "legacy" if creature_builder_mode == "legacy" else "modern",
         }
 
     commander_detail = lookup_commander_detail(commander)
@@ -807,6 +820,9 @@ async def build_new_submit(
         "lands": lands,
         "basic_lands": basic_lands,
         "creatures": creatures,
+        "creatures_min": creatures_min,
+        "creatures_max": creatures_max,
+        "on_theme_creatures": on_theme_creatures,
         "removal": removal,
         "wipes": wipes,
         "card_advantage": card_advantage,
@@ -818,6 +834,12 @@ async def build_new_submit(
         except Exception:
             pass
     sess["ideals"] = ideals
+    sess["creature_builder_mode"] = "legacy" if creature_builder_mode == "legacy" else "modern"
+    if creature_tolerance_pct is not None:
+        try:
+            sess["creature_tolerance"] = max(0.0, min(float(creature_tolerance_pct) / 100.0, bc.MAX_CREATURE_TOLERANCE))
+        except Exception:
+            pass
     if ENABLE_CUSTOM_THEMES:
         try:
             theme_mgr.refresh_resolution(

--- a/code/web/services/build_utils.py
+++ b/code/web/services/build_utils.py
@@ -196,6 +196,8 @@ def start_ctx_from_session(sess: dict, *, set_on_session: bool = True, deck_dir:
         budget_config=sess.get("budget_config"),
         deck_visibility=sess.get("deck_visibility"),
         printings=dict(sess.get("printings") or {}),
+        creature_builder_mode=sess.get("creature_builder_mode", "modern"),
+        creature_tolerance=sess.get("creature_tolerance"),
     )
     if set_on_session:
         sess["build_ctx"] = ctx

--- a/code/web/services/orchestrator.py
+++ b/code/web/services/orchestrator.py
@@ -1025,6 +1025,10 @@ def ideal_defaults() -> Dict[str, Any]:
         "basic_lands": getattr(bc, 'DEFAULT_BASIC_LAND_COUNT', 20),
         "fetch_lands": getattr(bc, 'FETCH_LAND_DEFAULT_COUNT', 3),
         "creatures": getattr(bc, 'DEFAULT_CREATURE_COUNT', 28),
+        "creatures_min": getattr(bc, 'DEFAULT_CREATURE_COUNT_MIN', 0),
+        "creatures_max": getattr(bc, 'DEFAULT_CREATURE_COUNT', 28),
+        "on_theme_creatures": getattr(bc, 'DEFAULT_ON_THEME_CREATURE_COUNT', 20),
+        "creature_tolerance_pct": int(round(getattr(bc, 'DEFAULT_CREATURE_TOLERANCE', 0.10) * 100)),
         "removal": getattr(bc, 'DEFAULT_REMOVAL_COUNT', 10),
         "wipes": getattr(bc, 'DEFAULT_WIPES_COUNT', 2),
         "card_advantage": getattr(bc, 'DEFAULT_CARD_ADVANTAGE_COUNT', 8),
@@ -1039,6 +1043,10 @@ def ideal_labels() -> Dict[str, str]:
         'basic_lands': 'Basic Lands (Min)',
         'fetch_lands': 'Fetch Lands',
         'creatures': 'Creatures',
+        'creatures_min': 'Ideal Min Creatures',
+        'creatures_max': 'Ideal Max Creatures',
+        'on_theme_creatures': 'On-Theme Creature Count',
+        'creature_tolerance_pct': 'Creature Count Tolerance (%)',
         'removal': 'Spot Removal',
         'wipes': 'Board Wipes',
         'card_advantage': 'Card Advantage',
@@ -1725,7 +1733,7 @@ def _ensure_setup_ready(out, force: bool = False) -> None:
             pass
 
 
-def run_build(commander: str, tags: List[str], bracket: int, ideals: Dict[str, int], tag_mode: str | None = None, *, use_owned_only: bool | None = None, prefer_owned: bool | None = None, owned_names: List[str] | None = None, prefer_combos: bool | None = None, combo_target_count: int | None = None, combo_balance: str | None = None, deck_dir: str = "deck_files") -> Dict[str, Any]:
+def run_build(commander: str, tags: List[str], bracket: int, ideals: Dict[str, int], tag_mode: str | None = None, *, use_owned_only: bool | None = None, prefer_owned: bool | None = None, owned_names: List[str] | None = None, prefer_combos: bool | None = None, combo_target_count: int | None = None, combo_balance: str | None = None, deck_dir: str = "deck_files", creature_builder_mode: str | None = None, creature_tolerance: float | None = None) -> Dict[str, Any]:
     """Run the deck build end-to-end with provided selections and capture logs.
 
     Returns: { ok: bool, log: str, csv_path: Optional[str], txt_path: Optional[str], error: Optional[str] }
@@ -1777,6 +1785,9 @@ def run_build(commander: str, tags: List[str], bracket: int, ideals: Dict[str, i
 
         # Ideal counts
         b.ideal_counts = {k: int(v) for k, v in (ideals or {}).items()}
+        b.creature_builder_mode = creature_builder_mode if creature_builder_mode in ('legacy', 'modern') else 'modern'
+        if creature_tolerance is not None:
+            b.ideal_counts['creature_tolerance'] = max(0.0, min(float(creature_tolerance), bc.MAX_CREATURE_TOLERANCE))
 
         # Apply tag combine mode
         try:
@@ -1981,6 +1992,11 @@ def run_build(commander: str, tags: List[str], bracket: int, ideals: Dict[str, i
                 b.add_spells_phase()
         except Exception as e:
             out(f"Spell phase failed: {e}")
+        try:
+            if hasattr(b, '_backfill_creature_floor'):
+                b._backfill_creature_floor()
+        except Exception as e:
+            out(f"Creature floor backfill failed: {e}")
         try:
             if hasattr(b, 'post_spell_land_adjust'):
                 b.post_spell_land_adjust()
@@ -2214,6 +2230,9 @@ def _make_stages_legacy(b: DeckBuilder) -> List[Dict[str, Any]]:
         except Exception:
             pass
         stages.append({"key": "spells", "label": "Spells", "runner_name": "add_spells_phase"})
+    # Creature floor backfill (modern mode only; no-op otherwise)
+    if hasattr(b, '_backfill_creature_floor'):
+        stages.append({"key": "creature_floor", "label": "Creature Floor Backfill", "runner_name": "_backfill_creature_floor"})
     # Post-adjust
     if hasattr(b, 'post_spell_land_adjust'):
         stages.append({"key": "post_adjust", "label": "Post-Spell Land Adjust", "runner_name": "post_spell_land_adjust"})
@@ -2316,6 +2335,10 @@ def _make_stages_new(b: DeckBuilder) -> List[Dict[str, Any]]:
     # 4) THEME FILL - Final spell topper
     if callable(getattr(b, 'fill_remaining_theme_spells', None)):
         stages.append({"key": "spells_fill", "label": "Theme Spell Fill", "runner_name": "fill_remaining_theme_spells"})
+    
+    # Creature floor backfill (modern mode only; no-op otherwise)
+    if hasattr(b, '_backfill_creature_floor'):
+        stages.append({"key": "creature_floor", "label": "Creature Floor Backfill", "runner_name": "_backfill_creature_floor"})
     
     # 5) LAND ADJUSTMENTS - Post-spell rebalance (same as legacy)
     if hasattr(b, 'post_spell_land_adjust'):
@@ -2589,6 +2612,8 @@ def start_build_ctx(
     budget_config: Dict[str, Any] | None = None,
     deck_visibility: str | None = None,
     printings: Dict[str, str] | None = None,
+    creature_builder_mode: str | None = None,
+    creature_tolerance: float | None = None,
 ) -> Dict[str, Any]:
     logs: List[str] = []
 
@@ -2668,6 +2693,9 @@ def start_build_ctx(
     b.bracket_limits = dict(getattr(bd, 'limits', {}))
     # Ideals
     b.ideal_counts = {k: int(v) for k, v in (ideals or {}).items()}
+    b.creature_builder_mode = creature_builder_mode if creature_builder_mode in ('legacy', 'modern') else 'modern'
+    if creature_tolerance is not None:
+        b.ideal_counts['creature_tolerance'] = max(0.0, min(float(creature_tolerance), bc.MAX_CREATURE_TOLERANCE))
     # Apply tag combine mode
     try:
         b.tag_mode = (str(tag_mode).upper() if tag_mode else b.tag_mode)

--- a/code/web/templates/build/_new_deck_ideals.html
+++ b/code/web/templates/build/_new_deck_ideals.html
@@ -4,21 +4,41 @@
     Sliders start at recommended defaults. Adjust as needed for your deck strategy.
     <span id="ideals-validation-warning" style="color:#f59e0b; display:none; margin-left:0.5rem;"></span>
   </div>
+  <div class="muted" style="font-size:12px; margin-bottom:0.75rem;">
+    <strong>How creature counts work:</strong> Min is a hard floor (backfilled if short); On-Theme is the actual target the builder fills toward; Max is a ceiling only, it caps creatures but is never actively pursued; Tolerance lets the on-theme target flex down when few matching creatures are available.
+  </div>
+  <div style="margin-bottom:1rem;">
+    <label for="creature_builder_mode" class="form-checkbox-label">
+      <input
+        type="checkbox"
+        name="creature_builder_mode"
+        id="creature_builder_mode"
+        value="legacy"
+        {% if form and form.creature_builder_mode == 'legacy' %}checked{% endif %}
+      />
+      <strong>Use Legacy Creature Allocation</strong>
+    </label>
+    <div class="muted" style="font-size:12px; margin-left:1.75rem; margin-top:0.25rem;">{{ LEGACY_CREATURE_MODE_DESCRIPTION }}</div>
+  </div>
   <div style="display:grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap:1rem;">
     {% set use_sliders = ideals_ui_mode == 'slider' %}
     {% set ideals_data = [
       ('ramp', labels.ramp, defaults.ramp, 0, 30),
       ('lands', labels.lands, defaults.lands, 25, 45),
       ('basic_lands', labels.basic_lands, defaults.basic_lands, 0, 40),
-      ('creatures', labels.creatures, defaults.creatures, 0, 70),
+      ('creatures_min', labels.creatures_min, defaults.creatures_min, 0, defaults.creatures_max),
+      ('creatures_max', labels.creatures_max, defaults.creatures_max, 0, 99 - defaults.lands),
+      ('on_theme_creatures', labels.on_theme_creatures, defaults.on_theme_creatures, 0, defaults.creatures_max),
+      ('creature_tolerance_pct', labels.creature_tolerance_pct, defaults.creature_tolerance_pct, 0, 15),
       ('removal', labels.removal, defaults.removal, 0, 30),
       ('wipes', labels.wipes, defaults.wipes, 0, 15),
       ('card_advantage', labels.card_advantage, defaults.card_advantage, 0, 30),
       ('protection', labels.protection, defaults.protection, 0, 20)
     ] %}
+    {% set legacy_disabled_fields = ['creatures_min', 'on_theme_creatures', 'creature_tolerance_pct'] %}
     
     {% for field_name, field_label, default_val, min_val, max_val in ideals_data %}
-      <div>
+      <div id="ideal_field_{{ field_name }}" {% if field_name in legacy_disabled_fields and form and form.creature_builder_mode == 'legacy' %}style="display:none;"{% endif %}>
         <label style="display:block; margin-bottom:0.25rem;">
           <span>{{ field_label }}</span>
           {% if use_sliders %}
@@ -31,6 +51,8 @@
                 value="{{ form[field_name] if form and form[field_name] is not none else default_val }}" 
                 class="ideals-slider"
                 data-field="{{ field_name }}"
+                data-default="{{ default_val }}"
+                {% if field_name in legacy_disabled_fields and form and form.creature_builder_mode == 'legacy' %}disabled{% endif %}
                 style="flex:1; cursor:pointer;"
               />
               <output 
@@ -49,12 +71,17 @@
               max="100" 
               value="{{ form[field_name] if form and form[field_name] is not none else '' }}" 
               placeholder="{{ default_val }} (Default)"
+              data-default="{{ default_val }}"
+              {% if field_name in legacy_disabled_fields and form and form.creature_builder_mode == 'legacy' %}disabled{% endif %}
               style="width:100%; margin-top:0.25rem;"
             />
           {% endif %}
         </label>
       </div>
     {% endfor %}
+  </div>
+  <div style="margin-top:0.75rem;">
+    <button type="button" id="ideals-reset-btn" class="btn" style="font-size:13px;">Reset to Defaults</button>
   </div>
   
   <script>
@@ -70,7 +97,7 @@
       };
       
       const lands = getValue('lands');
-      const creatures = getValue('creatures');
+      const creatures = getValue('creatures_max');
       const ramp = getValue('ramp');
       const removal = getValue('removal');
       const wipes = getValue('wipes');
@@ -95,6 +122,63 @@
         warning.style.display = 'none';
       }
     }
+
+    // Cascade: creatures_max's ceiling tracks (99 - lands); on_theme_creatures'
+    // ceiling in turn tracks creatures_max. Clamp current values down as needed.
+    function updateCreatureBounds() {
+      const landsInput = document.querySelector('[name="lands"]');
+      const maxInput = document.querySelector('[name="creatures_max"]');
+      const onThemeInput = document.querySelector('[name="on_theme_creatures"]');
+      if (!landsInput || !maxInput) return;
+
+      const setValue = (input, value) => {
+        input.value = value;
+        const output = document.getElementById(input.getAttribute('name') + '_value');
+        if (output) output.textContent = value;
+      };
+
+      // Read values BEFORE mutating `max` attributes: browsers silently clamp a
+      // range input's value when its max is lowered, which would otherwise hide
+      // the change from the paired <output> display.
+      const lands = parseInt(landsInput.value) || 0;
+      const maxCeiling = Math.max(0, 99 - lands);
+      const prevMaxVal = parseInt(maxInput.value) || 0;
+      maxInput.max = maxCeiling;
+      const clampedMaxVal = Math.min(prevMaxVal, maxCeiling);
+      setValue(maxInput, clampedMaxVal);
+
+      if (onThemeInput) {
+        const prevOnThemeVal = parseInt(onThemeInput.value) || 0;
+        onThemeInput.max = clampedMaxVal;
+        setValue(onThemeInput, Math.min(prevOnThemeVal, clampedMaxVal));
+      }
+    }
+
+    // Legacy mode ignores min/on-theme/tolerance; hide them entirely when checked.
+    function updateLegacyDisabled() {
+      const legacyCheckbox = document.querySelector('[name="creature_builder_mode"]');
+      const disable = !!(legacyCheckbox && legacyCheckbox.checked);
+      ['creatures_min', 'on_theme_creatures', 'creature_tolerance_pct'].forEach(fieldName => {
+        const input = document.querySelector('[name="' + fieldName + '"]');
+        if (input) input.disabled = disable;
+        const field = document.getElementById('ideal_field_' + fieldName);
+        if (field) field.style.display = disable ? 'none' : '';
+      });
+    }
+
+    // Reset every ideal-count field (and the legacy checkbox) back to its default.
+    function resetIdealsToDefaults() {
+      const legacyCheckbox = document.querySelector('[name="creature_builder_mode"]');
+      if (legacyCheckbox) legacyCheckbox.checked = false;
+      document.querySelectorAll('[data-default]').forEach(input => {
+        input.value = input.dataset.default;
+        const output = document.getElementById(input.getAttribute('name') + '_value');
+        if (output) output.textContent = input.dataset.default;
+      });
+      updateCreatureBounds();
+      updateLegacyDisabled();
+      validateIdealCounts();
+    }
     
     // Attach validation to all ideal inputs
     {% if use_sliders %}
@@ -105,6 +189,9 @@
       // Update display on input
       slider.addEventListener('input', function() {
         output.textContent = this.value;
+        if (fieldName === 'lands' || fieldName === 'creatures_max') {
+          updateCreatureBounds();
+        }
         validateIdealCounts();
       });
       
@@ -112,13 +199,30 @@
       output.textContent = slider.value;
     });
     {% else %}
-    document.querySelectorAll('[name="ramp"], [name="lands"], [name="basic_lands"], [name="creatures"], [name="removal"], [name="wipes"], [name="card_advantage"], [name="protection"]').forEach(input => {
-      input.addEventListener('input', validateIdealCounts);
+    document.querySelectorAll('[name="ramp"], [name="lands"], [name="basic_lands"], [name="creatures_min"], [name="creatures_max"], [name="on_theme_creatures"], [name="creature_tolerance_pct"], [name="removal"], [name="wipes"], [name="card_advantage"], [name="protection"]').forEach(input => {
+      input.addEventListener('input', function() {
+        if (input.name === 'lands' || input.name === 'creatures_max') {
+          updateCreatureBounds();
+        }
+        validateIdealCounts();
+      });
       input.addEventListener('change', validateIdealCounts);
     });
     {% endif %}
+
+    const legacyModeCheckbox = document.querySelector('[name="creature_builder_mode"]');
+    if (legacyModeCheckbox) {
+      legacyModeCheckbox.addEventListener('change', updateLegacyDisabled);
+    }
+
+    const idealsResetBtn = document.getElementById('ideals-reset-btn');
+    if (idealsResetBtn) {
+      idealsResetBtn.addEventListener('click', resetIdealsToDefaults);
+    }
     
-    // Run initial validation
+    // Run initial computations
+    updateCreatureBounds();
+    updateLegacyDisabled();
     validateIdealCounts();
   </script>
 </fieldset>

--- a/docs/user_guides/build_wizard.md
+++ b/docs/user_guides/build_wizard.md
@@ -110,13 +110,22 @@ Set target counts for key card categories using sliders or number inputs:
 - **Ramp**: 0–30 cards (default varies by commander)
 - **Lands**: 25–45 cards (default varies by commander speed)
 - **Basic Lands**: 0–40 cards (subset of total lands)
-- **Creatures**: 0–70 cards
+- **Ideal Min Creatures**: 0 – current max, default 0 (hard floor; the builder backfills on-theme creatures at the end of the build if the deck falls short)
+- **Ideal Max Creatures**: 0 – `99 - lands`, default 28 (hard cap on total creatures; a ceiling only, not a target the builder actively fills toward)
+- **On-Theme Creature Count**: 0 – max, default 20 (how many creatures should match your selected themes; the remainder can be any creature)
+- **Creature Count Tolerance**: 0–15%, default 10% (how much the on-theme target can flex when few matching creatures are available)
 - **Removal**: 0–30 cards (spot removal)
 - **Wipes**: 0–15 cards (board wipes)
 - **Card Advantage**: 0–30 cards (draw/recursion)
 - **Protection**: 0–20 cards (counterspells, indestructible effects)
 
+**Legacy Creature Allocation**: A checkbox above the sliders lets you opt into the original single-target algorithm instead: one creature target, filled by theme weight, backfilled with any on-theme creature if short. Checking it hides the Min/On-Theme/Tolerance sliders since they're ignored in this mode.
+
+**Note**: Ideal Max Creatures is only a ceiling, never an active target; if your deck comes in below it, that's expected. There's no automatic "fill remaining creature slots up to the max" step. If you want more creatures, raise On-Theme Creature Count (or Ideal Min Creatures) instead of just raising the max.
+
 **Warning**: The builder validates your totals. If ideal counts exceed 99 cards, reduce totals to avoid build issues.
+
+**Reset to Defaults**: A button below the sliders resets every count (and the Legacy Creature Allocation checkbox) back to its recommended default.
 
 **Tips**:
 - Start with default recommendations

--- a/docs/user_guides/land_bases.md
+++ b/docs/user_guides/land_bases.md
@@ -100,9 +100,9 @@ When [Budget Mode](budget_mode.md) is active and the land budget is under $50 wi
 
 ## Slot Earmarking
 
-After Smart Lands sets the land target, it proportionally scales down non-land ideal counts (creatures, ramp, removal, etc.) so they fit within the remaining 99 − `land_target` deck slots. This prevents spell phases from consuming land slots before lands get a chance to fill them.
+After Smart Lands sets the land target, it proportionally scales down non-land ideal counts (`creatures_max`, ramp, removal, etc.) so they fit within the remaining 99 − `land_target` deck slots. This prevents spell phases from consuming land slots before lands get a chance to fill them. `creatures_max` also has its own hard ceiling of `99 - land_target`, enforced independently of this proportional scaling.
 
-For example, with a 43-land target the non-land budget is 56 slots. If the combined non-land ideals sum to 63, each category is scaled down proportionally (e.g. 25 creatures → 22, 10 removal → 9, etc.).
+For example, with a 43-land target the non-land budget is 56 slots. If the combined non-land ideals sum to 63, each category is scaled down proportionally (e.g. `creatures_max` 25 → 22, 10 removal → 9, etc.).
 
 A **backfill** step at the end of all land phases adds basics from the color identity if any land phase still falls short — so the deck always reaches the configured target.
 

--- a/docs/user_guides/multi_copy.md
+++ b/docs/user_guides/multi_copy.md
@@ -91,7 +91,7 @@ The auto-suggest only triggers when your commander's theme tags match the archet
 Yes, but you need that many copies of the card in your owned card library. The builder will include the configured count regardless of owned status for Must Include cards — they bypass the owned filter.
 
 **Will the multi-copy card count toward my ideal creature or spell count?**
-Yes. Multi-copy creature archetypes (e.g., Relentless Rats) count toward the creature ideal, and non-creature archetypes (e.g., Dragon's Approach) count toward the spell ideal. Adjust your ideal counts in Step 6 accordingly.
+Yes. Multi-copy creature archetypes (e.g., Relentless Rats) count toward the creature max cap (`creatures_max`) and the cross-phase cap enforcement that keeps later phases from exceeding it, and non-creature archetypes (e.g., Dragon's Approach) count toward the spell ideal. Adjust your ideal counts in Step 6 accordingly.
 
 ---
 


### PR DESCRIPTION
## Summary

Reworks ideal creature count configuration to support a minimum, maximum, and on-theme target (with tolerance), instead of a single number, so decks can guarantee a creature floor while still weighting toward chosen themes.

### Added
- Ideal creature counts now support a minimum, a maximum, and an on-theme target (with a tolerance percentage, capped at 15%), instead of a single number
- The creature maximum is now enforced across every phase that can add a creature (ramp, removal, board wipes, card advantage, protection), not just creature selection
- A Legacy Creature Allocation option is available in the CLI and web build wizard for anyone who prefers the original single-target behavior
- The wizard's ideal-counts fieldset gained a Reset to Defaults button and a short note explaining how the controls interact
- Legacy-only fields are now hidden rather than just greyed out when legacy mode is enabled

See CHANGELOG.md for full details.

### Testing
- 17 new/updated tests in \	est_creature_allocation_helpers.py\ and \	est_creature_allocation_build_integration.py\
- Existing fast suites (\	est_replace_and_locks_flow\, \	est_summary_utils\, \	est_bracket_policy_applier\, \	est_api_v1_builds\) all passing
- Manual UI pass completed in web build wizard; all found issues triaged and fixed