### PR TITLE
Fix tag search accuracy, manual builder polish, tagging cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,16 +9,23 @@ This format follows Keep a Changelog principles and aims for Semantic Versioning
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- Manual Deck Builder: pressing Shift+Enter in the card search box instantly adds the best-guess match (an exact name match if one exists, otherwise the top result), which is now also shown beneath the search results ("Shift+Enter adds: <card>").
+- Card Browser: typing a `tag:`/`-tag:`/`theme:`/`-theme:` flag in the search box now suggests matching full tag names (e.g. typing `tag:Graveyard` suggests "Graveyard Hate", "Graveyard Matters", "Graveyard Recursion"); picking one fills in just that flag's value instead of replacing the whole search.
+- Public API: new `GET /api/v1/themes/autocomplete` endpoint for fuzzy tag/theme name suggestions by name only (not synergies/description); powers the same tag-value suggestion feature in the mobile app's card browser.
 
 ### Changed
-_No unreleased changes yet_
+- Manual Deck Builder: card name search now responds 300ms after you stop typing instead of 400ms, matching the debounce standardized elsewhere in the app (e.g. the New Deck modal's commander search).
 
 ### Fixed
-_No unreleased changes yet_
+- Manual Deck Builder: adding or removing a card no longer visually "jumps" the pool to a different category when the one you're viewing shrinks.
+- Manual Deck Builder: a saved/finished deck's Mana Overview panel now shows real pip and mana-source data instead of all zeros; it previously only worked correctly while the deck was still being built.
+- Manual Deck Builder: choosing a printing for one card in the name-search results no longer changes the printing shown for every other card in that search.
+- Manual Deck Builder: adding a card from the name-search results now removes it from the results immediately instead of only disappearing after re-running the search.
+- Tagging: cards with Airbending/Waterbending/Firebending/Earthbending keywords were double-tagged with both the short form (e.g. `Airbend`) and the full keyword form (e.g. `Airbending`); the short-form duplicates have been removed.
+- Search (card browser, manual deck builder, owned library, and the public API): a negated tag flag (e.g. `-tag:"Spellslinger"`) combined with another tag filter was incorrectly treated as another required tag instead of an exclusion, so cards with the excluded tag still showed up in results.
 
 ### Removed
-_No unreleased changes yet_
+- Card Browser and Owned Library: removed the separate "Themes (up to 5)" filter bar; theme/tag filtering is already available via `tag:`/`-tag:`/`theme:`/`-theme:` flags in the main search box.
 
 ### Security
 _No unreleased changes yet_

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -2,16 +2,22 @@
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- Manual Deck Builder: press Shift+Enter in the card search box to instantly add the best-guess match; the search results now show which card that would be.
+- Card Browser: typing a tag search flag now suggests matching tag names to fill in, so you don't have to know the exact spelling.
 
 ### Changed
-_No unreleased changes yet_
+- Manual Deck Builder: card name search feels a bit snappier while typing.
 
 ### Fixed
-_No unreleased changes yet_
+- Manual Deck Builder: the pool no longer jumps to a different section when adding or removing a card.
+- Manual Deck Builder: finished decks built manually now show correct mana pip/source charts instead of blank ones.
+- Manual Deck Builder: picking a printing for a searched card no longer affects other cards in the search results.
+- Manual Deck Builder: cards you add from search results now disappear from the list right away.
+- Tagging: fixed duplicate "bending" theme tags on Avatar-style cards (e.g. Airbend and Airbending on the same card).
+- Search: excluding a tag (e.g. `-tag:"Spellslinger"`) alongside another tag filter now actually excludes it instead of being ignored.
 
 ### Removed
-_No unreleased changes yet_
+- Card Browser and Owned Library: removed the separate "Themes" filter bar; you can already filter by theme/tag from the main search box.
 
 ### Security
 _No unreleased changes yet_

--- a/code/tagging/tagger.py
+++ b/code/tagging/tagger.py
@@ -4726,10 +4726,10 @@ def tag_for_bending(df: pd.DataFrame, color: str) -> None:
         earth_mask = tag_utils.create_text_mask(df, 'earthbend')
         bending_mask = air_mask | water_mask | fire_mask | earth_mask
         rules = [
-            {'mask': air_mask, 'tags': ['Airbend', 'Exile Matters', 'Leave the Battlefield']},
-            {'mask': water_mask, 'tags': ['Waterbend', 'Cost Reduction', 'Big Mana']},
-            {'mask': fire_mask, 'tags': ['Aggro', 'Combat Matters', 'Firebend', 'Mana Dork', 'Ramp', 'X Spells']},
-            {'mask': earth_mask, 'tags': ['Earthbend', 'Lands Matter', 'Landfall']},
+            {'mask': air_mask, 'tags': ['Airbending', 'Exile Matters', 'Leave the Battlefield']},
+            {'mask': water_mask, 'tags': ['Waterbending', 'Cost Reduction', 'Big Mana']},
+            {'mask': fire_mask, 'tags': ['Firebending', 'Combat Matters', 'Mana Dork', 'Ramp', 'X Spells']},
+            {'mask': earth_mask, 'tags': ['Earthbending', 'Lands Matter', 'Landfall']},
             {'mask': bending_mask, 'tags': ['Bending']},
         ]
         tag_utils.tag_with_rules_and_logging(df, rules, 'bending effects', color=color, logger=logger)

--- a/code/tests/test_api_v1_cards.py
+++ b/code/tests/test_api_v1_cards.py
@@ -84,6 +84,22 @@ def test_list_cards_by_tags_and_logic(client):
     assert names == {"Lightning Bolt", "Fire // Ice"}
 
 
+def test_list_cards_by_negative_tag_flag(client):
+    # `-tag:` should exclude cards with that tag, not silently be treated
+    # as another required (AND) positive tag.
+    resp = client.get("/api/v1/cards", params={"q": 'tag:Removal -tag:Burn'})
+    data = resp.json()["data"]
+    names = {c["name"] for c in data["cards"]}
+    assert names == set()  # every "Removal" card here also has "Burn"
+
+    resp = client.get("/api/v1/cards", params={"q": "-tag:Burn"})
+    data = resp.json()["data"]
+    names = {c["name"] for c in data["cards"]}
+    assert "Lightning Bolt" not in names
+    assert "Fire // Ice" not in names
+    assert "Sol Ring" in names
+
+
 def test_list_cards_cmc_range(client):
     resp = client.get("/api/v1/cards", params={"min_cmc": 2, "max_cmc": 2})
     data = resp.json()["data"]

--- a/code/tests/test_api_v1_themes.py
+++ b/code/tests/test_api_v1_themes.py
@@ -73,3 +73,22 @@ def test_theme_detail_with_slash_in_name(client):
     resp = client.get("/api/v1/themes/+1/+1 Counters")
     assert resp.status_code == 200
     assert resp.json()["data"]["theme"] == "+1/+1 Counters"
+
+
+def test_theme_autocomplete_matches_name_not_synergies(client):
+    """Unlike the main list endpoint (which also matches synergies/description),
+    autocomplete fuzzy-matches the theme's own name, so a query like 'grave'
+    should surface actual Graveyard-named themes near the top (allowing a few
+    fuzzy near-misses, same as the web card browser's autocomplete)."""
+    resp = client.get("/api/v1/themes/autocomplete", params={"q": "grave"})
+    assert resp.status_code == 200
+    names = resp.json()["data"]["themes"]
+    assert names, "expected at least one graveyard-named theme suggestion"
+    assert any("grave" in n.lower() for n in names)
+    assert "grave" in names[0].lower()
+
+
+def test_theme_autocomplete_respects_limit(client):
+    resp = client.get("/api/v1/themes/autocomplete", params={"q": "token", "limit": 3})
+    assert resp.status_code == 200
+    assert len(resp.json()["data"]["themes"]) <= 3

--- a/code/web/routes/api_v1/cards.py
+++ b/code/web/routes/api_v1/cards.py
@@ -320,15 +320,19 @@ async def list_cards(
 
     # Theme tags -- combine the explicit `tags` param with any `tag=` flags
     # parsed out of `q`; AND logic (a card must have all requested tags).
+    # `-tag:`/`-theme:` flags parsed out of `q` exclude cards with any of
+    # those tags (OR logic: excluded if it has at least one).
     requested_tags = {t.strip().lower() for t in tags.split(",") if t.strip()}
     if parsed.tags:
         requested_tags |= parsed.tags
-    if requested_tags and "themeTags" in df.columns:
+    if (requested_tags or parsed.tags_exclude) and "themeTags" in df.columns:
         # themeTags may be stored as a string, list, or numpy array depending on
         # source (raw CSV vs. Parquet) -- parse_theme_tags() normalizes all of them.
         card_tag_sets = df["themeTags"].apply(lambda v: {t.lower() for t in parse_theme_tags(v)})
-        mask = card_tag_sets.apply(lambda card_tags: all(tag in card_tags for tag in requested_tags))
-        df = df[mask]
+        if requested_tags:
+            df = df[card_tag_sets.loc[df.index].apply(lambda card_tags: all(tag in card_tags for tag in requested_tags))]
+        if parsed.tags_exclude:
+            df = df[card_tag_sets.loc[df.index].apply(lambda card_tags: not any(tag in card_tags for tag in parsed.tags_exclude))]
 
 
     if min_cmc is not None and "manaValue" in df.columns:

--- a/code/web/routes/api_v1/themes.py
+++ b/code/web/routes/api_v1/themes.py
@@ -20,6 +20,9 @@ from ...services.theme_catalog_loader import (
 )
 from ...services.theme_preview import get_theme_preview
 from ...utils.api_response import err, ok
+# Reuses the web card browser's theme catalog cache + fuzzy name scorer
+# instead of duplicating them, so tag: autocomplete stays consistent everywhere.
+from ..card_browser import _fuzzy_theme_match_score, get_theme_catalog
 
 router = APIRouter(prefix="/themes", tags=["themes"])
 
@@ -65,6 +68,28 @@ async def list_themes(
         },
         _rid(request),
     )
+
+
+@router.get("/autocomplete", summary="Fuzzy tag/theme name suggestions")
+async def theme_autocomplete(
+    request: Request,
+    q: str = Query(..., min_length=2, description="Partial theme/tag name"),
+    limit: int = Query(8, ge=1, le=20),
+):
+    """Fuzzy-match theme names by name only (not synergies/description), for
+    filling in a tag:/theme: search flag's value. Mirrors the web card
+    browser's `/cards/theme-autocomplete` HTML endpoint, minus the HTML."""
+    try:
+        all_themes = get_theme_catalog()
+    except Exception:
+        return err("Theme catalog unavailable.", "CATALOG_UNAVAILABLE", 503, _rid(request))
+
+    scored = [(_fuzzy_theme_match_score(q, theme), theme) for theme in all_themes]
+    scored = [(score, theme) for score, theme in scored if score >= 0.5]
+    scored.sort(key=lambda item: (-item[0], item[1].lower()))
+    names = [theme for _, theme in scored[:limit]]
+
+    return ok({"themes": names}, _rid(request))
 
 
 @router.get("/{theme:path}", summary="Get theme detail and preview")

--- a/code/web/routes/manual_builder.py
+++ b/code/web/routes/manual_builder.py
@@ -160,7 +160,15 @@ async def manual_builder_search(
     # so search results paginate the same as the rest of the pool.
     per_page = manual_builder_service._CATEGORY_PAGE_SIZE
     result = manual_builder_service.search_off_pool(sess, q, page=page, per_page=per_page)
-    ctx = {"request": request, "session_id": sid, "query": q, **result}
+    ctx = {
+        "request": request,
+        "session_id": sid,
+        "query": q,
+        "printings": sess.get("_manual_printings") or {},
+        "foils": sess.get("_manual_foils") or {},
+        "best_match": manual_builder_service.best_search_match(q, result["cards"]) if page == 1 else None,
+        **result,
+    }
     return templates.TemplateResponse("decks/_manual_search_results.html", ctx)
 
 

--- a/code/web/routes/owned.py
+++ b/code/web/routes/owned.py
@@ -78,9 +78,11 @@ def _apply_owned_search(
         if parsed.identity_clauses and not all(_color_matches(card_letters, c) for c in parsed.identity_clauses):
             return False
 
-        if parsed.tags:
+        if parsed.tags or parsed.tags_exclude:
             card_tags = {t.lower() for t in (tags_by_name.get(name) or [])}
-            if not all(tag in card_tags for tag in parsed.tags):
+            if parsed.tags and not all(tag in card_tags for tag in parsed.tags):
+                return False
+            if parsed.tags_exclude and any(tag in card_tags for tag in parsed.tags_exclude):
                 return False
 
         stats = stats_map.get(name) or {}

--- a/code/web/services/card_search.py
+++ b/code/web/services/card_search.py
@@ -137,6 +137,7 @@ class ParsedSearch:
     mana_cost_clauses: List[ManaCostClause] = field(default_factory=list)
     rarity: Optional[Set[str]] = None
     tags: Optional[Set[str]] = None
+    tags_exclude: Optional[Set[str]] = None
     is_new: Optional[bool] = None
     set_include: Set[str] = field(default_factory=set)
     set_exclude: Set[str] = field(default_factory=set)
@@ -439,7 +440,10 @@ def _apply_search_flag(parsed: ParsedSearch, canonical: str, op: str, value: str
     elif canonical == "tag":
         tags = {v.strip().lower() for v in value.split(",") if v.strip()}
         if tags:
-            parsed.tags = (parsed.tags or set()) | tags
+            if negate:
+                parsed.tags_exclude = (parsed.tags_exclude or set()) | tags
+            else:
+                parsed.tags = (parsed.tags or set()) | tags
     elif canonical == "is" and value.lower() == "new":
         parsed.is_new = False if negate else True
     elif canonical == "set":
@@ -502,9 +506,12 @@ def apply_extra_clauses(df: "pd.DataFrame", parsed: ParsedSearch) -> "pd.DataFra
     query params instead and don't want the `q` flags double-applied."""
     if parsed.rarity and "rarity" in df.columns:
         df = df[df["rarity"].astype(str).str.lower().isin(parsed.rarity)]
-    if parsed.tags and "themeTags" in df.columns:
+    if (parsed.tags or parsed.tags_exclude) and "themeTags" in df.columns:
         card_tag_sets = df["themeTags"].apply(lambda v: {t.lower() for t in parse_theme_tags(v)})
-        df = df[card_tag_sets.apply(lambda card_tags: all(tag in card_tags for tag in parsed.tags))]
+        if parsed.tags:
+            df = df[card_tag_sets.loc[df.index].apply(lambda card_tags: all(tag in card_tags for tag in parsed.tags))]
+        if parsed.tags_exclude:
+            df = df[card_tag_sets.loc[df.index].apply(lambda card_tags: not any(tag in card_tags for tag in parsed.tags_exclude))]
     if parsed.is_new is not None and "isNew" in df.columns:
         df = df[df["isNew"] == parsed.is_new]
     if parsed.set_include and "printings" in df.columns:
@@ -528,6 +535,6 @@ def has_structured_flags(parsed: ParsedSearch) -> bool:
         or parsed.power_clauses or parsed.toughness_clauses
         or parsed.loyalty_clauses or parsed.cmc_clauses
         or parsed.mana_cost_clauses
-        or parsed.rarity or parsed.tags or parsed.is_new is not None
+        or parsed.rarity or parsed.tags or parsed.tags_exclude or parsed.is_new is not None
         or parsed.set_include or parsed.set_exclude
     )

--- a/code/web/services/manual_builder_service.py
+++ b/code/web/services/manual_builder_service.py
@@ -876,6 +876,23 @@ def search_off_pool(
     return result
 
 
+def best_search_match(query: str, cards: List[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+    """The single card a Shift+Enter quick-add should add for `query`: an
+    exact (case-insensitive) name match if one is present in `cards`,
+    otherwise the top (most relevant/popular) result. `cards` should be
+    page 1 of `search_off_pool`'s results - a later page's top card isn't
+    the best guess for the query as a whole.
+    """
+    if not cards:
+        return None
+    q_norm = query.strip().lower()
+    if q_norm:
+        for card in cards:
+            if str(card.get("name") or "").strip().lower() == q_norm:
+                return card
+    return cards[0]
+
+
 # ---------------------------------------------------------------------------
 # Milestone 3: add / remove / deck panel
 # ---------------------------------------------------------------------------
@@ -1112,21 +1129,20 @@ def deck_panel_data(sess: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
-def mana_overview_data(sess: Dict[str, Any]) -> Dict[str, Any]:
-    """Pip distribution, mana sources, and mana curve for the in-progress
-    deck, for the sidebar mana-overview panel next to the commander image.
-    Reuses the same builder_utils helpers as the finished-deck summary
-    (`DeckBuilder.build_deck_summary`), fed from a synthetic card_library
-    built out of the session's deck_cards rather than a full DeckBuilder.
+def _mana_card_library(sess: Dict[str, Any]) -> tuple[Dict[str, Dict[str, Any]], Dict[str, Optional[pd.Series]]]:
+    """Card-library dict (name -> {Card Type, Mana Cost, Count}) for the
+    deck's cards plus the commander, and the raw row lookups behind it.
+    Shared by `mana_overview_data` (live in-progress sidebar) and
+    `_build_deck_summary` (saved `.summary.json`) so both compute pips/
+    sources the same way instead of drifting apart.
     """
     counts = deck_card_counts(sess)
-    color_identity = [c for c in ["W", "U", "B", "R", "G"] if c in (sess.get("color_identity") or [])]
-    card_library: Dict[str, Dict[str, Any]] = {}
     commander_name = sess.get("commander")
     lookup_names = list(counts.keys())
     if commander_name and commander_name not in counts:
         lookup_names.append(commander_name)
     rows = _lookup_card_rows(sess, lookup_names)
+    card_library: Dict[str, Dict[str, Any]] = {}
     for name, count in counts.items():
         row = rows.get(name)
         card_library[name] = {
@@ -1144,6 +1160,85 @@ def mana_overview_data(sess: Dict[str, Any]) -> Dict[str, Any]:
             "Mana Cost": str(commander_row.get("manaCost") or "") if commander_row is not None else "",
             "Count": 1,
         }
+    return card_library, rows
+
+
+def _mana_pip_and_source_summary(sess: Dict[str, Any]) -> Dict[str, Any]:
+    """`pip_distribution`/`mana_generation` in the same shape
+    `DeckBuilder.build_deck_summary()` produces (counts/weights/cards dicts,
+    raw source counts rather than percentages) for the saved deck's
+    `.summary.json` - which `decks/view.html`'s Mana Overview panel reads
+    via `partials/deck_summary.html`. Unlike `mana_overview_data` (percentage-
+    based, list-shaped, for the live in-progress sidebar), this matches the
+    finished-deck schema so manually-built decks render the same as
+    auto-built ones after saving.
+    """
+    color_identity = [c for c in ("W", "U", "B", "R", "G") if c in (sess.get("color_identity") or [])]
+    card_library, _rows = _mana_card_library(sess)
+
+    pip_density = compute_pip_density(card_library, color_identity)
+    pip_counts: Dict[str, float] = {}
+    for c in ("W", "U", "B", "R", "G"):
+        d = pip_density[c]
+        pip_counts[c] = float(d["single"] + d["double"] * 2 + d["triple"] * 3 + d["phyrexian"])
+    pip_cards: Dict[str, List[Dict[str, Any]]] = {c: [] for c in ("W", "U", "B", "R", "G")}
+    for name, entry in card_library.items():
+        if "land" in str(entry.get("Card Type") or "").lower():
+            continue
+        mana_cost = entry.get("Mana Cost") or ""
+        if not isinstance(mana_cost, str):
+            continue
+        colors_for_card: set = set()
+        for match in re.findall(r"\{([^}]+)\}", mana_cost):
+            sym = match.upper()
+            if len(sym) == 1 and sym in pip_cards:
+                colors_for_card.add(sym)
+            elif "/" in sym:
+                for p in sym.split("/"):
+                    if p in pip_cards:
+                        colors_for_card.add(p)
+            elif sym.endswith("P") and len(sym) == 2 and sym[0] in pip_cards:
+                colors_for_card.add(sym[0])
+        if colors_for_card:
+            cnt = int(entry.get("Count", 1))
+            for c in colors_for_card:
+                pip_cards[c].append({"name": name, "count": cnt})
+    total_pips = sum(pip_counts.values())
+    if total_pips <= 0 and color_identity:
+        share = 1 / len(color_identity)
+        for c in color_identity:
+            pip_counts[c] = share
+        total_pips = 1.0
+    pip_weights = {c: (pip_counts[c] / total_pips if total_pips else 0.0) for c in pip_counts}
+
+    full_df = _get_loader().load()
+    scoped_df = full_df[full_df["name"].astype(str).isin(card_library.keys())]
+    matrix = compute_color_source_matrix(card_library, scoped_df)
+    source_counts: Dict[str, int] = {c: 0 for c in ("W", "U", "B", "R", "G", "C")}
+    source_cards: Dict[str, List[Dict[str, Any]]] = {c: [] for c in ("W", "U", "B", "R", "G", "C")}
+    for name, flags in matrix.items():
+        copies = int(card_library.get(name, {}).get("Count", 1))
+        for c in source_counts:
+            if int(flags.get(c, 0)):
+                source_counts[c] += copies
+                source_cards[c].append({"name": name, "count": copies})
+    total_sources = sum(source_counts.values())
+
+    return {
+        "pip_distribution": {"counts": pip_counts, "weights": pip_weights, "cards": pip_cards},
+        "mana_generation": {**source_counts, "total_sources": total_sources, "cards": source_cards},
+    }
+
+
+def mana_overview_data(sess: Dict[str, Any]) -> Dict[str, Any]:
+    """Pip distribution, mana sources, and mana curve for the in-progress
+    deck, for the sidebar mana-overview panel next to the commander image.
+    Reuses the same builder_utils helpers as the finished-deck summary
+    (`DeckBuilder.build_deck_summary`), fed from a synthetic card_library
+    built out of the session's deck_cards rather than a full DeckBuilder.
+    """
+    color_identity = [c for c in ["W", "U", "B", "R", "G"] if c in (sess.get("color_identity") or [])]
+    card_library, rows = _mana_card_library(sess)
 
     pip_density = compute_pip_density(card_library, color_identity)
     pip_counts: Dict[str, float] = {}
@@ -1457,10 +1552,11 @@ def build_deck_txt_text(sess: Dict[str, Any]) -> str:
 
 def _build_deck_summary(sess: Dict[str, Any]) -> Dict[str, Any]:
     """Build the full `.summary.json` `summary` block (type_breakdown +
-    mana_curve + colors) from the in-memory session. Matches the schema
-    `decks.py`'s CSV-fallback (`_read_csv_summary`) produces, so the
-    finished-deck browser/view page renders manual decks the same as any
-    other saved deck instead of showing an empty list.
+    pip_distribution + mana_generation + mana_curve + colors) from the
+    in-memory session, matching `DeckBuilder.build_deck_summary()`'s schema
+    so the finished-deck view page (`decks/view.html` /
+    `partials/deck_summary.html`) renders manual decks - including a real
+    Mana Overview panel - the same as any auto-built deck.
     """
     rows = _build_deck_rows(sess)
     type_counts: Dict[str, int] = {}
@@ -1490,6 +1586,7 @@ def _build_deck_summary(sess: Dict[str, Any]) -> Dict[str, Any]:
             curve_cards[bucket].append({"name": r["name"], "count": r["count"]})
 
     type_order = [t for t in _DECK_TYPE_ORDER if t in type_counts]
+    mana_summary = _mana_pip_and_source_summary(sess)
     return {
         "type_breakdown": {
             "counts": type_counts,
@@ -1497,11 +1594,8 @@ def _build_deck_summary(sess: Dict[str, Any]) -> Dict[str, Any]:
             "cards": type_cards,
             "total": sum(type_counts.values()),
         },
-        "pip_distribution": {
-            "counts": {c: 0 for c in ("W", "U", "B", "R", "G")},
-            "weights": {c: 0 for c in ("W", "U", "B", "R", "G")},
-        },
-        "mana_generation": {"W": 0, "U": 0, "B": 0, "R": 0, "G": 0, "total_sources": 0},
+        "pip_distribution": mana_summary["pip_distribution"],
+        "mana_generation": mana_summary["mana_generation"],
         "mana_curve": {
             **curve_counts,
             "total_spells": sum(curve_counts.values()),

--- a/code/web/templates/browse/cards/index.html
+++ b/code/web/templates/browse/cards/index.html
@@ -142,47 +142,13 @@
           <button type="submit" class="btn">Search</button>
         </div>
         <div class="filter-row">
-          <span class="muted text-sm">Supports <a href="https://scryfall.com/docs/syntax" target="_blank" rel="noopener">Scryfall-style</a> flags, e.g. <code>t:creature</code>, <code>c:rg</code>, <code>mv&gt;=4</code>, <code>set:ala</code>, <code>is:new</code></span>
+          <span class="muted text-sm">Supports <a href="https://scryfall.com/docs/syntax" target="_blank" rel="noopener">Scryfall-style</a> flags, e.g. <code>tag:"Graveyard Hate"</code>, <code>c:rg</code>, <code>mv&gt;=4</code>, <code>set:ala</code>, <code>is:new</code></span>
         </div>
       </form>
     </div>
 
     {# Filter controls #}
     <div class="filter-section" style="margin-top: 1rem;">
-      <div class="filter-row">
-        {# Multi-select theme filter #}
-        <label for="filter-theme-input">Themes (up to 5)</label>
-        <div style="flex: 1; max-width: 500px;">
-          {# Selected themes as chips #}
-          <div id="selected-themes" style="display: flex; flex-wrap: wrap; gap: 0.5rem; margin-bottom: 0.5rem; min-height: 2rem;">
-            {% if themes %}
-              {% for t in themes %}
-              <span class="theme-chip" data-theme="{{ t }}">
-                {{ t }}
-                <button type="button" onclick="removeTheme('{{ t }}')" style="margin-left:0.5rem; background:none; border:none; color:inherit; cursor:pointer; padding:0; font-weight:bold;">&times;</button>
-              </span>
-              {% endfor %}
-            {% endif %}
-          </div>
-          
-          {# Autocomplete input #}
-          <div class="autocomplete-container" style="position:relative;">
-            <input 
-              type="text" 
-              id="filter-theme-input"
-              placeholder="Add theme..." 
-              autocomplete="off"
-              role="combobox"
-              aria-autocomplete="list"
-              aria-controls="theme-autocomplete-dropdown"
-              aria-expanded="false"
-              style="width: 100%;"
-            />
-            <div id="theme-autocomplete-dropdown" class="autocomplete-dropdown" role="listbox" aria-label="Theme suggestions"></div>
-          </div>
-        </div>
-      </div>
-      
       <div class="filter-row">
         {# Sort dropdown #}
         <label for="filter-sort">Sort By</label>
@@ -235,7 +201,7 @@
     <button 
       type="button"
       class="btn"
-      hx-get="/cards/grid?cursor={{ last_card|urlencode }}{% if search %}&search={{ search|urlencode }}{% endif %}{% for theme in themes %}&themes={{ theme|urlencode }}{% endfor %}{% if sort and sort != 'name_asc' %}&sort={{ sort|urlencode }}{% endif %}"
+      hx-get="/cards/grid?cursor={{ last_card|urlencode }}{% if search %}&search={{ search|urlencode }}{% endif %}{% if sort and sort != 'name_asc' %}&sort={{ sort|urlencode }}{% endif %}"
       hx-target="#card-grid"
       hx-swap="beforeend"
       hx-indicator="#load-indicator">
@@ -251,23 +217,18 @@
   <div class="no-results">
     <div class="no-results-title">No cards found</div>
     <div class="no-results-message">
-      {% if search or themes %}
+      {% if search %}
         No cards match your current filters.
-        {% if search %}Try a different search term{% endif %}{% if search and themes %} or {% endif %}{% if themes %}adjust your themes{% endif %}.
+        Try a different search term.
       {% else %}
         Unable to load cards. Please try refreshing the page.
       {% endif %}
     </div>
     
-    {% if search or themes %}
+    {% if search %}
     <div class="no-results-filters">
       <strong style="color: var(--text); margin-right: 0.5rem;">Active filters:</strong>
-      {% if search %}
       <span class="no-results-filter-tag">Search: "{{ search }}"</span>
-      {% endif %}
-      {% for t in themes %}
-      <span class="no-results-filter-tag">Theme: {{ t }}</span>
-      {% endfor %}
     </div>
     <p><a href="/cards" class="btn">Clear All Filters</a></p>
     {% endif %}
@@ -329,14 +290,8 @@ function applyFilter() {
   const search = document.getElementById('search-input')?.value || '';
   const sort = document.getElementById('filter-sort')?.value || '';
   
-  // Collect selected themes
-  const themeChips = document.querySelectorAll('#selected-themes .theme-chip');
-  const themes = Array.from(themeChips).map(chip => chip.dataset.theme);
-  
   const params = new URLSearchParams();
   if (search) params.set('search', search);
-  // Add themes as multiple params (themes=t1&themes=t2&themes=t3)
-  themes.forEach(theme => params.append('themes', theme));
   if (sort && sort !== 'name_asc') params.set('sort', sort); // Only include if not default
   
   window.location.href = `/cards?${params.toString()}`;
@@ -353,9 +308,78 @@ function applyFilter() {
   let selectedIndex = -1;
   let debounceTimer = null;
   let lastEscapeTime = 0;
-  
+  // When the caret is inside a tag:/-tag:/theme:/-theme: flag's value,
+  // suggestions recommend a full tag value to fill in that flag (not
+  // replace the whole search box) -- tracks the flag's value span so a
+  // selection can be spliced into just that one token.
+  let tagToken = null;
+  let TAG_TOKEN_RE = null;
+  try {
+    TAG_TOKEN_RE = new RegExp('(-)?\\b(tag|theme):(?:"([^"]*)"?|(\\S*))', 'dgi');
+  } catch (e) {
+    TAG_TOKEN_RE = null; // `d` (hasIndices) flag unsupported -- degrade to name-only autocomplete
+  }
+
+  // Finds the tag:/theme: flag (if any) whose value the caret is currently
+  // positioned in, e.g. `tag:Recursion tag:"Grave|yard"` (caret at `|`)
+  // returns {valueStart, valueEnd, partial: 'Grave'}.
+  const detectTagToken = (value, caret) => {
+    if (!TAG_TOKEN_RE) return null;
+    TAG_TOKEN_RE.lastIndex = 0;
+    let m;
+    while ((m = TAG_TOKEN_RE.exec(value)) !== null) {
+      const idx = m.indices;
+      if (!idx) return null;
+      const [start, end] = idx[0];
+      if (caret < start || caret > end) continue;
+      const quoted = m[3] !== undefined;
+      const span = quoted ? idx[3] : idx[4];
+      if (!span) continue;
+      const [valueStart, valueEnd] = span;
+      if (caret < valueStart) continue; // caret is still in "tag:" itself
+      return { valueStart, valueEnd, partial: value.slice(valueStart, Math.min(caret, valueEnd)) };
+    }
+    return null;
+  };
+
+  // Splices a chosen tag name into the active tag: flag's value (quoted),
+  // leaving the rest of the search box untouched. Returns false (no-op)
+  // if the caret isn't currently inside a tag:/theme: flag.
+  const applyTagSuggestion = (value) => {
+    if (!tagToken) return false;
+    const full = searchInput.value;
+    const quotedValue = `"${value}"`;
+    searchInput.value = full.slice(0, tagToken.valueStart) + quotedValue + full.slice(tagToken.valueEnd);
+    const caret = tagToken.valueStart + quotedValue.length;
+    searchInput.setSelectionRange(caret, caret);
+    tagToken = null;
+    searchInput.focus();
+    return true;
+  };
+
   // Fetch autocomplete suggestions
   const fetchSuggestions = () => {
+    const caret = searchInput.selectionStart ?? searchInput.value.length;
+    tagToken = detectTagToken(searchInput.value, caret);
+
+    if (tagToken) {
+      const partial = tagToken.partial.trim();
+      if (partial.length < 2) {
+        autocompleteDropdown.innerHTML = '';
+        return;
+      }
+      // Reuse the theme catalog autocomplete for tag:/theme: flag values.
+      fetch(`/cards/theme-autocomplete?q=${encodeURIComponent(partial)}&limit=8`)
+        .then(response => response.text())
+        .then(html => {
+          autocompleteDropdown.innerHTML = html;
+        })
+        .catch(() => {
+          autocompleteDropdown.innerHTML = '';
+        });
+      return;
+    }
+
     const query = searchInput.value.trim();
     if (query.length < 2) {
       autocompleteDropdown.innerHTML = '';
@@ -402,6 +426,11 @@ function applyFilter() {
     const items = getItems();
     const item = items[selectedIndex];
     if (item && item.dataset.value) {
+      if (applyTagSuggestion(item.dataset.value)) {
+        autocompleteDropdown.innerHTML = '';
+        selectedIndex = -1;
+        return;
+      }
       searchInput.value = item.dataset.value;
       autocompleteDropdown.innerHTML = '';
       selectedIndex = -1;
@@ -425,6 +454,11 @@ function applyFilter() {
     const item = e.target.closest('.autocomplete-item');
     if (item && item.dataset.value && autocompleteDropdown.contains(item)) {
       e.preventDefault();
+      if (applyTagSuggestion(item.dataset.value)) {
+        autocompleteDropdown.innerHTML = '';
+        selectedIndex = -1;
+        return;
+      }
       searchInput.value = item.dataset.value;
       autocompleteDropdown.innerHTML = '';
       selectedIndex = -1;
@@ -489,240 +523,6 @@ function applyFilter() {
   
   // Mouse hover to highlight items
   autocompleteDropdown.addEventListener('mouseover', (e) => {
-    const item = e.target.closest('.autocomplete-item');
-    if (item) {
-      const items = getItems();
-      const index = items.indexOf(item);
-      if (index >= 0) {
-        selectItem(index);
-      }
-    }
-  });
-})();
-
-// Multi-select theme filter
-(function() {
-  const themeInput = document.getElementById('filter-theme-input');
-  const themeDropdown = document.getElementById('theme-autocomplete-dropdown');
-  const selectedThemesContainer = document.getElementById('selected-themes');
-  
-  if (!themeInput || !themeDropdown) return;
-  
-  let selectedIndex = -1;
-  let debounceTimer = null;
-  let selectedThemes = new Set();
-  let lastEscapeTime = 0;
-  
-  // Initialize with existing themes from URL
-  const existingChips = selectedThemesContainer.querySelectorAll('.theme-chip');
-  existingChips.forEach(chip => {
-    selectedThemes.add(chip.dataset.theme);
-  });
-  
-  // Update input state based on theme count
-  const updateThemeInputState = () => {
-    if (selectedThemes.size >= 5) {
-      themeInput.disabled = true;
-      themeInput.placeholder = 'Maximum 5 themes selected';
-      themeInput.classList.add('disabled');
-    } else {
-      themeInput.disabled = false;
-      themeInput.placeholder = 'Add theme...';
-      themeInput.classList.remove('disabled');
-    }
-  };
-  
-  // Initialize the input state
-  updateThemeInputState();
-  
-  // Fetch theme suggestions
-  const fetchThemeSuggestions = () => {
-    const query = themeInput.value.trim();
-    if (query.length < 2) {
-      themeDropdown.innerHTML = '';
-      return;
-    }
-    
-    fetch(`/cards/theme-autocomplete?q=${encodeURIComponent(query)}`)
-      .then(response => response.text())
-      .then(html => {
-        themeDropdown.innerHTML = html;
-      })
-      .catch(err => {
-        console.error('Theme autocomplete error:', err);
-        themeDropdown.innerHTML = '';
-      });
-  };
-  
-  // Add theme chip
-  window.addTheme = function(theme) {
-    if (selectedThemes.size >= 5) {
-      return; // Input should already be disabled, but double-check
-    }
-    if (selectedThemes.has(theme)) {
-      return; // Already selected
-    }
-    
-    selectedThemes.add(theme);
-    
-    const chip = document.createElement('span');
-    chip.className = 'theme-chip';
-    chip.dataset.theme = theme;
-    chip.innerHTML = `${theme} <button type="button" onclick="removeTheme('${theme.replace(/'/g, "\\'")}')" style="margin-left:0.5rem; background:none; border:none; color:inherit; cursor:pointer; padding:0; font-weight:bold;">&times;</button>`;
-    
-    selectedThemesContainer.appendChild(chip);
-    themeInput.value = '';
-    themeDropdown.innerHTML = '';
-    selectedIndex = -1;
-    
-    updateThemeInputState();
-    
-    // Auto-focus the input on desktop (not mobile) for quick multi-selection
-    // Focus immediately since we're NOT reloading the page anymore
-    if (selectedThemes.size < 5 && window.innerWidth >= 768) {
-      // Small delay to ensure DOM updates are complete
-      requestAnimationFrame(() => {
-        themeInput.focus();
-      });
-    }
-    
-    // Don't auto-apply filter - let user add multiple themes then click Apply
-    // This allows the auto-focus to work and provides better UX
-    // applyFilter();
-  };
-  
-  // Remove theme chip
-  window.removeTheme = function(theme) {
-    selectedThemes.delete(theme);
-    const chip = selectedThemesContainer.querySelector(`.theme-chip[data-theme="${theme}"]`);
-    if (chip) {
-      chip.remove();
-    }
-    updateThemeInputState();
-    // Don't auto-apply filter - let user manage themes then click Apply
-    // applyFilter();
-  };
-  
-  // Debounced input handler
-  themeInput.addEventListener('input', () => {
-    clearTimeout(debounceTimer);
-    debounceTimer = setTimeout(fetchThemeSuggestions, 150);
-  });
-  
-  // Helper functions
-  const getItems = () => Array.from(themeDropdown.querySelectorAll('.autocomplete-item'));
-  
-  const selectItem = (index) => {
-    const items = getItems();
-    items.forEach((item, i) => {
-      if (i === index) {
-        item.classList.add('selected');
-        item.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-      } else {
-        item.classList.remove('selected');
-      }
-    });
-    selectedIndex = index;
-  };
-  
-  const applySelectedItem = () => {
-    const items = getItems();
-    const item = items[selectedIndex];
-    if (item && item.dataset.value) {
-      addTheme(item.dataset.value);
-    }
-  };
-  
-  // Reset selection when dropdown changes
-  const observer = new MutationObserver(() => {
-    selectedIndex = -1;
-    getItems().forEach(item => item.classList.remove('selected'));
-    const hasContent = themeDropdown.children.length > 0;
-    themeInput.setAttribute('aria-expanded', hasContent ? 'true' : 'false');
-  });
-  observer.observe(themeDropdown, { childList: true });
-  
-  // Click handler
-  document.body.addEventListener('click', (e) => {
-    const item = e.target.closest('.autocomplete-item');
-    if (item && item.dataset.value && themeDropdown.contains(item)) {
-      e.preventDefault();
-      addTheme(item.dataset.value);
-    }
-  });
-  
-  // Close dropdown when clicking outside
-  document.addEventListener('click', (e) => {
-    if (!e.target.closest('#filter-theme-input') && !e.target.closest('#theme-autocomplete-dropdown')) {
-      themeDropdown.innerHTML = '';
-      selectedIndex = -1;
-    }
-  });
-  
-  // Keyboard navigation
-  themeInput.addEventListener('keydown', (e) => {
-    const items = getItems();
-    const hasItems = items.length > 0;
-    
-    if (e.key === 'Escape') {
-      const now = Date.now();
-      const timeSinceLastEscape = now - lastEscapeTime;
-      
-      if (hasItems) {
-        // Close dropdown if open
-        themeDropdown.innerHTML = '';
-        selectedIndex = -1;
-        lastEscapeTime = now;
-        e.preventDefault();
-      } else if (timeSinceLastEscape < 500) {
-        // Double-tap Escape within 500ms - clear all filters
-        console.log('Double Escape detected - clearing filters');
-        e.preventDefault();
-        window.location.href = '/cards';
-      } else {
-        // First escape with no dropdown
-        lastEscapeTime = now;
-        e.preventDefault();
-      }
-    } else if (e.key === 'ArrowDown' && hasItems) {
-      e.preventDefault();
-      const newIndex = selectedIndex < items.length - 1 ? selectedIndex + 1 : 0;
-      selectItem(newIndex);
-    } else if (e.key === 'ArrowUp' && hasItems) {
-      e.preventDefault();
-      const newIndex = selectedIndex > 0 ? selectedIndex - 1 : items.length - 1;
-      selectItem(newIndex);
-    } else if (e.key === 'Enter') {
-      e.preventDefault();
-      if (e.shiftKey) {
-        // Shift+Enter: Add current theme if any, then apply all filters
-        if (hasItems) {
-          // Add the first match before applying
-          if (selectedIndex >= 0) {
-            applySelectedItem();
-          } else {
-            selectItem(0);
-            applySelectedItem();
-          }
-          // Small delay to ensure theme is added before applying filters
-          setTimeout(() => applyFilter(), 50);
-        } else {
-          // No autocomplete, just apply filters
-          applyFilter();
-        }
-      } else if (selectedIndex >= 0 && hasItems) {
-        // Apply the explicitly selected item
-        applySelectedItem();
-      } else if (hasItems) {
-        // No item selected, but there are items - select the first one
-        selectItem(0);
-        applySelectedItem();
-      }
-    }
-  });
-  
-  // Mouse hover
-  themeDropdown.addEventListener('mouseover', (e) => {
     const item = e.target.closest('.autocomplete-item');
     if (item) {
       const items = getItems();
@@ -806,13 +606,6 @@ window.addEventListener('load', function() {
   if (loadMoreContainer) {
     scrollObserver.observe(loadMoreContainer);
   }
-  
-  // Initialize theme chips from URL params
-  {% if themes %}
-  {% for theme in themes %}
-  addTheme('{{ theme|replace("'", "\\'") }}');
-  {% endfor %}
-  {% endif %}
 });
 </script>
 <script>
@@ -826,7 +619,6 @@ window.addEventListener('load', function() {
     var n = 0;
     var si = document.getElementById('search-input');
     if (si && si.value) n++;
-    n += document.querySelectorAll('#selected-themes .theme-chip').length;
     el.textContent = n > 0 ? ' (' + n + ' active)' : '';
   }
   window.toggleFilterPanel = function() {

--- a/code/web/templates/build/_new_deck_modal.html
+++ b/code/web/templates/build/_new_deck_modal.html
@@ -31,7 +31,7 @@
               <span>Commander</span>
     <input type="text" name="commander" required placeholder="Type a commander name" value="{{ form.commander if form else '' }}" autofocus autocomplete="off" autocapitalize="off" spellcheck="false"
       role="combobox" aria-autocomplete="list" aria-controls="newdeck-candidates"
-      hx-get="/build/new/candidates" hx-trigger="input changed delay:220ms, change" hx-target="#newdeck-candidates" hx-sync="this:replace" />
+      hx-get="/build/new/candidates" hx-trigger="input changed delay:300ms, change" hx-target="#newdeck-candidates" hx-sync="this:replace" />
             </label>
             <small class="muted block mt-1">Start typing to see matches, then select one to load themes.</small>
             <div id="newdeck-candidates" class="muted text-xs min-h-[1.1em]"></div>

--- a/code/web/templates/decks/_manual_pool_card.html
+++ b/code/web/templates/decks/_manual_pool_card.html
@@ -5,7 +5,7 @@
 {% set reasons_str = (card.reasons|join('; ')) if card.reasons else '' %}
 {% set deck_theme_tags = (card.tag_badges|selectattr('kind', 'equalto', 'deck_theme')|map(attribute='name')|list) if card.tag_badges else [] %}
 {% set all_tag_names = (card.tag_badges|map(attribute='name')|list) if card.tag_badges else [] %}
-<div class="card-browser-tile card-tile" data-card-name="{{ card.name }}" data-role="{{ card.role }}">
+<div class="card-browser-tile card-tile" data-card-name="{{ card.name }}" data-role="{{ card.role }}"{% if is_best_match is defined and is_best_match %} data-search-best-match="1"{% endif %}>
   <div class="card-browser-tile-image">
     <img
       id="pool-img-{{ tile_id }}"
@@ -60,7 +60,14 @@
       <button type="button" class="btn btn-sm"
               hx-post="/decks/manual/{{ session_id }}/add"
               hx-vals='{"name": "{{ card.name }}"}'
-              hx-target="#manual-deck-panel" hx-swap="outerHTML">+ Add</button>
+              hx-target="#manual-deck-panel" hx-swap="outerHTML"
+              {% if category == 'search' %}
+              {# The add response only OOB-refreshes the deck panel/pool
+                 categories, not this search list, so without this the
+                 just-added card lingers here until the user re-searches. #}
+              hx-on::after-request="if(event.detail.successful){ this.closest('.card-browser-tile').remove(); }"
+              {% endif %}
+              >+ Add</button>
     </div>
   </div>
 </div>

--- a/code/web/templates/decks/_manual_search_results.html
+++ b/code/web/templates/decks/_manual_search_results.html
@@ -4,8 +4,16 @@
   {% elif not cards %}
   <div class="panel">No matches for "{{ query }}".</div>
   {% else %}
+  {% if best_match %}
+  <div class="muted text-xs" style="margin-bottom:.5rem;">
+    <kbd>Shift</kbd>+<kbd>Enter</kbd> adds <strong>{{ best_match.name }}</strong>
+  </div>
+  {% endif %}
   <div class="card-browser-grid">
     {% for card in cards %}
+      {% set category = 'search' %}
+      {% set card_idx = loop.index0 %}
+      {% set is_best_match = best_match and card.name == best_match.name %}
       {% include "decks/_manual_pool_card.html" %}
     {% endfor %}
   </div>

--- a/code/web/templates/decks/manual_builder.html
+++ b/code/web/templates/decks/manual_builder.html
@@ -31,15 +31,16 @@
     </div>
 
     <form
+      id="manual-search-form"
       hx-get="/decks/manual/{{ session_id }}/search"
       hx-target="#manual-search-results"
       hx-swap="outerHTML"
-      hx-trigger="submit, keyup changed delay:400ms from:input[name='q']"
+      hx-trigger="submit, keyup changed delay:300ms from:input[name='q']"
       style="margin-bottom:.5rem;">
       <input type="text" name="q" placeholder="Search by name or using Scryfall-style flags"
-        title="Plain words match the card name. Also supports Scryfall-style flags: t:/type: (e.g. t:creature), o:/oracle: (rules text), c:/color:, id:/identity:, m:/mana: (e.g. m:2WW), mv:/cmc:, pow:/tou:/loy: (e.g. pow>=4). Each accepts :, =, >, <, >=, <=, != and may be negated with a leading -, e.g. -t:land."
+        title="Plain words match the card name. Also supports Scryfall-style flags: t:/type: (e.g. t:creature), o:/oracle: (rules text), c:/color:, id:/identity:, m:/mana: (e.g. m:2WW), mv:/cmc:, pow:/tou:/loy: (e.g. pow>=4). Each accepts :, =, >, <, >=, <=, != and may be negated with a leading -, e.g. -t:land. Tip: Shift+Enter instantly adds the best-match result."
         style="width:100%; max-width:420px;" />
-      <span class="muted text-sm" style="margin-left:.5rem;">Supports <a href="https://scryfall.com/docs/syntax" target="_blank" rel="noopener">Scryfall-style</a> flags, e.g. <code>t:creature</code>, <code>c:rg</code>, <code>mv&gt;=4</code></span>
+      <span class="muted text-sm" style="margin-left:.5rem;">Supports <a href="https://scryfall.com/docs/syntax" target="_blank" rel="noopener">Scryfall-style</a> flags, e.g. <code>tag:"Graveyard Hate"</code>, <code>c:rg</code>, <code>mv&gt;=4</code></span>
     </form>
     <div id="manual-search-results" style="margin-bottom:1rem;"></div>
 
@@ -118,6 +119,75 @@
   if (pinnedEl && window.ResizeObserver) {
     new ResizeObserver(updateScrollOffset).observe(pinnedEl);
   }
+})();
+(function(){
+  // Adding/removing cards re-renders every category body via hx-swap-oob,
+  // which can shrink a category you've already scrolled into (e.g. a full
+  // row disappearing). Without compensation the browser just reflows in
+  // place, silently pulling the next category up into view - it looks like
+  // an unwanted "jump" even though nothing navigated. Record each swapped
+  // category body's height/viewport-top just before its OOB swap, then once
+  // the whole response has settled, offset scroll by the height delta for
+  // any category whose top had already scrolled past (top < 0) so the
+  // content the user was actually looking at stays put.
+  var pending = {};
+  document.body.addEventListener('htmx:oobBeforeSwap', function(evt){
+    var oldEl = evt.detail && evt.detail.target;
+    if (oldEl && oldEl.id && oldEl.id.indexOf('category-body-') === 0) {
+      var rect = oldEl.getBoundingClientRect();
+      pending[oldEl.id] = {top: rect.top, height: rect.height};
+    }
+  });
+  document.body.addEventListener('htmx:afterSettle', function(){
+    var ids = Object.keys(pending);
+    if (!ids.length) return;
+    var totalDelta = 0;
+    ids.forEach(function(id){
+      var before = pending[id];
+      delete pending[id];
+      var el = document.getElementById(id);
+      if (!el || before.top >= 0) return;
+      totalDelta += el.getBoundingClientRect().height - before.height;
+    });
+    if (totalDelta) {
+      window.scrollBy(0, totalDelta);
+    }
+  });
+})();
+
+(function(){
+  // Shift+Enter in the search box quick-adds the "Shift+Enter adds ..."
+  // candidate shown beneath the results (an exact name match if there is
+  // one, otherwise the top/most-relevant result). Forces a fresh, non-
+  // debounced search first so a still-pending keyup debounce can't cause
+  // a stale result to get added instead of what's currently typed.
+  var form = document.getElementById('manual-search-form');
+  var input = form && form.querySelector('input[name="q"]');
+  var results = document.getElementById('manual-search-results');
+  if (!form || !input || !results) return;
+
+  input.addEventListener('keydown', function(evt){
+    if (evt.key !== 'Enter' || !evt.shiftKey) return;
+    evt.preventDefault();
+    if (!input.value.trim()) return;
+
+    function onSettle(evt2){
+      var target = evt2.target && evt2.target.id === 'manual-search-results'
+        ? evt2.target
+        : (evt2.target && evt2.target.closest && evt2.target.closest('#manual-search-results'));
+      if (!target) return;
+      document.body.removeEventListener('htmx:afterSettle', onSettle);
+      var best = target.querySelector('[data-search-best-match="1"] button.btn-sm');
+      if (best) best.click();
+    }
+    document.body.addEventListener('htmx:afterSettle', onSettle);
+
+    if (window.htmx) {
+      window.htmx.trigger(form, 'submit');
+    } else {
+      form.requestSubmit ? form.requestSubmit() : form.submit();
+    }
+  });
 })();
 </script>
 {% endblock %}

--- a/code/web/templates/owned/index.html
+++ b/code/web/templates/owned/index.html
@@ -75,38 +75,7 @@
         <button type="button" class="btn" onclick="applyFilter()">Search</button>
       </div>
       <div class="filter-row">
-        <span class="muted text-sm">Supports <a href="https://scryfall.com/docs/syntax" target="_blank" rel="noopener">Scryfall-style</a> flags, e.g. <code>t:creature</code>, <code>c:rg</code>, <code>mv&gt;=4</code></span>
-      </div>
-
-      {# Themes multi-select row — exact card browser layout #}
-      <div class="filter-row">
-        <label for="filter-theme-input">Themes (up to 5)</label>
-        <div style="flex:1; max-width:500px;">
-          <div id="selected-themes" style="display:flex; flex-wrap:wrap; gap:0.5rem; margin-bottom:0.5rem; min-height:2rem;">
-            {% if filter_tags %}
-              {% for t in filter_tags %}
-              <span class="theme-chip" data-theme="{{ t }}">
-                {{ t }}
-                <button type="button" onclick="removeTheme('{{ t }}')" style="margin-left:0.5rem; background:none; border:none; color:inherit; cursor:pointer; padding:0; font-weight:bold;">&times;</button>
-              </span>
-              {% endfor %}
-            {% endif %}
-          </div>
-          <div class="autocomplete-container" style="position:relative;">
-            <input
-              type="text"
-              id="filter-theme-input"
-              placeholder="Add theme..."
-              autocomplete="off"
-              role="combobox"
-              aria-autocomplete="list"
-              aria-controls="theme-autocomplete-dropdown"
-              aria-expanded="false"
-              style="width:100%;"
-            />
-            <div id="theme-autocomplete-dropdown" class="autocomplete-dropdown" role="listbox" aria-label="Theme suggestions"></div>
-          </div>
-        </div>
+        <span class="muted text-sm">Supports <a href="https://scryfall.com/docs/syntax" target="_blank" rel="noopener">Scryfall-style</a> flags, e.g. <code>tag:"Graveyard Hate"</code>, <code>c:rg</code>, <code>mv&gt;=4</code></span>
       </div>
 
       {# Filter controls row #}
@@ -211,14 +180,9 @@ function applyFilter() {
   var search = (document.getElementById('search-input') || {value:''}).value || '';
   var sort   = (document.getElementById('filter-sort')  || {value:''}).value || '';
 
-  // Collect theme chips
-  var themeChips = document.querySelectorAll('#selected-themes .theme-chip');
-  var themes = Array.from(themeChips).map(function(c){ return c.dataset.theme; });
-
   var params = new URLSearchParams();
   if (search) params.set('search', search);
   if (sort && sort !== 'name') params.set('sort_by', sort);
-  themes.forEach(function(t){ params.append('filter_tags', t); });
 
   var qs = params.toString();
   window.location.href = '/owned' + (qs ? '?' + qs : '');
@@ -297,101 +261,6 @@ document.addEventListener('keydown', function(e) {
   dropdown.addEventListener('mouseover', function(e) { var item = e.target.closest('.autocomplete-item'); if (item) { var idx = getItems().indexOf(item); if (idx >= 0) selectItem(idx); } });
 })();
 
-// Multi-select theme filter — exact copy of card browser behaviour
-(function() {
-  var themeInput     = document.getElementById('filter-theme-input');
-  var themeDropdown  = document.getElementById('theme-autocomplete-dropdown');
-  var themesContainer = document.getElementById('selected-themes');
-  if (!themeInput || !themeDropdown) return;
-
-  var selectedIndex  = -1;
-  var debounceTimer  = null;
-  var selectedThemes = new Set();
-  var lastEscapeTime = 0;
-
-  // Seed from existing chips (server-rendered on page load)
-  themesContainer.querySelectorAll('.theme-chip').forEach(function(c){ selectedThemes.add(c.dataset.theme); });
-
-  var updateInputState = function() {
-    if (selectedThemes.size >= 5) {
-      themeInput.disabled = true; themeInput.placeholder = 'Maximum 5 themes selected'; themeInput.classList.add('disabled');
-    } else {
-      themeInput.disabled = false; themeInput.placeholder = 'Add theme...'; themeInput.classList.remove('disabled');
-    }
-  };
-  updateInputState();
-
-  var fetchThemes = function() {
-    var q = themeInput.value.trim();
-    if (q.length < 2) { themeDropdown.innerHTML = ''; return; }
-    fetch('/cards/theme-autocomplete?q=' + encodeURIComponent(q))
-      .then(function(r){ return r.text(); })
-      .then(function(html){ themeDropdown.innerHTML = html; })
-      .catch(function(){ themeDropdown.innerHTML = ''; });
-  };
-
-  window.addTheme = function(theme) {
-    if (selectedThemes.size >= 5 || selectedThemes.has(theme)) return;
-    selectedThemes.add(theme);
-    var chip = document.createElement('span');
-    chip.className = 'theme-chip';
-    chip.dataset.theme = theme;
-    chip.innerHTML = theme + ' <button type="button" onclick="removeTheme(\'' + theme.replace(/'/g, "\\'") + '\')" style="margin-left:0.5rem; background:none; border:none; color:inherit; cursor:pointer; padding:0; font-weight:bold;">&times;</button>';
-    themesContainer.appendChild(chip);
-    themeInput.value = '';
-    themeDropdown.innerHTML = '';
-    selectedIndex = -1;
-    updateInputState();
-    if (selectedThemes.size < 5 && window.innerWidth >= 768) requestAnimationFrame(function(){ themeInput.focus(); });
-  };
-
-  window.removeTheme = function(theme) {
-    selectedThemes.delete(theme);
-    var chip = themesContainer.querySelector('.theme-chip[data-theme="' + theme + '"]');
-    if (chip) chip.remove();
-    updateInputState();
-  };
-
-  themeInput.addEventListener('input', function() { clearTimeout(debounceTimer); debounceTimer = setTimeout(fetchThemes, 150); });
-
-  var getItems = function() { return Array.from(themeDropdown.querySelectorAll('.autocomplete-item')); };
-  var selectItem = function(i) { getItems().forEach(function(item, idx){ item.classList.toggle('selected', idx === i); }); selectedIndex = i; };
-  var applyItem  = function() { var items = getItems(); var item = items[selectedIndex]; if (item && item.dataset.value) addTheme(item.dataset.value); };
-
-  new MutationObserver(function() {
-    selectedIndex = -1;
-    getItems().forEach(function(i){ i.classList.remove('selected'); });
-    themeInput.setAttribute('aria-expanded', themeDropdown.children.length > 0 ? 'true' : 'false');
-  }).observe(themeDropdown, { childList: true });
-
-  document.body.addEventListener('click', function(e) {
-    var item = e.target.closest('.autocomplete-item');
-    if (item && item.dataset.value && themeDropdown.contains(item)) { e.preventDefault(); addTheme(item.dataset.value); }
-  });
-  document.addEventListener('click', function(e) { if (!e.target.closest('#filter-theme-input') && !e.target.closest('#theme-autocomplete-dropdown')) { themeDropdown.innerHTML = ''; selectedIndex = -1; } });
-
-  themeInput.addEventListener('keydown', function(e) {
-    var items = getItems();
-    var hasItems = items.length > 0;
-    if (e.key === 'Escape') {
-      var now = Date.now();
-      if (hasItems) { themeDropdown.innerHTML = ''; selectedIndex = -1; lastEscapeTime = now; e.preventDefault(); }
-      else if (now - lastEscapeTime < 500) { e.preventDefault(); window.location.href = '/owned'; }
-      else { lastEscapeTime = now; e.preventDefault(); }
-    } else if (e.key === 'ArrowDown' && hasItems) { e.preventDefault(); selectItem(selectedIndex < items.length - 1 ? selectedIndex + 1 : 0); }
-    else if (e.key === 'ArrowUp'   && hasItems) { e.preventDefault(); selectItem(selectedIndex > 0 ? selectedIndex - 1 : items.length - 1); }
-    else if (e.key === 'Enter') {
-      e.preventDefault();
-      if (e.shiftKey) {
-        if (hasItems) { if (selectedIndex >= 0) applyItem(); else { selectItem(0); applyItem(); } setTimeout(applyFilter, 50); }
-        else applyFilter();
-      } else if (selectedIndex >= 0 && hasItems) applyItem();
-      else if (hasItems) { selectItem(0); applyItem(); }
-    }
-  });
-  themeDropdown.addEventListener('mouseover', function(e) { var item = e.target.closest('.autocomplete-item'); if (item) { var idx = getItems().indexOf(item); if (idx >= 0) selectItem(idx); } });
-})();
-
 // Bulk action + selection
 (function(){
   var grid = document.getElementById('owned-grid');
@@ -446,8 +315,6 @@ document.addEventListener('keydown', function(e) {
   .autocomplete-item:hover, .autocomplete-item.selected { background: var(--bg); }
   .autocomplete-item.selected { border-left: 3px solid var(--ring); padding-left: calc(.75rem - 3px); }
   .autocomplete-empty { padding: .75rem; text-align: center; color: var(--muted); font-size: .85rem; }
-  /* Theme chips */
-  .theme-chip { display:inline-flex; align-items:center; background:var(--accent,.38bdf8); color:#fff; border-radius:16px; padding:3px 10px; font-size:.85rem; gap:.25rem; }
   /* Mana dots */
   .mana{ display:inline-block; width:14px; height:14px; border-radius:50%; box-sizing:border-box; }
   .mana-W{ background:#f9fafb; border:1px solid #d1d5db; }
@@ -477,7 +344,6 @@ document.addEventListener('keydown', function(e) {
     var n = 0;
     var si = document.getElementById('search-input');
     if (si && si.value) n++;
-    n += document.querySelectorAll('#selected-themes .theme-chip').length;
     el.textContent = n > 0 ? ' (' + n + ' active)' : '';
   }
   window.toggleFilterPanel = function() {


### PR DESCRIPTION
## Summary
- Fix negated tag: exclusion bug across card browser, manual deck builder, owned library, and the public API (a negated tag flag combined with another tag filter was treated as required instead of excluded)
- Add fuzzy tag/theme name autocomplete to the card browser search box (tag:/theme: flag values); add matching \GET /api/v1/themes/autocomplete\ public API endpoint (also powers the mobile app)
- Remove the separate Themes filter bar from Card Browser and Owned Library (redundant with tag:/theme: search flags)
- Manual Deck Builder: Shift+Enter adds the best-guess search match; faster debounce; fixed pool-jump, printing-selection cross-talk, mana pip/source chart, and add-from-search-removal bugs
- Tagging: removed duplicate bending short-form tags (e.g. Airbend alongside Airbending)

## Testing
- \pytest -q code/tests/test_manual_builder.py code/tests/test_api_v1_cards.py code/tests/test_api_v1_themes.py code/tests/test_web_tag_endpoints.py\ (all passing)
- Manually verified Card Browser and Owned Library pages in the running dev container after removing the Themes filter bar

See CHANGELOG.md / RELEASE_NOTES_TEMPLATE.md Unreleased sections for full details.