### PR TITLE
fix: manual builder fetch lands, color identity parsing, and deck summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ _No unreleased changes yet_
 _No unreleased changes yet_
 
 ### Fixed
-_No unreleased changes yet_
+- Manual Deck Builder: fetch lands that only search for basic land types outside your commander's colors (e.g. Polluted Delta in a white/green deck) no longer show up in the card pool.
+- Manual Deck Builder: saved decks now show their full card list when viewed in the deck browser instead of appearing empty; a two-color commander's color identity was also being parsed incorrectly in some cases, which could affect pool filtering.
 
 ### Removed
 _No unreleased changes yet_

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -8,7 +8,8 @@ _No unreleased changes yet_
 _No unreleased changes yet_
 
 ### Fixed
-_No unreleased changes yet_
+- Manual Deck Builder: fetch lands unrelated to your commander's colors (e.g. Polluted Delta in a white/green deck) no longer show up in the card pool.
+- Manual Deck Builder: saved decks now show their full card list in the deck browser instead of appearing empty.
 
 ### Removed
 _No unreleased changes yet_

--- a/code/tests/test_manual_builder.py
+++ b/code/tests/test_manual_builder.py
@@ -101,6 +101,37 @@ def test_pool_filtered_to_color_identity_and_budget_visible(monkeypatch):
     assert "Expensive Rock" in names
 
 
+def test_pool_excludes_off_color_fetch_lands(monkeypatch):
+    """Fetch lands have no colorIdentity pips, so the plain color-identity
+    subset check alone always lets them through. A W/G deck shouldn't see
+    Polluted Delta (Island/Swamp) even though it's technically colorless.
+    """
+    manual_builder_service = importlib.import_module("code.web.services.manual_builder_service")
+
+    df = pd.DataFrame([
+        {"name": "Polluted Delta", "colorIdentity": "", "type": "Land", "manaValue": 0.0,
+         "themeTags": [], "metadataTags": ["Island Fetch", "Swamp Fetch"], "edhrecRank": 10.0, "isNew": False},
+        {"name": "Windswept Heath", "colorIdentity": "", "type": "Land", "manaValue": 0.0,
+         "themeTags": [], "metadataTags": ["Plains Fetch", "Forest Fetch"], "edhrecRank": 20.0, "isNew": False},
+        {"name": "Evolving Wilds", "colorIdentity": "", "type": "Land", "manaValue": 0.0,
+         "themeTags": [], "metadataTags": ["Any Basic Fetch"], "edhrecRank": 30.0, "isNew": False},
+    ])
+
+    class _FakeLoader:
+        def load(self):
+            return df
+
+    monkeypatch.setattr(manual_builder_service, "AllCardsLoader", _FakeLoader)
+
+    sess = {"color_identity": ["W", "G"], "commander": "Some Commander"}
+    pool = manual_builder_service.get_card_pool(sess)
+    names = set(pool["name"].astype(str))
+
+    assert "Polluted Delta" not in names  # fetches Island/Swamp, neither in W/G
+    assert "Windswept Heath" in names     # fetches Plains/Forest, matches W/G
+    assert "Evolving Wilds" in names      # universal fetch, always allowed
+
+
 def test_pool_dedupes_double_faced_card_rows(monkeypatch):
     """A DFC/split card is stored as one row per face sharing the same
     `name`; the pool should show it once, with themeTags merged from both
@@ -173,6 +204,45 @@ def test_remove_card_updates_session(monkeypatch):
     result = manual_builder_service.remove_card_from_deck(sess, "Rampant Growth")
     assert result["status"] == "removed"
     assert sess["deck_cards"] == []
+
+
+def test_resolve_color_identity_parses_comma_separated_string(monkeypatch):
+    """colorIdentity in commander_cards.csv is stored like \"G, W\" (comma +
+    space separated); resolving it must split on comma, not iterate chars.
+    """
+    manual_builder_service = importlib.import_module("code.web.services.manual_builder_service")
+
+    df = pd.DataFrame([{"name": "Some Commander", "colorIdentity": "G, W"}])
+
+    class _FakeBuilder:
+        def __init__(self, *a, **k):
+            pass
+
+        def load_commander_data(self):
+            return df
+
+    monkeypatch.setattr(manual_builder_service, "DeckBuilder", _FakeBuilder)
+
+    result = manual_builder_service.resolve_color_identity("Some Commander")
+    assert result == ["G", "W"]
+
+
+def test_save_manual_deck_writes_full_type_breakdown(monkeypatch, tmp_path):
+    manual_builder_service = importlib.import_module("code.web.services.manual_builder_service")
+    sess = _manual_sess(monkeypatch, manual_builder_service, _sample_deck_df())
+    sess["deck_cards"] = ["Rampant Growth", "Lightning Bolt", "Forest"]
+
+    manual_builder_service.save_manual_deck(sess, str(tmp_path))
+
+    import json
+    summary_path = next(tmp_path.glob("*.summary.json"))
+    payload = json.loads(summary_path.read_text(encoding="utf-8"))
+    tb = payload["summary"]["type_breakdown"]
+    assert tb["counts"]["Sorcery"] == 1
+    assert tb["counts"]["Instant"] == 1
+    assert tb["counts"]["Land"] == 1
+    assert "Rampant Growth" in {c["name"] for c in tb["cards"]["Sorcery"]}
+    assert payload["summary"]["mana_curve"]["1"] == 1  # Lightning Bolt (mv 1)
 
 
 def test_duplicate_blocked(monkeypatch):

--- a/code/web/services/manual_builder_service.py
+++ b/code/web/services/manual_builder_service.py
@@ -17,7 +17,13 @@ import pandas as pd
 
 from deck_builder.builder import DeckBuilder
 from deck_builder import builder_constants as bc
-from deck_builder.builder_utils import basic_land_names, compute_color_source_matrix, compute_pip_density, parse_theme_tags
+from deck_builder.builder_utils import (
+    basic_land_names,
+    compute_color_source_matrix,
+    compute_pip_density,
+    fetch_land_allowed_for_colors,
+    parse_theme_tags,
+)
 from deck_builder.brackets_compliance import (
     banned_category_names,
     capped_category_names,
@@ -176,8 +182,15 @@ def resolve_color_identity(
     row = df[df["name"].astype(str) == commander]
     if row.empty:
         return []
-    color_str = row.iloc[0].get("colorIdentity", "") or ""
-    return list(color_str)
+    raw_ci = row.iloc[0].get("colorIdentity", "") or ""
+    if isinstance(raw_ci, (list, tuple, set)):
+        return [str(c).strip().upper() for c in raw_ci if str(c).strip()]
+    raw_ci = str(raw_ci)
+    if raw_ci.strip().lower() == "colorless":
+        return []
+    if "," in raw_ci:
+        return [c.strip().strip("'[] ").upper() for c in raw_ci.split(",") if c.strip().strip("'[] ")]
+    return [c.upper() for c in raw_ci if c.isalpha()]
 
 
 def manual_session_state(sess: Dict[str, Any]) -> Dict[str, Any]:
@@ -450,6 +463,17 @@ def get_card_pool(sess: Dict[str, Any]) -> pd.DataFrame:
     if commander:
         pool = pool[pool["name"].astype(str) != str(commander)]
     pool = _merge_multi_face_pool_rows(pool)
+
+    # Fetch lands are colorless (no colorIdentity pips), so the plain
+    # color-identity subset check above always lets them through even when
+    # they only search for basic land types outside the deck's identity
+    # (e.g. Polluted Delta -> Island/Swamp in a W/G deck). Filter those out.
+    if "metadataTags" in pool.columns:
+        identity_list = sorted(identity)
+        fetch_mask = pool["metadataTags"].apply(
+            lambda tags: fetch_land_allowed_for_colors(tags, identity_list)
+        )
+        pool = pool[fetch_mask]
 
     banned = banned_category_names(bracket)
     banned_names: set = set()
@@ -1443,6 +1467,62 @@ def build_deck_txt_text(sess: Dict[str, Any]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _build_deck_summary(sess: Dict[str, Any]) -> Dict[str, Any]:
+    """Build the full `.summary.json` `summary` block (type_breakdown +
+    mana_curve + colors) from the in-memory session. Matches the schema
+    `decks.py`'s CSV-fallback (`_read_csv_summary`) produces, so the
+    finished-deck browser/view page renders manual decks the same as any
+    other saved deck instead of showing an empty list.
+    """
+    rows = _build_deck_rows(sess)
+    type_counts: Dict[str, int] = {}
+    type_cards: Dict[str, List[Dict[str, Any]]] = {}
+    curve_bins = ["0", "1", "2", "3", "4", "5", "6+"]
+    curve_counts: Dict[str, int] = {b: 0 for b in curve_bins}
+    curve_cards: Dict[str, List[Dict[str, Any]]] = {b: [] for b in curve_bins}
+
+    def _mv_bucket(mv: Any) -> str:
+        try:
+            v = float(mv)
+        except Exception:
+            v = 0.0
+        return "6+" if v >= 6 else str(int(v))
+
+    for r in rows:
+        if r["is_commander"]:
+            continue
+        cat = _deck_type_category(r["type"])
+        type_counts[cat] = type_counts.get(cat, 0) + r["count"]
+        type_cards.setdefault(cat, []).append({
+            "name": r["name"], "count": r["count"], "tags": r["tags"],
+        })
+        if "land" not in r["type"].lower():
+            bucket = _mv_bucket(r["cmc"])
+            curve_counts[bucket] += r["count"]
+            curve_cards[bucket].append({"name": r["name"], "count": r["count"]})
+
+    type_order = [t for t in _DECK_TYPE_ORDER if t in type_counts]
+    return {
+        "type_breakdown": {
+            "counts": type_counts,
+            "order": type_order,
+            "cards": type_cards,
+            "total": sum(type_counts.values()),
+        },
+        "pip_distribution": {
+            "counts": {c: 0 for c in ("W", "U", "B", "R", "G")},
+            "weights": {c: 0 for c in ("W", "U", "B", "R", "G")},
+        },
+        "mana_generation": {"W": 0, "U": 0, "B": 0, "R": 0, "G": 0, "total_sources": 0},
+        "mana_curve": {
+            **curve_counts,
+            "total_spells": sum(curve_counts.values()),
+            "cards": curve_cards,
+        },
+        "colors": list(sess.get("color_identity") or []),
+    }
+
+
 def save_manual_deck(sess: Dict[str, Any], deck_dir: str) -> tuple:
     """Write the manual deck's CSV + TXT + `.summary.json` + `_compliance.json`
     sidecars. Mirrors `deck_import_service.save_imported_deck`'s file-writing
@@ -1529,8 +1609,9 @@ def save_manual_deck(sess: Dict[str, Any], deck_dir: str) -> tuple:
         if edit_source:
             meta["last_edited"] = _date.today().isoformat()
         card_count = sum(deck_card_counts(sess).values()) + (1 if commander_name else 0)
+        summary = {"card_count": card_count, **_build_deck_summary(sess)}
         with open(summary_path, "w", encoding="utf-8") as fh:
-            json.dump({"meta": meta, "summary": {"card_count": card_count}}, fh, ensure_ascii=False, indent=2)
+            json.dump({"meta": meta, "summary": summary}, fh, ensure_ascii=False, indent=2)
     except Exception as exc:
         try:
             os.remove(csv_path)


### PR DESCRIPTION
## Summary
Fixes three Manual Deck Builder bugs found during real manual builds:

1. Fetch lands unrelated to the commander's colors (e.g. Polluted Delta in a white/green deck) showed up in the pool. Fetch lands have no `colorIdentity` pips, so the plain color-identity subset legality check always let them through. The pool now also filters them through `fetch_land_allowed_for_colors` (reused from the auto-builder) so only fetches whose basic land types overlap the deck's colors remain.
2. Saved manual decks appeared empty when viewed in the finished-deck browser (editing showed the full list). `resolve_color_identity` parsed a commander's `colorIdentity` string (e.g. `"G, W"`) with `list(color_str)`, producing garbage per-character output instead of splitting on comma. Separately, `save_manual_deck` only wrote `{"card_count": N}` for `summary`, which short-circuited the deck-view route's CSV-fallback reconstruction (any truthy dict skips it), so the view template found no `type_breakdown`. Added `_build_deck_summary()` to write the full `type_breakdown`/`mana_curve`/`colors` schema matching the existing CSV-fallback format.

## Testing
- `pytest -q code/tests/test_manual_builder.py` (28 passed, including 3 new tests covering fetch-land filtering, color-identity comma parsing, and the full summary schema).

## Docs
- CHANGELOG.md / RELEASE_NOTES_TEMPLATE.md `Fixed` entries added.
