### PR TITLE
fix: CI headless smoke test uses removed --config flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Headless smoke test (dry-run)
         run: |
-          python -m code.headless_runner --config config/deck.json --dry-run
+          python -m code.headless_runner --commander "Aang, Airbending Master" --dry-run
 
       - name: Tests
         run: |


### PR DESCRIPTION
PR #96 removed `--config`/`DECK_CONFIG` support from `headless_runner.py` but left the CI smoke-test step calling `--config config/deck.json --dry-run`, breaking CI on every run since (that PR's own CI, the `main` push CI for v5.4.0, and PR #97).

Updates the step to use `--commander` directly, matching the new CLI surface.

Verified locally: `python -m code.headless_runner --commander "Aang, Airbending Master" --dry-run` exits 0 and prints the preview JSON.
