### PR TITLE
feat: add Rulebreaker Commanders

### DIFF
--- a/.github/ISSUE_TEMPLATE/rulebreaker-card-report.md
+++ b/.github/ISSUE_TEMPLATE/rulebreaker-card-report.md
@@ -1,0 +1,55 @@
+---
+name: Rulebreaker Card Report
+about: Report a new or unrecognized "Rulebreaker" commander (a card that grants a
+  unique, named deckbuilding rules exception) so its rule can be added to the registry.
+title: 'Rulebreaker: '
+labels: enhancement, rulebreaker
+assignees: ''
+
+---
+
+### Card Name
+_Exact printed name of the card._
+
+### Set / Collector Number
+_If known (e.g. "MBC #123"). Leave blank if unreleased/unknown._
+
+### Detected By
+- [ ] Automated tagging pass (flagged during `run_tagging()` as an unrecognized candidate)
+- [ ] Manual report (found while browsing spoilers/previews)
+
+### Oracle Text
+_Paste the card's full oracle text verbatim, including the deckbuilding-rule-exception line._
+
+```
+(paste oracle text here)
+```
+
+### Suggested Rule Type
+_Which existing `rule_type` (see `RULEBREAKER_ARCHETYPES` in `code/deck_builder/builder_constants.py`) does this match, if any?_
+
+- [ ] `any_land` — allows any land regardless of color identity
+- [ ] `type_any_color` — allows a card type/subtype of any color identity
+- [ ] `type_cmc_any_color` — allows a card type/subtype + mana value threshold of any color identity
+- [ ] `instant_sorcery_extra_color` — allows Instant/Sorcery of one user-chosen extra color
+- [ ] `no_max_deck_size` — removes the maximum deck size cap
+- [ ] Other / new pattern not covered by the above (describe below)
+
+### Proposed Registry Entry
+_Best-effort draft entry for `RULEBREAKER_ARCHETYPES`, even if incomplete._
+
+```python
+'card_name_slug': {
+    'id': 'card_name_slug',
+    'name': 'Card Name',
+    'color_identity': [],
+    'rule_type': '',
+    'params': {},
+    'basic_lands_scope': 'any',  # 'any' | 'identity_plus_extra_color' | 'strict'
+    'no_max_deck_size': False,
+    'requires_user_input': False,
+},
+```
+
+### Additional Notes
+_Anything else we should know? Links to spoilers/previews are welcome._

--- a/.github/workflows/build-similarity-cache.yml
+++ b/.github/workflows/build-similarity-cache.yml
@@ -1,5 +1,9 @@
 name: Build Similarity Cache
 
+permissions:
+  contents: write
+  issues: write
+
 # Manual trigger + weekly schedule + callable from other workflows
 on:
   workflow_dispatch:
@@ -103,6 +107,61 @@ jobs:
             echo "ERROR: Tagging completion flag not found"
             exit 1
           fi
+      
+      # File an issue for any unregistered Rulebreaker
+      # candidate found during tagging. Best-effort only; never fails the job.
+      - name: File issues for unrecognized Rulebreaker candidates
+        if: steps.check_cache.outputs.needs_build == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set +e
+          rm -rf _rb_candidates && mkdir -p _rb_candidates
+          python -c "
+          import json
+          from pathlib import Path
+
+          path = Path('logs/rulebreaker_candidates.json')
+          if not path.exists():
+              print('No rulebreaker_candidates.json found, skipping.')
+              raise SystemExit(0)
+
+          candidates = json.loads(path.read_text(encoding='utf-8'))
+          if not candidates:
+              print('No unrecognized Rulebreaker candidates found.')
+              raise SystemExit(0)
+
+          from code.tagging.rulebreaker_report import build_candidate_issue_body
+
+          out_dir = Path('_rb_candidates')
+          manifest_lines = []
+          for i, c in enumerate(candidates):
+              name = c.get('name', '')
+              title = f'Rulebreaker: {name}'
+              body = build_candidate_issue_body(c)
+              (out_dir / f'{i}.md').write_text(body, encoding='utf-8')
+              manifest_lines.append(f'{i}\t{title}')
+              print(f'::notice::Candidate found: {name}')
+          (out_dir / 'manifest.tsv').write_text('\n'.join(manifest_lines), encoding='utf-8')
+          "
+
+          # One issue per candidate, deduped against existing open/closed issues
+          # by exact title search (kept in shell so gh auth/search stays simple
+          # and any single failure here is non-fatal to the overall job).
+          if [ -f _rb_candidates/manifest.tsv ]; then
+            while IFS=$'\t' read -r idx title; do
+              [ -z "$title" ] && continue
+              existing=$(gh issue list --search "\"$title\" in:title" --state all --json number --jq '.[0].number' 2>/dev/null)
+              if [ -n "$existing" ]; then
+                echo "Issue already exists for '$title' (#$existing), skipping."
+                continue
+              fi
+              gh issue create --title "$title" --body-file "_rb_candidates/${idx}.md" --label enhancement,rulebreaker \
+                || echo "WARNING: failed to create issue for '$title' (non-fatal)"
+            done < _rb_candidates/manifest.tsv
+          fi
+          rm -rf _rb_candidates
+          set -e
       
       - name: Refresh price data and write to parquet
         if: steps.check_cache.outputs.needs_build == 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,24 @@ This format follows Keep a Changelog principles and aims for Semantic Versioning
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- Rulebreaker Commanders: added support for 8 commanders whose oracle text bends normal deckbuilding rules, each relaxing the color-identity and/or deck-size rules for a specific card type or condition:
+  - Grizzlegom, Hurloon Hero: any basic land type, regardless of color identity, split evenly across all five basics.
+  - Maular, the Next Evolution: creatures with mana value 7 or greater can be any color.
+  - Seluma, Light of Aysen: Angels can be any color.
+  - The Everforger: Artifact Creatures and Equipment can be any color.
+  - The Unluckiest Planeswalker: Auras can be any color.
+  - Tolabow, Loch Rascal: Instants and Sorceries can be your color identity plus one additional color of your choice.
+  - Valko Indorian: cards with the Phyrexian subtype can be any color.
+  - Whtz, the Bibliophile: no maximum deck size (a 100-card minimum still applies); the Ideal Counts sliders in "Build a New Deck" scale their recommended defaults live as you change the deck size, and stay fully adjustable afterward instead of being silently re-scaled behind the scenes at build time.
+- Manual Deck Builder: the role health bar (Lands/Ramp/Removal/etc.) now shows targets based on the deck's actual chosen ideal counts instead of the fixed 100-card defaults, so a larger Whtz deck shows an accurate land target instead of a stale "X/35".
+- Public API: commander detail (`GET /api/v1/commanders/{name}`) now reports Rulebreaker Commander metadata, and `POST /api/v1/builds` accepts the matching optional `rulebreaker_extra_color`/`rulebreaker_target_deck_size` fields; the mobile app's build wizard now shows the same optional color picker and target-deck-size field the web UI does when a Rulebreaker commander is selected.
+- Setup/Tagging: a local, offline check now flags any Commander-legal card that looks like it may carry the Rulebreaker mechanic but isn't yet in the registry (e.g. a newly spoiled/printed card), surfacing a review banner with a ready-to-copy issue body on the Setup/Tagging page; the weekly/manual "Build Similarity Cache" GitHub Actions workflow additionally auto-files (and dedupes) an issue for any candidate it finds.
 
 ### Changed
-_No unreleased changes yet_
+- Build a New Deck: the default power bracket is now Bracket 4 (Optimized) instead of Bracket 3 (Upgraded).
 
 ### Fixed
-_No unreleased changes yet_
+- Setup: the card printing image picker's metadata index could silently go missing on a fresh install or after a disk cleanup, causing every card image to fall back to a live Scryfall request instead of using already-downloaded local images. Setup now automatically restores it (downloading a prebuilt copy, or rebuilding it locally if that's unavailable).
 
 ### Removed
 _No unreleased changes yet_

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -2,13 +2,24 @@
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- Rulebreaker Commanders: added support for 8 commanders whose oracle text bends normal deckbuilding rules:
+  - Grizzlegom, Hurloon Hero: any basic land type, regardless of color identity, split evenly across all five basics.
+  - Maular, the Next Evolution: creatures with mana value 7 or greater can be any color.
+  - Seluma, Light of Aysen: Angels can be any color.
+  - The Everforger: Artifact Creatures and Equipment can be any color.
+  - The Unluckiest Planeswalker: Auras can be any color.
+  - Tolabow, Loch Rascal: Instants and Sorceries can be your color identity plus one additional color of your choice.
+  - Valko Indorian: cards with the Phyrexian subtype can be any color.
+  - Whtz, the Bibliophile: no maximum deck size (a 100-card minimum still applies); the Ideal Counts sliders in "Build a New Deck" scale their recommended defaults live as you change the deck size, and stay fully adjustable afterward instead of being silently re-scaled behind the scenes at build time.
+- The Manual Deck Builder's role health bar (Lands/Ramp/Removal/etc.) now shows targets based on the deck's actual chosen ideal counts, so a larger Whtz deck shows an accurate land target instead of a stale "X/35".
+- The mobile app's build wizard now shows the same optional color picker and target-deck-size field the web UI does when a Rulebreaker commander is selected.
+- Setup/Tagging now flags any Commander-legal card that looks like it may carry the Rulebreaker mechanic but isn't yet recognized (e.g. a newly spoiled card), with a review banner and ready-to-copy issue report on the Setup/Tagging page.
 
 ### Changed
-_No unreleased changes yet_
+- The "Build a New Deck" default power bracket is now Bracket 4 (Optimized) instead of Bracket 3 (Upgraded).
 
 ### Fixed
-_No unreleased changes yet_
+- Fixed an issue where card images could fall back to loading from Scryfall instead of your local cache after a fresh install.
 
 ### Removed
 _No unreleased changes yet_

--- a/code/deck_builder/builder.py
+++ b/code/deck_builder/builder.py
@@ -277,9 +277,11 @@ class DeckBuilder(
                             pass
                         # If owned-only build is incomplete, generate recommendations
                         try:
+                            from deck_builder import builder_utils as bu
+                            target_size = bu.effective_deck_size(self)
                             total_cards = sum(int(v.get('Count', 1)) for v in self.card_library.values())
-                            if self.use_owned_only and total_cards < 100:
-                                missing = 100 - total_cards
+                            if self.use_owned_only and total_cards < target_size:
+                                missing = target_size - total_cards
                                 rec_limit = int(math.ceil(1.5 * float(missing)))
                                 self._generate_recommendations(base_stem=base, limit=rec_limit)
                         except Exception:
@@ -296,9 +298,11 @@ class DeckBuilder(
             # If owned-only and deck not complete, print a note
             try:
                 if self.use_owned_only:
+                    from deck_builder import builder_utils as bu
+                    target_size = bu.effective_deck_size(self)
                     total_cards = sum(int(v.get('Count', 1)) for v in self.card_library.values())
-                    if total_cards < 100:
-                        self.output_func(f"Note: deck is incomplete ({total_cards}/100). Not enough owned cards to fill the deck.")
+                    if total_cards < target_size:
+                        self.output_func(f"Note: deck is incomplete ({total_cards}/{target_size}). Not enough owned cards to fill the deck.")
             except Exception:
                 pass
             end_ts = datetime.datetime.now()
@@ -446,6 +450,11 @@ class DeckBuilder(
     # Diagnostics storage for include/exclude processing
     include_exclude_diagnostics: Optional[Dict[str, Any]] = None
 
+    # Rulebreaker commanders (Roadmap 35)
+    active_rulebreakers: List[Dict[str, Any]] = field(default_factory=list)
+    rulebreaker_extra_color: Optional[str] = None  # Tolabow's chosen extra color (WUBRG letter)
+    rulebreaker_target_deck_size: Optional[int] = None  # Whtz's chosen deck size (>=100)
+
     # Supplemental user themes (M4: Config & Headless Support)
     user_theme_requested: List[str] = field(default_factory=list)
     user_theme_resolved: List[str] = field(default_factory=list)
@@ -563,14 +572,16 @@ class DeckBuilder(
 
         self.output_func(f"\nLand Backfill: {shortfall} slot(s) below target; adding basics to reach {land_target}.")
         added = 0
+        from deck_builder import builder_utils as bu
+        target_deck_size = bu.effective_deck_size(self)
         for i in range(shortfall):
             basic = usable_basics[i % len(usable_basics)]
             total_cards = sum(int(e.get('Count', 1)) for e in self.card_library.values())
-            if total_cards < 100:
+            if total_cards < target_deck_size:
                 self.add_card(basic, card_type='Land', role='basic', sub_role='basic', added_by='lands_backfill')
                 added += 1
             else:
-                # Deck is at the 100-card limit.  Swap: remove the lowest-priority non-land card
+                # Deck is at the deck-size limit.  Swap: remove the lowest-priority non-land card
                 # (the last-inserted unlocked non-land in the library) then add the basic.
                 removed_name: Optional[str] = None
                 for name in reversed(list(self.card_library.keys())):
@@ -1268,6 +1279,14 @@ class DeckBuilder(
                 self.commander_dict["Colors"] = list(self.color_identity)
             except Exception:
                 pass
+
+        # Rulebreaker Commanders (Roadmap 35): detect after color identity (incl. any
+        # partner/background union) is finalized, per Contract §3.
+        try:
+            from deck_builder import builder_utils as bu
+            self.active_rulebreakers = bu.detect_active_rulebreakers(self)
+        except Exception:
+            self.active_rulebreakers = []
         return full, load_files
 
     def setup_dataframes(self) -> pd.DataFrame:
@@ -1309,9 +1328,37 @@ class DeckBuilder(
                     return True
                 # Card is legal if its colors are a subset of commander colors
                 return card_colors.issubset(self.color_identity)
-            
+
+            # Rulebreaker Commanders (Roadmap 35): OR-branch, non-basic-land card pool
+            # exception. Only pay the row-wise cost when a Rulebreaker is active.
+            active_rulebreakers = getattr(self, 'active_rulebreakers', None) or []
+
             if 'colorIdentity' in all_cards_df.columns:
-                mask = all_cards_df['colorIdentity'].apply(card_matches_identity)
+                if active_rulebreakers:
+                    from deck_builder.rulebreaker_rules import card_pool_exception
+
+                    extra_color = getattr(self, 'rulebreaker_extra_color', None)
+                    # Rulebreaker Commanders (Roadmap 35): when basic_lands_scope
+                    # is 'any'/'any_land', all 5 basics (+ Wastes/snow variants)
+                    # must stay in the identity-filtered pool too, not just be
+                    # addable later - otherwise add_card()'s type/mana enrichment
+                    # lookup can't find off-identity basics and they end up with
+                    # blank/incorrect Card Type metadata (e.g. missing "Basic
+                    # Land - Mountain" for a blue commander's off-color basic).
+                    basic_names: set = set()
+                    if bu.resolve_basic_lands_scope(self) in ('any', 'any_land'):
+                        basic_names = bu.basic_land_names()
+
+                    def card_matches_identity_row(row):
+                        if card_matches_identity(row.get('colorIdentity')):
+                            return True
+                        if basic_names and row.get('name') in basic_names:
+                            return True
+                        return card_pool_exception(row, active_rulebreakers, extra_color)
+
+                    mask = all_cards_df.apply(card_matches_identity_row, axis=1)
+                else:
+                    mask = all_cards_df['colorIdentity'].apply(card_matches_identity)
                 combined = all_cards_df[mask].copy()
                 logger.info(f"M4 COLOR_FILTER: Filtered {len(all_cards_df)} cards to {len(combined)} cards for identity {sorted(self.color_identity)}")
             else:
@@ -2320,6 +2367,16 @@ class DeckBuilder(
         # Smart land analysis — runs after defaults are seeded so env overrides still win
         self.run_land_analysis()
         self._clamp_creatures_max_to_land_budget()
+
+        # Rulebreaker Commanders (Roadmap 35, Milestone 4): scale ideal counts up
+        # when Whtz's chosen deck size exceeds the 100-card baseline.
+        try:
+            from deck_builder import builder_utils as bu
+            target_size = bu.effective_deck_size(self)
+            if target_size > 100:
+                self.ideal_counts = bu.scale_ideal_counts_for_deck_size(self.ideal_counts, target_size)
+        except Exception:
+            pass
 
         # Basic validation adjustments
         # Ensure basic_lands <= lands

--- a/code/deck_builder/builder_constants.py
+++ b/code/deck_builder/builder_constants.py
@@ -187,7 +187,7 @@ DEFAULT_RAMP_COUNT: Final[int] = 8  # Default number of ramp pieces
 DEFAULT_LAND_COUNT: Final[int] = 35  # Default total land count
 DEFAULT_BASIC_LAND_COUNT: Final[int] = 15  # Default minimum basic lands
 
-# Smart land analysis thresholds (Roadmap 14)
+# Smart land analysis thresholds
 CURVE_FAST_THRESHOLD: Final[float] = 3.0   # Commander CMC below this → fast deck
 CURVE_SLOW_THRESHOLD: Final[float] = 4.0   # Commander CMC above this → slow deck
 LAND_COUNT_FAST: Final[int] = 33            # Land target for fast decks
@@ -841,6 +841,123 @@ MULTI_COPY_ARCHETYPES: Final[dict[str, dict[str, Any]]] = {
 EXCLUSIVE_GROUPS: Final[dict[str, list[str]]] = {
     'rats': ['relentless_rats', 'rat_colony']
 }
+
+# ==============================================================================
+# Rulebreaker Commanders
+# ==============================================================================
+# Small, hand-authored registry of named commander-tied rules exceptions,
+# structurally parallel to MULTI_COPY_ARCHETYPES above. Keyed by a stable
+# lowercase id; 'name' is the exact printed card name used for detection
+# (see detect_active_rulebreakers() in builder_utils.py).
+#
+# rule_type values (see code/deck_builder/rulebreaker_rules.py for predicates):
+#   - 'any_land': any land card is legal regardless of color identity.
+#   - 'type_any_color': cards matching params['types'] are legal in any color
+#     identity (matched against the card's type line).
+#   - 'type_cmc_any_color': like type_any_color, plus a mana-value floor
+#     (params['mv_min']).
+#   - 'instant_sorcery_extra_color': Instant/Sorcery cards may include one
+#     additional user-chosen color beyond the commander's own identity.
+#   - 'no_max_deck_size': the deck's normal 100-card maximum is lifted (a
+#     100-card minimum still applies).
+#
+# basic_lands_scope values: 'any_land' (any land, superset), 'any' (all 5
+# basics + Snow variants, regardless of identity), 'strict' (no relaxation).
+RULEBREAKER_ARCHETYPES: Final[dict[str, dict[str, Any]]] = {
+    'grizzlegom_hurloon_hero': {
+        'id': 'grizzlegom_hurloon_hero',
+        'name': 'Grizzlegom, Hurloon Hero',
+        'color_identity': ['R', 'G'],
+        'rule_type': 'any_land',
+        'params': {},
+        'basic_lands_scope': 'any_land',
+        'no_max_deck_size': False,
+        'requires_user_input': False,
+    },
+    'maular_next_evolution': {
+        'id': 'maular_next_evolution',
+        'name': 'Maular, the Next Evolution',
+        'color_identity': ['G'],
+        'rule_type': 'type_cmc_any_color',
+        'params': {'types': ['Creature'], 'mv_min': 7},
+        'basic_lands_scope': 'any',
+        'no_max_deck_size': False,
+        'requires_user_input': False,
+    },
+    'seluma_light_of_aysen': {
+        'id': 'seluma_light_of_aysen',
+        'name': 'Seluma, Light of Aysen',
+        'color_identity': ['W'],
+        'rule_type': 'type_any_color',
+        'params': {'types': ['Angel']},
+        'basic_lands_scope': 'any',
+        'no_max_deck_size': False,
+        'requires_user_input': False,
+    },
+    'the_everforger': {
+        'id': 'the_everforger',
+        'name': 'The Everforger',
+        'color_identity': [],
+        'rule_type': 'type_any_color',
+        'params': {'types': ['Artifact Creature', 'Equipment']},
+        'basic_lands_scope': 'any',
+        'no_max_deck_size': False,
+        'requires_user_input': False,
+    },
+    'the_unluckiest_planeswalker': {
+        'id': 'the_unluckiest_planeswalker',
+        'name': 'The Unluckiest Planeswalker',
+        'color_identity': ['R'],
+        'rule_type': 'type_any_color',
+        'params': {'types': ['Aura']},
+        'basic_lands_scope': 'any',
+        'no_max_deck_size': False,
+        'requires_user_input': False,
+    },
+    'tolabow_loch_rascal': {
+        'id': 'tolabow_loch_rascal',
+        'name': 'Tolabow, Loch Rascal',
+        'color_identity': ['U'],
+        'rule_type': 'instant_sorcery_extra_color',
+        'params': {'types': ['Instant', 'Sorcery'], 'extra_color_count': 1},
+        'basic_lands_scope': 'any',   # unconditional "any basic land cards", confirmed by real oracle text
+        'no_max_deck_size': False,
+        'requires_user_input': False,   # extra color is optional ("can include one color of your choice")
+        'random_mode_excluded': True,   # opted out of surprise/random commander pools; no one to pick the (optional) extra color during an automated pick
+    },
+    'valko_indorian': {
+        'id': 'valko_indorian',
+        'name': 'Valko Indorian',
+        'color_identity': ['B'],
+        'rule_type': 'type_any_color',
+        'params': {'types': ['Phyrexian']},   # matched against type line subtype
+        'basic_lands_scope': 'any',
+        'no_max_deck_size': False,
+        'requires_user_input': False,
+    },
+    'whtz_the_bibliophile': {
+        'id': 'whtz_the_bibliophile',
+        'name': 'Whtz, the Bibliophile',
+        'color_identity': ['U', 'W'],
+        'rule_type': 'no_max_deck_size',
+        'params': {},
+        'basic_lands_scope': 'strict',   # normal color identity rules, no relaxation
+        'no_max_deck_size': True,
+        'requires_user_input': False,
+    },
+}
+
+# Lookup of Rulebreaker archetypes keyed by exact card name (case-insensitive
+# lookups should casefold before checking this dict).
+RULEBREAKER_NAMES: Final[dict[str, str]] = {
+    meta['name']: aid for aid, meta in RULEBREAKER_ARCHETYPES.items()
+}
+
+# Milestone 4: deck-size scaling premium (Whtz, the Bibliophile). A smooth
+# logarithmic land-percentage premium applied once rulebreaker_target_deck_size
+# exceeds the 100-card baseline; see builder_utils.scale_ideal_counts_for_deck_size.
+DECK_SIZE_LAND_PREMIUM_K: Final[float] = 0.12
+DECK_SIZE_LAND_PREMIUM_CAP: Final[float] = 0.48
 
 # Popular and iconic cards for fuzzy matching prioritization
 POPULAR_CARDS: Final[set[str]] = {

--- a/code/deck_builder/builder_utils.py
+++ b/code/deck_builder/builder_utils.py
@@ -622,7 +622,11 @@ def read_foil_overrides_from_csv(csv_path: Path) -> Dict[str, bool]:
 	return overrides
 
 
-def compute_color_source_matrix(card_library: Dict[str, dict], full_df) -> Dict[str, Dict[str, int]]:
+def compute_color_source_matrix(
+	card_library: Dict[str, dict],
+	full_df,
+	color_identity: Optional[Iterable[str]] = None,
+) -> Dict[str, Dict[str, int]]:
 	"""Build a matrix mapping card name -> {color: 0/1} indicating if that card
 	can (reliably) produce each color of mana on the battlefield.
 
@@ -630,6 +634,10 @@ def compute_color_source_matrix(card_library: Dict[str, dict], full_df) -> Dict[
 	  - Includes lands and non-lands (artifacts/creatures/enchantments/planeswalkers) that produce mana.
 	  - Excludes instants/sorceries (rituals) by design; this is a "source" count, not ramp burst.
 	  - Any-color effects set W/U/B/R/G (not C). Colorless '{C}' is tracked separately.
+	  - "Add one mana of any color in your commander's color identity" (Command Tower,
+	    Arcane Signet, etc.) is restricted to ``color_identity`` rather than all 5 colors:
+	    a Rulebreaker's expanded basic-land pool (e.g. Grizzlegom's off-color basics) doesn't
+	    change what these cards can actually tap for.
 	  - For lands, we also infer from basic land types in the type line. For non-lands, we rely on text.
 	  - Fallback name mapping applies only to exact basic lands (incl. Snow-Covered) and Wastes.
 
@@ -639,7 +647,11 @@ def compute_color_source_matrix(card_library: Dict[str, dict], full_df) -> Dict[
 		Current deck card entries (expects 'Card Type' and 'Count').
 	full_df : pandas.DataFrame | None
 		Full card dataset used for type/text lookups. May be None/empty.
+	color_identity : Iterable[str] | None
+		Commander's true printed color identity, used to cap "any color in your
+		commander's color identity" effects. Defaults to all 5 colors if omitted.
 	"""
+	identity_colors = [c for c in COLOR_LETTERS if c in (color_identity or COLOR_LETTERS)] or list(COLOR_LETTERS)
 	matrix: Dict[str, Dict[str, int]] = {}
 	lookup = {}
 	if full_df is not None and not getattr(full_df, 'empty', True) and 'name' in full_df.columns:
@@ -727,7 +739,19 @@ def compute_color_source_matrix(card_library: Dict[str, dict], full_df) -> Dict[
 			if 'forest' in tline:
 				colors['G'] = 1
 		# Text-based inference for both lands and non-lands
+		# Match the specific "any color in your commander('s/s') color identity"
+		# phrase (Command Tower, Arcane Signet) rather than loosely checking for
+		# 'add'/'commander'/'color identity' anywhere in the text -- War Room has
+		# an unrelated draw ability that mentions "commanders' color identity"
+		# alongside its separate "Add {C}" mana ability, which would otherwise
+		# false-positive as an any-color source.
 		if (
+			'any color in your commander' in tf or
+			'any colour in your commander' in tf
+		):
+			for k in identity_colors:
+				colors[k] = 1
+		elif (
 			'add one mana of any color' in tf or
 			'add one mana of any colour' in tf or
 			('add' in tf and ('mana of any color' in tf or 'mana of any one color' in tf or 'any color of mana' in tf))
@@ -885,6 +909,50 @@ def compute_pip_density(card_library: Dict[str, dict], color_identity: Iterable[
 		if c not in pip_colors_identity:
 			result[c] = {'single': 0, 'double': 0, 'triple': 0, 'phyrexian': 0}
 	return result
+
+
+def rulebreaker_pip_identity(
+	card_library: Dict[str, dict],
+	color_identity: Iterable[str],
+	active_rulebreakers: Optional[List[dict]] = None,
+	extra_color: Optional[str] = None,
+) -> List[str]:
+	"""Expand ``color_identity`` for pip/mana-source *display* purposes when a
+	Rulebreaker Commander is active, so legally-included off-identity cards
+	aren't zeroed out of the Pips/Sources charts by ``compute_pip_density``.
+
+	Tolabow pins a single known ``rulebreaker_extra_color``, but the
+	type-based exceptions (Seluma's Angels, Grizzlegom's basics, Maular's
+	7+ MV creatures, etc.) allow *any* color for matching cards, so there's
+	no single color to add ahead of time -- instead, scan the actual cards
+	in ``card_library`` for off-identity mana symbols. Only does this scan
+	when a Rulebreaker is active; otherwise returns the identity unchanged.
+	"""
+	base = [c for c in COLOR_LETTERS if c in (color_identity or [])]
+	identity = set(base)
+	if extra_color:
+		extra_color = extra_color.strip().upper()
+		if extra_color in COLOR_LETTERS:
+			identity.add(extra_color)
+	if not active_rulebreakers:
+		return [c for c in COLOR_LETTERS if c in identity]
+	for entry in card_library.values():
+		if 'land' in str(entry.get('Card Type', '')).lower():
+			continue
+		mana_cost = entry.get('Mana Cost') or entry.get('mana_cost') or ''
+		if not isinstance(mana_cost, str):
+			continue
+		for match in re.findall(r'\{([^}]+)\}', mana_cost):
+			sym = match.upper()
+			if len(sym) == 1 and sym in COLOR_LETTERS:
+				identity.add(sym)
+			elif '/' in sym:
+				for p in sym.split('/'):
+					if p in COLOR_LETTERS:
+						identity.add(p)
+			elif sym.endswith('P') and len(sym) == 2 and sym[0] in COLOR_LETTERS:
+				identity.add(sym[0])
+	return [c for c in COLOR_LETTERS if c in identity]
 
 
 def analyze_curve(commander_mana_value: float, color_count: int) -> Dict[str, Any]:
@@ -1529,6 +1597,148 @@ def detect_viable_multi_copy_archetypes(builder) -> list[dict]:
 	return kept
 
 
+def detect_active_rulebreakers(builder) -> list[dict]:
+	"""Return the RULEBREAKER_ARCHETYPES entries active for this builder's commander(s).
+
+	Checks the primary commander name (and, if present, a partner/background
+	secondary commander name) against RULEBREAKER_ARCHETYPES by exact,
+	case-insensitive name match. Returns 0, 1, or (rarely) 2 entries \u2014 2 only
+	if both halves of a partner pair happen to be Rulebreaker commanders.
+
+	Note: full combined-commander wiring (running after the color identity
+	union is finalized, scanning the secondary commander via
+	combined_commander.py) is completed in Milestone 3; this function is
+	written to accept either shape so that wiring is additive.
+
+	Never raises; returns [] on missing/malformed data.
+	"""
+	try:
+		from . import builder_constants as bc
+	except Exception:
+		return []
+
+	names: list[str] = []
+	try:
+		primary = getattr(builder, 'commander_name', None)
+		if primary:
+			names.append(str(primary))
+	except Exception:
+		pass
+	# Best-effort secondary/partner commander lookup; several shapes are
+	# tolerated since full wiring lands in Milestone 3.
+	for attr in ('secondary_commander_name', 'secondary_commander'):
+		try:
+			secondary = getattr(builder, attr, None)
+			if secondary:
+				names.append(str(secondary))
+				break
+		except Exception:
+			continue
+	try:
+		combined = getattr(builder, 'combined_commander', None)
+		secondary_name = getattr(combined, 'secondary_name', None) if combined is not None else None
+		if secondary_name:
+			names.append(str(secondary_name))
+	except Exception:
+		pass
+
+	archetypes = getattr(bc, 'RULEBREAKER_ARCHETYPES', {}) or {}
+	name_lookup = {meta.get('name', '').casefold(): meta for meta in archetypes.values()}
+
+	out: list[dict] = []
+	seen_ids: set[str] = set()
+	for name in names:
+		meta = name_lookup.get(name.strip().casefold())
+		if meta and meta.get('id') not in seen_ids:
+			out.append(dict(meta))
+			seen_ids.add(meta.get('id'))
+	return out
+
+
+_BASIC_LANDS_SCOPE_RANK = {'any_land': 2, 'any': 1, 'strict': 0}
+
+
+def resolve_basic_lands_scope(builder) -> str:
+	"""Return the least-restrictive basic_lands_scope among active Rulebreakers.
+
+	'any_land' beats 'any' beats 'strict' (Contract §3). Returns 'strict' (no
+	relaxation) when no Rulebreaker is active. Never raises.
+	"""
+	active = getattr(builder, 'active_rulebreakers', None) or []
+	best = 'strict'
+	for meta in active:
+		scope = meta.get('basic_lands_scope', 'strict')
+		if _BASIC_LANDS_SCOPE_RANK.get(scope, 0) > _BASIC_LANDS_SCOPE_RANK.get(best, 0):
+			best = scope
+	return best
+
+
+def rulebreaker_no_max_deck_size(builder) -> bool:
+	"""Return True if any active Rulebreaker lifts the 100-card maximum (Whtz)."""
+	active = getattr(builder, 'active_rulebreakers', None) or []
+	return any(meta.get('no_max_deck_size') for meta in active)
+
+
+def effective_deck_size(builder) -> int:
+	"""Return the deck-size target the builder should aim for/clamp to.
+
+	100 unless a no_max_deck_size Rulebreaker (Whtz) is active *and* a valid
+	rulebreaker_target_deck_size (>=100) has been set, in which case that
+	target is used. Never raises; always returns at least 100.
+	"""
+	if not rulebreaker_no_max_deck_size(builder):
+		return 100
+	target = getattr(builder, 'rulebreaker_target_deck_size', None)
+	try:
+		target = int(target) if target is not None else 100
+	except (TypeError, ValueError):
+		target = 100
+	return target if target >= 100 else 100
+
+
+_SCALABLE_IDEAL_COUNT_KEYS = (
+	'lands', 'basic_lands', 'creatures_max', 'creatures_min', 'creatures',
+	'on_theme_creatures', 'ramp', 'removal', 'wipes', 'card_advantage', 'protection',
+)
+
+
+def scale_ideal_counts_for_deck_size(ideal_counts: dict, target_size: int) -> dict:
+	"""Scale 100-card-baseline ideal_counts up for a larger rulebreaker_target_deck_size.
+
+	Applies a smooth logarithmic land-percentage premium:
+	    ratio = target_size / 100
+	    premium = 1 + DECK_SIZE_LAND_PREMIUM_K * ln(ratio)
+	    effective_pct = min(base_pct * premium, DECK_SIZE_LAND_PREMIUM_CAP)
+	    scaled_count = round(effective_pct * target_size)
+	No-op (returns ideal_counts unchanged) when target_size <= 100. Each scaled
+	value is floored at its original unscaled default so target_size == 100 is
+	always a regression-safe no-op. Never raises.
+	"""
+	if not ideal_counts or not target_size or target_size <= 100:
+		return ideal_counts
+	try:
+		k = float(getattr(bc, 'DECK_SIZE_LAND_PREMIUM_K', 0.12))
+		cap = float(getattr(bc, 'DECK_SIZE_LAND_PREMIUM_CAP', 0.48))
+		ratio = target_size / 100.0
+		premium = 1.0 + k * math.log(ratio)
+		scaled = dict(ideal_counts)
+		for key in _SCALABLE_IDEAL_COUNT_KEYS:
+			base = ideal_counts.get(key)
+			if base is None:
+				continue
+			try:
+				base = float(base)
+			except (TypeError, ValueError):
+				continue
+			base_pct = base / 100.0
+			effective_pct = min(base_pct * premium, cap)
+			scaled_count = int(round(effective_pct * target_size))
+			scaled[key] = max(int(round(base)), scaled_count)
+		return scaled
+	except Exception:
+		return ideal_counts
+
+
 def prefer_owned_first(df, owned_names_lower: set[str], name_col: str = 'name'):
 	"""Stable-reorder DataFrame to put owned names first while preserving prior sort.
 
@@ -1750,7 +1960,7 @@ def is_creature_row(row) -> bool:
 
 
 def creature_cap_with_tolerance(builder) -> int:
-	"""Effective creature cap: creatures_max plus its +/- tolerance grace, floored (roadmap 33)."""
+	"""Effective creature cap: creatures_max plus its +/- tolerance grace, floored."""
 	ic = getattr(builder, 'ideal_counts', None) or {}
 	cap = ic.get('creatures_max', ic.get('creatures'))
 	if cap is None:
@@ -1762,7 +1972,7 @@ def creature_cap_with_tolerance(builder) -> int:
 def creature_room_remaining(builder) -> int:
 	"""How many more creature-typed cards can be added before hitting the tolerant cap.
 
-	Legacy mode has no cross-phase cap enforcement (roadmap 33); returns unlimited room.
+	Legacy mode has no cross-phase cap enforcement; returns unlimited room.
 	"""
 	if getattr(builder, 'creature_builder_mode', 'modern') != 'modern':
 		return 10 ** 9

--- a/code/deck_builder/phases/phase2_lands_analysis.py
+++ b/code/deck_builder/phases/phase2_lands_analysis.py
@@ -198,9 +198,22 @@ class LandAnalysisMixin:
     def _earmark_land_slots(self, land_target: int) -> None:
         """Scale non-land ideal_counts down so they fit within 99 - land_target slots.
 
+        Rulebreaker Commanders (Roadmap 35): this budget is calibrated to the
+        100-card baseline (99 non-commander slots) and runs BEFORE Whtz's
+        deck-size scale-up, so for an oversized target it would pre-shrink
+        small categories (e.g. wipes/protection) using the 100-card budget;
+        the later scale-up would then compound on the shrunken value instead
+        of the true default. Skip entirely when a larger size is targeted -
+        `scale_ideal_counts_for_deck_size` handles proportional sizing there.
+
         This ensures the spell phases never consume the slots reserved for lands,
         making backfill unnecessary in the normal case.
         """
+        try:
+            if bu.effective_deck_size(self) > 100:
+                return
+        except Exception:
+            pass
         # Ensure creatures_max exists (and mirrors the legacy 'creatures' alias) before scaling.
         normalize = getattr(self, '_normalize_creature_ideal_keys', None)
         if callable(normalize):

--- a/code/deck_builder/phases/phase2_lands_basics.py
+++ b/code/deck_builder/phases/phase2_lands_basics.py
@@ -90,6 +90,13 @@ class LandBasicsMixin:
         target_basics = basic_min
 
         colors = [c for c in getattr(self, 'color_identity', []) if c in ['W', 'U', 'B', 'R', 'G']]
+        # Rulebreaker Commanders (Roadmap 35): 'any'/'any_land' basic_lands_scope
+        # (Maular, Seluma, Everforger, Unluckiest Planeswalker, Tolabow, Valko,
+        # Grizzlegom) allows all 5 basics regardless of color identity, including
+        # for The Everforger's own colorless identity.
+        from .. import builder_utils as bu
+        if bu.resolve_basic_lands_scope(self) in ('any', 'any_land'):
+            colors = ['W', 'U', 'B', 'R', 'G']
         if not colors:  # colorless special case -> Wastes only
             colors = []
 
@@ -119,10 +126,13 @@ class LandBasicsMixin:
         # Add to library
         for land_name, count in allocation.items():
             for _ in range(count):
-                # Role metadata: basics (or snow basics)
+                # Role metadata: basics (or snow basics). Leave card_type blank
+                # so add_card() enriches it from the card data (e.g. "Basic
+                # Land - Mountain") instead of falling back to a bare "Land" -
+                # matters for off-identity basics (Rulebreaker scope) that
+                # haven't been added by any earlier phase yet.
                 self.add_card(
                     land_name,
-                    card_type='Land',
                     role='basic',
                     sub_role='snow-basic' if use_snow else 'basic',
                     added_by='lands_step1',

--- a/code/deck_builder/phases/phase2_lands_duals.py
+++ b/code/deck_builder/phases/phase2_lands_duals.py
@@ -34,6 +34,11 @@ class LandDualsMixin:
         if len(colors) < 2:
             self.output_func("Dual Lands: Not multi-color; skipping step 5.")
             return
+        # Rulebreaker Commanders (Roadmap 35): Grizzlegom's any_land scope allows
+        # off-color nonbasic lands too, so any 2-color pair is eligible, not just
+        # the commander's own identity.
+        from .. import builder_utils as bu
+        any_land_active = bu.resolve_basic_lands_scope(self) == 'any_land'
         land_target = (getattr(self, 'ideal_counts', {}) or {}).get('lands', getattr(bc, 'DEFAULT_LAND_COUNT', 35))
         df = getattr(self, '_combined_cards_df', None)
         pool: List[str] = []
@@ -66,7 +71,7 @@ class LandDualsMixin:
                                 mapped_colors.add('G')
                         if len(mapped_colors) != 2:
                             continue
-                        if not mapped_colors.issubset(set(colors)):
+                        if not any_land_active and not mapped_colors.issubset(set(colors)):
                             continue
                         pool.append(name)
                         type_to_card[name] = tline

--- a/code/deck_builder/phases/phase4_spells.py
+++ b/code/deck_builder/phases/phase4_spells.py
@@ -763,12 +763,13 @@ class SpellAdditionMixin:
     # Theme Spell Filler to 100
     # ---------------------------
     def fill_remaining_theme_spells(self):
-        """Fill remaining deck slots with theme spells to reach 100 cards.
+        """Fill remaining deck slots with theme spells to reach the deck-size target.
         Uses primary, secondary, and tertiary tags to select spells matching deck themes.
         Applies weighted selection and fallback to general utility spells if needed.
         """
+        from .. import builder_utils as bu
         total_cards = sum(entry.get('Count', 1) for entry in self.card_library.values())
-        remaining = 100 - total_cards
+        remaining = bu.effective_deck_size(self) - total_cards
         if remaining <= 0:
             return
         df = getattr(self, '_combined_cards_df', None)

--- a/code/deck_builder/phases/phase5_color_balance.py
+++ b/code/deck_builder/phases/phase5_color_balance.py
@@ -24,7 +24,9 @@ class ColorBalanceMixin:
         """
         if self._color_source_matrix_cache is not None and not self._color_source_cache_dirty:
             return self._color_source_matrix_cache
-        matrix = bu.compute_color_source_matrix(self.card_library, getattr(self, '_full_cards_df', None))
+        matrix = bu.compute_color_source_matrix(
+            self.card_library, getattr(self, '_full_cards_df', None), getattr(self, 'color_identity', None)
+        )
         self._color_source_matrix_cache = matrix
         self._color_source_cache_dirty = False
         return matrix
@@ -160,7 +162,14 @@ class ColorBalanceMixin:
 
         # Always consider basic-land rebalance when requested
         # M5: Skip rebalance for colorless commanders (they should have only Wastes)
-        if rebalance_basics and self.color_identity:  # Only rebalance if commander has colors
+        # Rulebreaker Commanders (Roadmap 35): Grizzlegom's 'any_land' relaxation
+        # only widens which LANDS are legal, not which spell colors are legal, so
+        # its deck's spells have zero pip demand outside R/G. Rebalancing basics
+        # toward pip demand would zero out the other 3 colors added by
+        # add_basic_lands()' even split, collapsing to just Mountain/Forest -
+        # skip the pip-driven rebalance entirely so that even split is preserved.
+        skip_rebalance = bu.resolve_basic_lands_scope(self) == 'any_land'
+        if rebalance_basics and self.color_identity and not skip_rebalance:  # Only rebalance if commander has colors
             try:
                 basic_map = getattr(bc, 'COLOR_TO_BASIC_LAND', {})
                 basics_present = {nm: entry for nm, entry in self.card_library.items() if nm in basic_map.values()}

--- a/code/deck_builder/phases/phase6_reporting.py
+++ b/code/deck_builder/phases/phase6_reporting.py
@@ -186,15 +186,18 @@ class ReportingMixin:
 
         # Enforce
         report = enforce_bracket_compliance(self, mode=mode)
-        # If enforcement removed cards without enough replacements, top up to 100 using theme filler
+        # If enforcement removed cards without enough replacements, top up to the
+        # deck-size target using theme filler
         try:
+            from .. import builder_utils as bu
+            target_size = bu.effective_deck_size(self)
             total_cards = 0
             for _n, _e in getattr(self, 'card_library', {}).items():
                 try:
                     total_cards += int(_e.get('Count', 1))
                 except Exception:
                     total_cards += 1
-            if int(total_cards) < 100 and hasattr(self, 'fill_remaining_theme_spells'):
+            if int(total_cards) < target_size and hasattr(self, 'fill_remaining_theme_spells'):
                 before = int(total_cards)
                 try:
                     self.fill_remaining_theme_spells()
@@ -211,7 +214,7 @@ class ReportingMixin:
                 except Exception:
                     total_cards = before
                 try:
-                    self.output_func(f"Topped up deck to {total_cards}/100 after enforcement.")
+                    self.output_func(f"Topped up deck to {total_cards}/{target_size} after enforcement.")
                 except Exception:
                     pass
         except Exception:
@@ -527,7 +530,9 @@ class ReportingMixin:
         try:
             from deck_builder import builder_utils as _builder_utils
             builder_utils_module = _builder_utils
-            color_matrix = builder_utils_module.compute_color_source_matrix(self.card_library, full_df)
+            color_matrix = builder_utils_module.compute_color_source_matrix(
+                self.card_library, full_df, getattr(self, 'color_identity', None)
+            )
         except Exception:
             color_matrix = {}
         dfc_land_lookup: Dict[str, Dict[str, Any]] = {}
@@ -611,7 +616,18 @@ class ReportingMixin:
         # pip_cards map (color → card list for UI cross-highlighting) is built here
         # since it is specific to the reporting layer and not needed elsewhere.
         from .. import builder_utils as _bu
-        pip_density = _bu.compute_pip_density(self.card_library, getattr(self, 'color_identity', []) or [])
+        # Rulebreaker Commanders: Tolabow's off-color Instants/Sorceries (a
+        # fixed rulebreaker_extra_color) and type-based exceptions like
+        # Seluma's Angels or Grizzlegom's basics (any color) both need to be
+        # included here, or their pips get zeroed out as "outside identity"
+        # despite being legally in the deck.
+        _pip_identity = _bu.rulebreaker_pip_identity(
+            self.card_library,
+            getattr(self, 'color_identity', []) or [],
+            getattr(self, 'active_rulebreakers', None) or [],
+            getattr(self, 'rulebreaker_extra_color', None),
+        )
+        pip_density = _bu.compute_pip_density(self.card_library, _pip_identity)
         # Flatten density buckets into a single float per color (single + double*2 + triple*3 + phyrexian)
         # so that pip_counts stays numerically compatible with pip_weights downstream.
         pip_counts: Dict[str, float] = {}
@@ -646,7 +662,7 @@ class ReportingMixin:
                 for c in colors_for_card:
                     pip_cards[c].append({'name': name, 'count': cnt})
         if total_pips <= 0:
-            colors = [c for c in ('W', 'U', 'B', 'R', 'G') if c in (getattr(self, 'color_identity', []) or [])]
+            colors = _pip_identity
             if colors:
                 share = 1 / len(colors)
                 for c in colors:
@@ -882,7 +898,9 @@ class ReportingMixin:
         builder_utils_module = None
         try:
             from deck_builder import builder_utils as builder_utils_module  # type: ignore
-            color_matrix = builder_utils_module.compute_color_source_matrix(self.card_library, full_df)
+            color_matrix = builder_utils_module.compute_color_source_matrix(
+                self.card_library, full_df, getattr(self, 'color_identity', None)
+            )
         except Exception:
             color_matrix = {}
         dfc_land_lookup: Dict[str, Dict[str, Any]] = {}
@@ -945,6 +963,19 @@ class ReportingMixin:
         commander_names = commander_meta.get('commander_names') or []
         if commander_names:
             header_suffix.append(f"Commanders: {', '.join(commander_names)}")
+        try:
+            active_rulebreakers = getattr(self, 'active_rulebreakers', None) or []
+            if active_rulebreakers:
+                rb_names = ', '.join(meta.get('name', '') for meta in active_rulebreakers)
+                header_suffix.append(f"Rulebreaker: {rb_names}")
+                extra_color = getattr(self, 'rulebreaker_extra_color', None)
+                if extra_color:
+                    header_suffix.append(f"Rulebreaker Extra Color: {extra_color}")
+                target_size = getattr(self, 'rulebreaker_target_deck_size', None)
+                if target_size and int(target_size) > 100:
+                    header_suffix.append(f"Rulebreaker Deck Size: {target_size}")
+        except Exception:
+            pass
         header_row = headers + header_suffix
         suffix_padding = [''] * len(header_suffix)
 
@@ -1205,7 +1236,9 @@ class ReportingMixin:
 
         try:
             from deck_builder import builder_utils as _builder_utils
-            color_matrix = _builder_utils.compute_color_source_matrix(self.card_library, full_df)
+            color_matrix = _builder_utils.compute_color_source_matrix(
+                self.card_library, full_df, getattr(self, 'color_identity', None)
+            )
         except Exception:
             color_matrix = {}
         dfc_land_lookup: Dict[str, str] = {}
@@ -1243,6 +1276,19 @@ class ReportingMixin:
         color_identity = commander_meta.get('color_identity') or []
         if color_identity:
             header_lines.append(f"# Colors: {', '.join(color_identity)}")
+        try:
+            active_rulebreakers = getattr(self, 'active_rulebreakers', None) or []
+            if active_rulebreakers:
+                rb_names = ', '.join(meta.get('name', '') for meta in active_rulebreakers)
+                header_lines.append(f"# Rulebreaker: {rb_names}")
+                extra_color = getattr(self, 'rulebreaker_extra_color', None)
+                if extra_color:
+                    header_lines.append(f"# Rulebreaker Extra Color: {extra_color}")
+                target_size = getattr(self, 'rulebreaker_target_deck_size', None)
+                if target_size and int(target_size) > 100:
+                    header_lines.append(f"# Rulebreaker Deck Size: {target_size}")
+        except Exception:
+            pass
 
         with open(path, 'w', encoding='utf-8') as f:
             if header_lines:

--- a/code/deck_builder/random_entrypoint.py
+++ b/code/deck_builder/random_entrypoint.py
@@ -438,6 +438,17 @@ def _load_commanders_df() -> pd.DataFrame:
     
     # Filter to commanders using boolean flag
     commanders_df = bc.get_commanders(df)
+
+    # Roadmap 35 (Rulebreaker Commanders): exclude any archetype flagged
+    # 'random_mode_excluded' (currently just Tolabow, Loch Rascal) from
+    # surprise/random commander pools; its optional extra-color choice has
+    # no one to answer it during a fully automated pick.
+    excluded_names = {
+        meta['name'] for meta in bc.RULEBREAKER_ARCHETYPES.values() if meta.get('random_mode_excluded')
+    }
+    if excluded_names and 'name' in commanders_df.columns:
+        commanders_df = commanders_df[~commanders_df['name'].isin(excluded_names)]
+
     return _ensure_theme_tag_cache(commanders_df)
 
 

--- a/code/deck_builder/rulebreaker_rules.py
+++ b/code/deck_builder/rulebreaker_rules.py
@@ -1,0 +1,130 @@
+"""Rule predicates for the Rulebreaker commander mechanic (Roadmap 35).
+
+Each predicate takes a single card row (``pd.Series`` or any Mapping with
+``type``/``manaValue``/``text`` keys) plus the archetype's ``params`` dict from
+``RULEBREAKER_ARCHETYPES`` and returns whether that card is eligible under the
+archetype's rules exception. These predicates only express *type/mana-value*
+eligibility for the card-pool exception; the color-identity OR-branch that
+combines a predicate match with the "otherwise off-color" check lives in the
+builder's card pool filtering (see Roadmap 35, Milestone 3), not here.
+
+``no_max_deck_size`` has no card-pool predicate of its own (it only affects the
+deck size cap, not which cards are legal), so it always returns ``False``.
+"""
+from __future__ import annotations
+
+from typing import Any, Callable, Iterable, Mapping
+
+__all__ = ["RULE_TYPE_PREDICATES", "card_pool_exception"]
+
+
+def _get(card_row: Mapping[str, Any], key: str, default: Any = "") -> Any:
+    try:
+        value = card_row.get(key, default)
+    except AttributeError:
+        value = getattr(card_row, key, default)
+    return default if value is None else value
+
+
+def _type_line(card_row: Mapping[str, Any]) -> str:
+    value = _get(card_row, "type", "")
+    return str(value) if value else ""
+
+
+def _mana_value(card_row: Mapping[str, Any]) -> float | None:
+    value = _get(card_row, "manaValue", None)
+    if value in (None, ""):
+        value = _get(card_row, "cmc", None)
+    try:
+        return float(value) if value not in (None, "") else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _rule_any_land(card_row: Mapping[str, Any], params: dict) -> bool:
+    """Any land card is eligible (Grizzlegom, Hurloon Hero)."""
+    return "Land" in _type_line(card_row)
+
+
+def _rule_type_any_color(card_row: Mapping[str, Any], params: dict) -> bool:
+    """Card's type line contains any of ``params['types']``."""
+    type_line = _type_line(card_row)
+    types = params.get("types", []) or []
+    return any(t in type_line for t in types)
+
+
+def _rule_type_cmc_any_color(card_row: Mapping[str, Any], params: dict) -> bool:
+    """Like ``type_any_color``, plus a mana-value floor (``params['mv_min']``)."""
+    if not _rule_type_any_color(card_row, params):
+        return False
+    mv_min = params.get("mv_min")
+    if mv_min is None:
+        return True
+    mana_value = _mana_value(card_row)
+    return mana_value is not None and mana_value >= mv_min
+
+
+def _rule_instant_sorcery_extra_color(card_row: Mapping[str, Any], params: dict) -> bool:
+    """Card's type line is Instant or Sorcery (Tolabow, Loch Rascal).
+
+    The extra-color legality check (whether the card's own color identity is
+    within the commander's identity plus the chosen extra color) is performed
+    by the caller, not here \u2014 this predicate only expresses type eligibility.
+    """
+    return _rule_type_any_color(card_row, params)
+
+
+def _rule_no_max_deck_size(card_row: Mapping[str, Any], params: dict) -> bool:
+    """No card-pool exception; only the deck size cap is affected (Whtz)."""
+    return False
+
+
+RULE_TYPE_PREDICATES: dict[str, Callable[[Mapping[str, Any], dict], bool]] = {
+    "any_land": _rule_any_land,
+    "type_any_color": _rule_type_any_color,
+    "type_cmc_any_color": _rule_type_cmc_any_color,
+    "instant_sorcery_extra_color": _rule_instant_sorcery_extra_color,
+    "no_max_deck_size": _rule_no_max_deck_size,
+}
+
+
+def _card_color_identity(card_row: Mapping[str, Any]) -> set[str]:
+    """Parse a card row's ``colorIdentity`` field into an uppercase letter set."""
+    value = _get(card_row, "colorIdentity", None)
+    if value is None:
+        return set()
+    if isinstance(value, str):
+        return {c.strip().upper() for c in value.split(",") if c.strip()}
+    if isinstance(value, Iterable):
+        return {str(c).strip().upper() for c in value if str(c).strip()}
+    return set()
+
+
+def card_pool_exception(
+    card_row: Mapping[str, Any],
+    active_rulebreakers: Iterable[Mapping[str, Any]],
+    extra_color: str | None = None,
+) -> bool:
+    """Return True if any active Rulebreaker archetype makes this card legal
+    regardless of the normal color-identity subset check (Contract §3's
+    card-pool OR-branch). Basic-land relaxation is handled separately by the
+    land phases, not here (see Milestone 3).
+    """
+    for meta in active_rulebreakers or []:
+        rule_type = meta.get("rule_type")
+        if rule_type == "no_max_deck_size":
+            continue
+        predicate = RULE_TYPE_PREDICATES.get(rule_type)
+        if predicate is None:
+            continue
+        params = meta.get("params") or {}
+        if not predicate(card_row, params):
+            continue
+        if rule_type == "instant_sorcery_extra_color":
+            if not extra_color:
+                continue
+            card_ci = _card_color_identity(card_row)
+            if not card_ci or not card_ci.issubset({str(extra_color).strip().upper()}):
+                continue
+        return True
+    return False

--- a/code/file_setup/setup.py
+++ b/code/file_setup/setup.py
@@ -31,6 +31,7 @@ from .setup_constants import (
     NON_LEGAL_SETS,
     FILTER_CONFIG,
     SORT_CONFIG,
+    RULEBREAKER_CARD_NAMES,
 )
 from .setup_utils import _load_banned_cards, _load_commander_illegal_cards
 import logging_util
@@ -252,7 +253,10 @@ def process_raw_parquet(raw_path: str, output_path: str) -> pd.DataFrame:
     # legalities.commander == "not_legal" on every printing), e.g. promo-only
     # cards like Aswan Jaguar - distinct from the hardcoded set-code/type
     # exclusions above, which can't keep up with every one-off promo set.
-    illegal_set = {c.casefold() for c in _load_commander_illegal_cards()}
+    # Rulebreaker commander mechanic cards (Roadmap 35) are intentionally kept
+    # despite being not_legal in Scryfall's data.
+    rulebreaker_exempt = {n.casefold() for n in RULEBREAKER_CARD_NAMES}
+    illegal_set = {c.casefold() for c in _load_commander_illegal_cards()} - rulebreaker_exempt
     if illegal_set:
         logger.info("Removing cards not tournament-legal in Commander")
         name_lc = df['name'].astype(str).str.casefold()
@@ -346,6 +350,55 @@ def process_raw_parquet(raw_path: str, output_path: str) -> pd.DataFrame:
     return df
 
 
+# Prebuilt printings index published by .github/workflows/build-similarity-cache.yml
+_PRINTINGS_INDEX_GITHUB_URL = (
+    "https://raw.githubusercontent.com/mwisnowski/mtg_python_deckbuilder/"
+    "similarity-cache-data/card_files/processed/card_printings.parquet"
+)
+
+
+def ensure_printings_index(bulk_data_path: str | None = None) -> None:
+    """Make sure `card_files/processed/card_printings.parquet` exists.
+
+    Used by the "Choose Printing" picker regardless of whether image
+    caching is enabled. The file lives under `card_files/` which is
+    gitignored, so it doesn't survive a fresh clone/disk wipe and has no
+    other auto-regeneration hook -- try downloading the prebuilt copy
+    published to GitHub first (fast), falling back to building it locally
+    from Scryfall bulk data (slower, but works offline once bulk data is
+    downloaded).
+
+    No-ops if the index already exists.
+    """
+    from code.file_setup.image_cache import ImageCache
+
+    cache = ImageCache()
+    if cache.printings_index_path.exists():
+        return
+
+    logger.info("Printings index missing; attempting to fetch prebuilt copy from GitHub...")
+    try:
+        resp = requests.get(_PRINTINGS_INDEX_GITHUB_URL, timeout=30)
+        resp.raise_for_status()
+        cache.printings_index_path.parent.mkdir(parents=True, exist_ok=True)
+        cache.printings_index_path.write_bytes(resp.content)
+        logger.info(f"Downloaded printings index from GitHub -> {cache.printings_index_path}")
+        return
+    except Exception as exc:
+        logger.warning(f"Could not fetch prebuilt printings index from GitHub ({exc}); building locally instead.")
+
+    bulk_path = bulk_data_path or str(cache.bulk_data_path)
+    if not os.path.exists(bulk_path):
+        logger.warning("No Scryfall bulk data available; skipping local printings index build.")
+        return
+
+    try:
+        count = cache.build_printings_index()
+        logger.info(f"Built printings index locally: {count} rows")
+    except Exception as exc:
+        logger.warning(f"Failed to build printings index locally: {exc}")
+
+
 def initial_setup() -> None:
     """Download and process MTGJSON Parquet data.
     
@@ -385,6 +438,14 @@ def initial_setup() -> None:
         refresh_card_lists_from_bulk(bulk_path)
     except Exception as exc:
         logger.warning(f"Could not refresh card lists from bulk data ({exc}). Using existing lists.")
+
+    # Step 1c: Ensure the printings index exists (used by the "Choose Printing"
+    # picker regardless of CACHE_CARD_IMAGES; card_files/ is gitignored so this
+    # can silently go missing without an explicit regeneration step).
+    try:
+        ensure_printings_index(bulk_data_path=bulk_path)
+    except Exception as exc:
+        logger.warning(f"Could not ensure printings index ({exc}). Continuing anyway.")
 
     # Step 2: Process raw → processed
     processed_path = get_processed_cards_path()

--- a/code/file_setup/setup_constants.py
+++ b/code/file_setup/setup_constants.py
@@ -10,7 +10,7 @@ __all__ = [
     'SETUP_COLORS', 'COLOR_ABRV', 'COLUMN_ORDER', 'TAGGED_COLUMN_ORDER',
     'BANNED_CARDS', 'MTGJSON_API_URL', 'LEGENDARY_OPTIONS', 'NON_LEGAL_SETS',
     'CARD_TYPES_TO_EXCLUDE', 'CSV_PROCESSING_COLUMNS', 'SORT_CONFIG',
-    'FILTER_CONFIG'
+    'FILTER_CONFIG', 'RULEBREAKER_CARD_NAMES'
 ]
 
 # Banned cards consolidated here (remains specific to setup concerns)
@@ -74,6 +74,21 @@ CARD_TYPES_TO_EXCLUDE: List[str] = [
     'Stickers',
     'Attraction',
     'Contraption',
+]
+
+# Rulebreaker commander mechanic (Roadmap 35): Mystery Booster Commander Edition
+# playtest cards that Scryfall marks legalities.commander == "not_legal" on every
+# printing (so they'd otherwise be dropped by the commander-illegal-cards filter),
+# but which this deckbuilder intentionally supports as a special commander mechanic.
+RULEBREAKER_CARD_NAMES: List[str] = [
+    'Grizzlegom, Hurloon Hero',
+    'Maular, the Next Evolution',
+    'Seluma, Light of Aysen',
+    'The Everforger',
+    'The Unluckiest Planeswalker',
+    'Tolabow, Loch Rascal',
+    'Valko Indorian',
+    'Whtz, the Bibliophile',
 ]
 
 # Columns to keep when processing CSV files

--- a/code/headless_runner.py
+++ b/code/headless_runner.py
@@ -213,6 +213,8 @@ def run(
     background: Optional[str] = None,
     enable_partner_mechanics: bool = False,
     creature_builder_mode: Optional[str] = None,
+    rulebreaker_extra_color: Optional[str] = None,
+    rulebreaker_target_deck_size: Optional[int] = None,
 ) -> DeckBuilder:
     """Run a scripted non-interactive deck build and return the DeckBuilder instance.
 
@@ -255,7 +257,7 @@ def run(
     scripted_inputs.extend(owned_prompt_inputs)
     # Bracket (meta power / style) selection; default to 3 if not provided
     scripted_inputs.append(str(bracket_level if isinstance(bracket_level, int) and 1 <= bracket_level <= 5 else 3))
-    # Legacy creature allocation opt-in prompt (roadmap 33, Milestone 5)
+    # Legacy creature allocation opt-in prompt
     scripted_inputs.append("y" if creature_builder_mode == "legacy" else "n")
     # Ideal count prompts (press Enter for defaults). Include fetch_lands if present.
     ideal_keys = {
@@ -323,6 +325,16 @@ def run(
         builder.enforcement_mode = enforcement_mode
         builder.allow_illegal = allow_illegal
         builder.fuzzy_matching = fuzzy_matching
+    except Exception:
+        pass
+
+    # Rulebreaker Commanders: apply before color
+    # identity/deck-size logic runs.
+    try:
+        extra_color_clean = (rulebreaker_extra_color or "").strip().upper() or None
+        builder.rulebreaker_extra_color = extra_color_clean
+        if rulebreaker_target_deck_size is not None:
+            builder.rulebreaker_target_deck_size = max(100, int(rulebreaker_target_deck_size))
     except Exception:
         pass
 
@@ -1509,7 +1521,7 @@ def _main() -> int:
     _ensure_data_ready()
     parser = _build_arg_parser()
     args = parser.parse_args()
-    # JSON-config-file input was removed (Roadmap 34); this stays empty so the
+    # JSON-config-file input was removed; this stays empty so the
     # existing CLI > ENV > JSON > default resolver below still works unchanged.
     json_cfg: Dict[str, Any] = {}
 
@@ -1755,6 +1767,19 @@ def _main() -> int:
         json_cfg,
         "enable_partner_mechanics",
     )
+    resolved_rulebreaker_extra_color = _resolve_string_option(
+        getattr(args, "rulebreaker_extra_color", None),
+        "RULEBREAKER_EXTRA_COLOR",
+        json_cfg,
+        "rulebreaker_extra_color",
+    )
+    resolved_rulebreaker_target_deck_size = _resolve_value(
+        getattr(args, "rulebreaker_target_deck_size", None),
+        "RULEBREAKER_TARGET_DECK_SIZE",
+        json_cfg,
+        "rulebreaker_target_deck_size",
+        None,
+    )
 
     resolved = {
         "command_name": _resolve_value(args.commander, "DECK_COMMANDER", json_cfg, "commander", defaults["command_name"]),
@@ -1787,6 +1812,8 @@ def _main() -> int:
         "secondary_commander": resolved_secondary_commander,
         "background": resolved_background,
         "enable_partner_mechanics": bool(resolved_partner_flag) if resolved_partner_flag is not None else False,
+        "rulebreaker_extra_color": resolved_rulebreaker_extra_color,
+        "rulebreaker_target_deck_size": resolved_rulebreaker_target_deck_size,
     }
 
     if args.dry_run:

--- a/code/tagging/rulebreaker_report.py
+++ b/code/tagging/rulebreaker_report.py
@@ -1,0 +1,102 @@
+"""Roadmap 35 Milestone 9: shared helpers for reporting unrecognized Rulebreaker candidates.
+
+Used by both the CI auto-filing step (`build-similarity-cache.yml`, via a small
+Python one-liner) and the web app's `/status/setup` panel, so the CI-filed issue
+and the local copy-paste textarea always render the same body shape. No `gh`/
+network code beyond the plain, unauthenticated GitHub search used by
+`lookup_existing_issue()`; CI files issues via the `gh` CLI directly, not
+through this module.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any, Optional
+
+import requests
+
+import logging_util
+
+logger = logging_util.logging.getLogger(__name__)
+logger.setLevel(logging_util.LOG_LEVEL)
+
+REPO = "mwisnowski/mtg_python_deckbuilder"
+_SEARCH_URL = "https://api.github.com/search/issues"
+_LOOKUP_CACHE_TTL_SECONDS = 300
+
+# name (casefolded) -> (cached_at_monotonic, html_url_or_None)
+_lookup_cache: dict[str, tuple[float, Optional[str]]] = {}
+
+
+def build_candidate_issue_body(candidate: dict[str, Any]) -> str:
+    """Render one candidate into the same section structure as the
+    `.github/ISSUE_TEMPLATE/rulebreaker-card-report.md` template, so a
+    CI-filed issue and the web UI's copy-paste textarea are always identical
+    in shape.
+    """
+    name = str(candidate.get('name', '')).strip()
+    text = str(candidate.get('text_snippet') or candidate.get('text') or '')
+    matched_signal = str(candidate.get('matched_signal', ''))
+    detected_by = str(candidate.get('detected_by') or 'Automated tagging pass (flagged during run_tagging())')
+    slug = (
+        name.lower().replace(',', '').replace("'", '').replace(' ', '_').strip('_')
+        or 'card_name_slug'
+    )
+    return (
+        "### Card Name\n"
+        f"{name}\n\n"
+        "### Set / Collector Number\n"
+        "_Unknown (detected automatically during tagging)._\n\n"
+        "### Detected By\n"
+        f"{detected_by}\n\n"
+        "### Oracle Text\n"
+        "```\n"
+        f"{text}\n"
+        "```\n\n"
+        "### Suggested Rule Type\n"
+        "_Not yet reviewed; please classify against the existing `rule_type` values._\n\n"
+        "### Proposed Registry Entry\n"
+        "```python\n"
+        f"'{slug}': {{\n"
+        f"    'id': '{slug}',\n"
+        f"    'name': '{name}',\n"
+        "    'color_identity': [],\n"
+        "    'rule_type': '',\n"
+        "    'params': {},\n"
+        "    'basic_lands_scope': 'any',\n"
+        "    'no_max_deck_size': False,\n"
+        "    'requires_user_input': False,\n"
+        "},\n"
+        "```\n\n"
+        "### Additional Notes\n"
+        f"Matched signal: `{matched_signal}`\n"
+    )
+
+
+def lookup_existing_issue(name: str) -> Optional[str]:
+    """Unauthenticated GitHub issue search for an existing report of `name`.
+
+    Fails soft (returns None) on any network error, non-200 response, or empty
+    result set -- never raises. Results are cached in-process for a few
+    minutes per name to stay well under GitHub's low unauthenticated search
+    rate limit across repeated status polls.
+    """
+    now = time.monotonic()
+    cached = _lookup_cache.get(name)
+    if cached is not None and (now - cached[0]) < _LOOKUP_CACHE_TTL_SECONDS:
+        return cached[1]
+
+    result: Optional[str] = None
+    try:
+        query = f'repo:{REPO} "Rulebreaker: {name}" in:title'
+        resp = requests.get(_SEARCH_URL, params={"q": query}, timeout=5)
+        if resp.status_code == 200:
+            items = (resp.json() or {}).get("items") or []
+            if items:
+                result = items[0].get("html_url")
+        else:
+            logger.debug(f"lookup_existing_issue: non-200 response ({resp.status_code}) for '{name}'")
+    except Exception as e:
+        logger.debug(f"lookup_existing_issue: request failed for '{name}': {e}")
+
+    _lookup_cache[name] = (now, result)
+    return result

--- a/code/tagging/tag_constants.py
+++ b/code/tagging/tag_constants.py
@@ -1187,6 +1187,11 @@ KEYWORD_NORMALIZATION_MAP: Dict[str, str] = {
 # Already excluded during keyword tagging, but documented here
 KEYWORD_EXCLUSION_SET: set[str] = {
     'partner',  # Already excluded in tag_for_keywords
+    # Rulebreaker commander mechanic: each of the 8 cards has a
+    # unique, unrelated rule exception and no shared color identity, so it
+    # isn't a usable deckbuilding theme; the per-card metadata marker
+    # (Rulebreaker: {name}) from tag_for_rulebreakers is used instead.
+    'rulebreaker',
 }
 
 # Keyword allowlist - keywords that should survive singleton pruning
@@ -1243,7 +1248,32 @@ METADATA_TAG_PREFIXES: List[str] = [
     'Diagnostic:',
     'Internal:',
     'Token Detail:',
+    'Rulebreaker:',
 ]
+
+# Rulebreaker commander mechanic (Roadmap 35): exact printed names of the
+# commander cards that grant a named rules exception. Name-exact-match only
+# (not regex-derived) since the population is fixed and finite. Sourced from
+# file_setup.setup_constants (single source of truth; also used there to
+# exempt these cards from the commander-illegal-cards legality filter).
+from file_setup.setup_constants import RULEBREAKER_CARD_NAMES  # noqa: E402
+
+# Roadmap 35 Milestone 9: signals used to flag Commander-legal cards that look
+# like they may carry the Rulebreaker mechanic but aren't yet in
+# RULEBREAKER_CARD_NAMES above (e.g. a not-yet-registered card from a future
+# spoiler/print run). The italicized ability word "Rulebreaker" is the
+# primary, high-confidence signal since all 8 known cards print it verbatim.
+# The text-signal phrases are a lower-confidence fallback for a later set that
+# reuses the rules-exception concept without the same ability word.
+RULEBREAKER_ABILITY_WORD: Final[str] = 'Rulebreaker'
+
+RULEBREAKER_TEXT_SIGNALS: Final[list[str]] = [
+    'regardless of color identity',
+    "as though it were in your commander's color identity",
+    'there is no maximum deck size',
+    "choose a color that isn't in your commander's color identity",
+]
+
 
 # Specific metadata tags (full match) - additional tags to classify as metadata
 # These are typically diagnostic, bracket-related, or internal annotations

--- a/code/tagging/tagger.py
+++ b/code/tagging/tagger.py
@@ -1063,7 +1063,10 @@ def tag_for_keywords(df: pd.DataFrame, color: str) -> None:
         if has_keywords.any():
             # Vectorized split and merge into themeTags
             keywords_df = df.loc[has_keywords, ['themeTags', 'keywords']].copy()
-            exclusion_keywords = {'partner'}
+            # 'rulebreaker' also excluded: it's the ability word printed on the
+            # 8 Rulebreaker commander cards, not a usable deckbuilding theme
+            # (see tag_constants.KEYWORD_EXCLUSION_SET for the normalized path).
+            exclusion_keywords = {'partner', 'rulebreaker'}
 
             def _merge_keywords(row: pd.Series) -> list[str]:
                 base_tags = list(row['themeTags']) if hasattr(row.get('themeTags'), '__len__') and not isinstance(row.get('themeTags'), str) else []
@@ -4482,6 +4485,8 @@ def tag_for_themes(df: pd.DataFrame, color: str) -> None:
     print('\n==========\n')
     tag_for_multiple_copies(df, color)
     print('\n==========\n')
+    tag_for_rulebreakers(df, color)
+    print('\n==========\n')
     tag_for_planeswalkers(df, color)
     print('\n==========\n')
     tag_for_reanimate(df, color)
@@ -5779,6 +5784,96 @@ def tag_for_multiple_copies(df: pd.DataFrame, color: str) -> None:
     except Exception as e:
         logger.error(f'Error in tag_for_multiple_copies: {str(e)}')
         raise
+
+## Rulebreaker Commanders (Roadmap 35)
+def tag_for_rulebreakers(df: pd.DataFrame, color: str) -> None:
+    """Tag the fixed set of Rulebreaker commander cards with a per-card marker tag.
+
+    Applies `Rulebreaker: {card_name}` to each of the RULEBREAKER_CARD_NAMES
+    exact matches. This tag is a lookup/marker aid (UI badges, docs); it does
+    not itself encode the rules exception (see RULEBREAKER_ARCHETYPES in
+    code/deck_builder/builder_constants.py).
+
+    Args:
+        df: DataFrame containing card data
+        color: Color identifier for logging purposes
+
+    Raises:
+        ValueError: If required DataFrame columns are missing
+        TypeError: If inputs are not of correct type
+    """
+    try:
+        if not isinstance(df, pd.DataFrame):
+            raise TypeError("df must be a pandas DataFrame")
+        if not isinstance(color, str):
+            raise TypeError("color must be a string")
+        required_cols = {'name', 'themeTags'}
+        tag_utils.validate_dataframe_columns(df, required_cols)
+        names = tag_constants.RULEBREAKER_CARD_NAMES
+        rulebreaker_mask = tag_utils.create_name_mask(df, names, regex=False)
+        if rulebreaker_mask.any():
+            matching_cards = df[rulebreaker_mask]['name'].unique()
+            rules = [
+                {'mask': (df['name'] == card_name), 'tags': [f'Rulebreaker: {card_name}']}
+                for card_name in matching_cards
+            ]
+            tag_utils.apply_rules(df, rules=rules)
+            logger.info(f'Tagged {rulebreaker_mask.sum()} cards with Rulebreaker marker tags')
+
+    except Exception as e:
+        logger.error(f'Error in tag_for_rulebreakers: {str(e)}')
+        raise
+
+
+def detect_unrecognized_rulebreakers(df: pd.DataFrame) -> list[dict]:
+    """Flag Commander-legal cards with Rulebreaker-shaped oracle text that
+    aren't yet in the RULEBREAKER_CARD_NAMES registry (Roadmap 35, Milestone 9).
+
+    Purely local/offline: no network calls. Intended to be called with a
+    Commander-legal card DataFrame (e.g. commander_cards.parquet) near the end
+    of run_tagging().
+
+    Returns a list of candidate dicts: {'name', 'text_snippet', 'matched_signal'}.
+    """
+    candidates: list[dict] = []
+    if df is None or df.empty or 'name' not in df.columns or 'text' not in df.columns:
+        return candidates
+
+    known_names = {n.casefold() for n in tag_constants.RULEBREAKER_CARD_NAMES}
+    ability_word = tag_constants.RULEBREAKER_ABILITY_WORD
+    signals = tag_constants.RULEBREAKER_TEXT_SIGNALS
+    seen: set[str] = set()
+
+    for _, row in df.iterrows():
+        name = str(row.get('name') or '').strip()
+        if not name or name.casefold() in known_names or name.casefold() in seen:
+            continue
+        text = str(row.get('text') or '')
+        if not text:
+            continue
+        matched: str | None = None
+        if ability_word in text:
+            matched = ability_word
+        else:
+            lowered = text.lower()
+            for sig in signals:
+                if sig.lower() in lowered:
+                    matched = sig
+                    break
+        if matched is None:
+            continue
+        seen.add(name.casefold())
+        snippet = text if len(text) <= 240 else text[:237] + '...'
+        candidates.append({'name': name, 'text_snippet': snippet, 'matched_signal': matched})
+
+    for c in candidates:
+        logger.warning(
+            f"Unrecognized Rulebreaker candidate detected: {c['name']} "
+            f"(matched: {c['matched_signal']}). See logs/rulebreaker_candidates.json "
+            "for a ready-to-paste issue body."
+        )
+    return candidates
+
 
 ## Planeswalkers
 def create_planeswalker_text_mask(df: pd.DataFrame) -> pd.Series:
@@ -7357,7 +7452,24 @@ def run_tagging(parallel: bool = False, max_workers: int | None = None):
         logger.info(f"✓ Wrote tagging completion flag to {flag_path}")
     except Exception as e:
         logger.warning(f"Failed to write tagging completion flag: {e}")
-    
+
+    # Roadmap 35 Milestone 9: detect unregistered Rulebreaker-shaped cards.
+    # Local-only, no network calls; overwrites (not appends) each run so a
+    # since-registered candidate naturally stops being flagged.
+    try:
+        from code.path_util import get_processed_cards_path
+        commander_path = os.path.join(os.path.dirname(get_processed_cards_path()), 'commander_cards.parquet')
+        if os.path.exists(commander_path):
+            commander_df = _data_loader.read_cards(commander_path, format="parquet")
+            candidates = detect_unrecognized_rulebreakers(commander_df)
+            os.makedirs("logs", exist_ok=True)
+            with open(os.path.join("logs", "rulebreaker_candidates.json"), "w", encoding="utf-8") as f:
+                json.dump(candidates, f, indent=2)
+            if candidates:
+                logger.warning(f"Found {len(candidates)} unrecognized Rulebreaker candidate(s); see logs/rulebreaker_candidates.json")
+    except Exception as e:
+        logger.warning(f"Rulebreaker candidate detection failed (non-fatal): {e}")
+
     # R21: Theme stripping after tagging (if THEME_MIN_CARDS > 1)
     try:
         from settings import THEME_MIN_CARDS

--- a/code/tests/test_api_v1_builds.py
+++ b/code/tests/test_api_v1_builds.py
@@ -117,6 +117,131 @@ def test_create_build_uses_per_user_deck_dir(client, auth_headers, monkeypatch):
     assert seen_kwargs["deck_dir"] != "deck_files"
 
 
+def test_create_build_passes_rulebreaker_fields(client, auth_headers, monkeypatch):
+    """Roadmap 35, Milestone 7: rulebreaker_extra_color/rulebreaker_target_deck_size
+    reach orch.start_build_ctx unchanged (uppercased/trimmed for the color)."""
+    import code.web.routes.api_v1.builds as builds_route
+
+    seen_kwargs: dict = {}
+
+    def _capturing_start_build_ctx(**kwargs):
+        seen_kwargs.update(kwargs)
+        return {"stages": [0], "idx": 0}
+
+    monkeypatch.setattr(builds_route.orch, "start_build_ctx", _capturing_start_build_ctx)
+    monkeypatch.setattr(builds_route.orch, "ideal_defaults", lambda: {})
+    monkeypatch.setattr(builds_route.orch, "bracket_options", lambda: [{"level": 1}])
+
+    resp = client.post(
+        "/api/v1/builds",
+        json={
+            "commander": "Tolabow, Loch Rascal",
+            "rulebreaker_extra_color": "b",
+            "rulebreaker_target_deck_size": 150,
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 202
+    assert seen_kwargs["rulebreaker_extra_color"] == "B"
+    assert seen_kwargs["rulebreaker_target_deck_size"] == 150
+
+
+def test_create_build_rejects_invalid_rulebreaker_color(client, auth_headers, monkeypatch):
+    _fake_orchestrator(monkeypatch)
+    resp = client.post(
+        "/api/v1/builds",
+        json={"commander": "Tolabow, Loch Rascal", "rulebreaker_extra_color": "Z"},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "INVALID_RULEBREAKER_COLOR"
+
+
+def test_create_build_rejects_undersized_rulebreaker_deck_size(client, auth_headers, monkeypatch):
+    _fake_orchestrator(monkeypatch)
+    resp = client.post(
+        "/api/v1/builds",
+        json={"commander": "Whtz, the Bibliophile", "rulebreaker_target_deck_size": 50},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 400
+    assert resp.json()["code"] == "INVALID_RULEBREAKER_DECK_SIZE"
+
+
+def test_create_build_manual_mode_stores_rulebreaker_fields(client, auth_headers, monkeypatch):
+    """Regression: the API's manual-mode session previously omitted
+    rulebreaker_extra_color/rulebreaker_target_deck_size entirely, so
+    manual_builder_service.py's already-correct handling of those fields
+    (Tolabow's extra color pool, Whtz's deck-size target/role-bar) never
+    saw them for API/mobile-originated manual builds."""
+    import code.web.routes.api_v1.builds as builds_route
+    from code.web.services import api_build_store as build_store
+
+    monkeypatch.setattr(
+        builds_route, "_start_manual_session_sync", lambda *a, **k: ["W", "U"]
+    )
+
+    resp = client.post(
+        "/api/v1/builds",
+        json={
+            "commander": "Whtz, the Bibliophile",
+            "mode": "manual",
+            "rulebreaker_extra_color": "b",
+            "rulebreaker_target_deck_size": 150,
+        },
+        headers=auth_headers,
+    )
+    assert resp.status_code == 201
+    build_id = resp.json()["data"]["build_id"]
+    ctx = build_store.get_ctx(build_id)
+    assert ctx["rulebreaker_extra_color"] == "B"
+    assert ctx["rulebreaker_target_deck_size"] == 150
+
+
+def test_create_build_scales_ideal_counts_for_deck_size(client, auth_headers, monkeypatch):
+    """Regression: auto/guided-mode ideal_counts must be scaled server-side
+    for a >100-card rulebreaker_target_deck_size, since the mobile app (unlike
+    the web UI's client-side JS) submits unscaled defaults/overrides."""
+    import code.web.routes.api_v1.builds as builds_route
+
+    seen_kwargs: dict = {}
+
+    def _capturing_start_build_ctx(**kwargs):
+        seen_kwargs.update(kwargs)
+        return {"stages": [0], "idx": 0}
+
+    monkeypatch.setattr(builds_route.orch, "start_build_ctx", _capturing_start_build_ctx)
+    monkeypatch.setattr(builds_route.orch, "ideal_defaults", lambda: {"lands": 35, "removal": 10})
+    monkeypatch.setattr(builds_route.orch, "bracket_options", lambda: [{"level": 1}])
+
+    resp = client.post(
+        "/api/v1/builds",
+        json={"commander": "Whtz, the Bibliophile", "rulebreaker_target_deck_size": 200},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 202
+    assert seen_kwargs["ideals"]["lands"] > 35
+    assert seen_kwargs["ideals"]["removal"] > 10
+
+
+def test_ideal_defaults_scales_with_query_param(client, auth_headers, monkeypatch):
+    """Regression: GET /ideal-defaults previously always returned flat
+    100-card defaults with no way to preview scaled values for a mobile
+    client that has no client-side scaling JS."""
+    import code.web.routes.api_v1.builds as builds_route
+
+    monkeypatch.setattr(builds_route.orch, "ideal_defaults", lambda: {"lands": 35})
+    monkeypatch.setattr(builds_route.orch, "ideal_labels", lambda: {"lands": "Lands"})
+
+    resp = client.get(
+        "/api/v1/builds/ideal-defaults",
+        params={"rulebreaker_target_deck_size": 200},
+        headers=auth_headers,
+    )
+    assert resp.status_code == 200
+    assert resp.json()["data"]["defaults"]["lands"] > 35
+
+
 def _fake_guided_orchestrator(monkeypatch, *, stage_count: int = 2):
     """Like _fake_orchestrator, but run_stage never batches -- each call advances
     exactly one stage and returns added_cards, matching guided-mode semantics."""

--- a/code/tests/test_api_v1_commanders.py
+++ b/code/tests/test_api_v1_commanders.py
@@ -55,6 +55,59 @@ def test_commander_detail(client, sample_commander):
     data = resp.json()["data"]
     assert data["name"] == sample_commander.display_name
     assert "oracle_text" in data
+    assert data["is_rulebreaker"] is False
+    assert data["rulebreaker_rule_type"] is None
+
+
+def test_commander_detail_rulebreaker_metadata(client, monkeypatch):
+    """Roadmap 35, Milestone 7: a Rulebreaker commander's detail response
+    includes archetype metadata the mobile client uses to show the optional
+    color picker / deck-size field."""
+    from code.web.services.commander_catalog_loader import CommanderRecord, find_commander_record
+    import code.web.routes.api_v1.commanders as commanders_route
+
+    fake_record = CommanderRecord(
+        name="Tolabow, Loch Rascal",
+        face_name="Tolabow, Loch Rascal",
+        display_name="Tolabow, Loch Rascal",
+        slug="tolabow-loch-rascal",
+        color_identity=("U",),
+        color_identity_key="U",
+        is_colorless=False,
+        colors=("U",),
+        mana_cost="{1}{U}",
+        mana_value=2.0,
+        type_line="Legendary Creature — Human Rogue",
+        creature_types=("Human", "Rogue"),
+        oracle_text="Rulebreaker — Instants and sorceries you cast can include one color of your choice not in your commander's color identity.",
+        power=None,
+        toughness=None,
+        keywords=(),
+        themes=(),
+        theme_tokens=(),
+        edhrec_rank=None,
+        layout="normal",
+        side=None,
+        image_small_url="",
+        image_normal_url="",
+        partner_with=(),
+        has_plain_partner=False,
+        is_partner=False,
+        supports_backgrounds=False,
+        is_background=False,
+        is_doctor=False,
+        is_doctors_companion=False,
+        restricted_partner_labels=(),
+        search_haystack="tolabow, loch rascal",
+    )
+    monkeypatch.setattr(commanders_route, "find_commander_record", lambda name: fake_record)
+
+    resp = client.get("/api/v1/commanders/Tolabow, Loch Rascal")
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert data["is_rulebreaker"] is True
+    assert data["rulebreaker_rule_type"] == "instant_sorcery_extra_color"
+    assert data["rulebreaker_no_max_deck_size"] is False
 
 
 def test_commander_detail_not_found(client):

--- a/code/tests/test_manual_builder.py
+++ b/code/tests/test_manual_builder.py
@@ -292,6 +292,107 @@ def test_role_bar_counts_correct(monkeypatch):
     assert removal_pill["actual"] == 1
 
 
+def test_mana_overview_includes_rulebreaker_extra_color(monkeypatch):
+    """Tolabow's extra-color Instants/Sorceries (and their mana sources)
+    were previously zeroed out of pips/sources because they're outside the
+    commander's base color_identity."""
+    manual_builder_service = importlib.import_module("code.web.services.manual_builder_service")
+
+    df = pd.DataFrame([
+        {"name": "Some Commander", "colorIdentity": "U", "type": "Legendary Creature - Otter",
+         "manaCost": "{1}{U}", "manaValue": 2.0, "themeTags": [], "edhrecRank": 1.0, "isNew": False},
+        {"name": "Lightning Bolt", "colorIdentity": "R", "type": "Instant",
+         "manaCost": "{R}", "manaValue": 1.0, "themeTags": ["Removal"], "edhrecRank": 100.0, "isNew": False},
+        {"name": "Mountain", "colorIdentity": "", "type": "Basic Land - Mountain",
+         "manaCost": "", "manaValue": 0.0, "themeTags": [], "edhrecRank": 1.0, "isNew": False},
+    ])
+
+    class _FakeLoader:
+        def load(self):
+            return df
+
+    monkeypatch.setattr(manual_builder_service, "AllCardsLoader", _FakeLoader)
+    sess = {
+        "color_identity": ["U"],
+        "commander": "Some Commander",
+        "rulebreaker_extra_color": "R",
+        "deck_cards": ["Lightning Bolt", "Mountain"],
+    }
+
+    data = manual_builder_service.mana_overview_data(sess)["mana_overview"]
+    red_pip = next((p for p in data["pips"] if p["color"] == "R"), None)
+    red_source = next((s for s in data["sources"] if s["color"] == "R"), None)
+    assert red_pip is not None and red_pip["count"] > 0
+    assert red_source is not None and red_source["count"] > 0
+
+
+def test_mana_overview_includes_type_based_rulebreaker_any_color(monkeypatch):
+    """Seluma (Angels can be any color), Grizzlegom, Maular, etc. don't pin a
+    single known extra color like Tolabow does -- the actual off-identity
+    color has to be detected from the cards actually in the deck."""
+    manual_builder_service = importlib.import_module("code.web.services.manual_builder_service")
+
+    df = pd.DataFrame([
+        {"name": "Seluma, Light of Aysen", "colorIdentity": "W", "type": "Legendary Creature - Angel Warrior",
+         "manaCost": "{2}{W}{W}", "manaValue": 4.0, "themeTags": [], "edhrecRank": 1.0, "isNew": False},
+        {"name": "Off-Color Angel", "colorIdentity": "B", "type": "Creature - Angel",
+         "manaCost": "{2}{B}{B}", "manaValue": 4.0, "themeTags": [], "edhrecRank": 100.0, "isNew": False},
+        {"name": "Swamp", "colorIdentity": "", "type": "Basic Land - Swamp",
+         "manaCost": "", "manaValue": 0.0, "themeTags": [], "edhrecRank": 1.0, "isNew": False},
+    ])
+
+    class _FakeLoader:
+        def load(self):
+            return df
+
+    monkeypatch.setattr(manual_builder_service, "AllCardsLoader", _FakeLoader)
+    sess = {
+        "color_identity": ["W"],
+        "commander": "Seluma, Light of Aysen",
+        "deck_cards": ["Off-Color Angel", "Swamp"],
+    }
+
+    data = manual_builder_service.mana_overview_data(sess)["mana_overview"]
+    black_pip = next((p for p in data["pips"] if p["color"] == "B"), None)
+    black_source = next((s for s in data["sources"] if s["color"] == "B"), None)
+    assert black_pip is not None and black_pip["count"] > 0
+    assert black_source is not None and black_source["count"] > 0
+
+
+def test_mana_overview_sources_show_basic_lands_without_matching_spell(monkeypatch):
+    """Seluma/Grizzlegom's 'any basic land' exception lets a deck run all 5
+    basics even with zero off-identity spells -- Sources should reflect
+    those actual lands, not just colors that happen to have spell pips."""
+    manual_builder_service = importlib.import_module("code.web.services.manual_builder_service")
+
+    df = pd.DataFrame([
+        {"name": "Seluma, Light of Aysen", "colorIdentity": "W", "type": "Legendary Creature - Angel Warrior",
+         "manaCost": "{2}{W}{W}", "manaValue": 4.0, "themeTags": [], "edhrecRank": 1.0, "isNew": False},
+        {"name": "Forest", "colorIdentity": "", "type": "Basic Land - Forest",
+         "manaCost": "", "manaValue": 0.0, "themeTags": [], "edhrecRank": 1.0, "isNew": False},
+        {"name": "Island", "colorIdentity": "", "type": "Basic Land - Island",
+         "manaCost": "", "manaValue": 0.0, "themeTags": [], "edhrecRank": 1.0, "isNew": False},
+    ])
+
+    class _FakeLoader:
+        def load(self):
+            return df
+
+    monkeypatch.setattr(manual_builder_service, "AllCardsLoader", _FakeLoader)
+    sess = {
+        "color_identity": ["W"],
+        "commander": "Seluma, Light of Aysen",
+        "deck_cards": ["Forest", "Island"],
+    }
+
+    data = manual_builder_service.mana_overview_data(sess)["mana_overview"]
+    green_source = next((s for s in data["sources"] if s["color"] == "G"), None)
+    blue_source = next((s for s in data["sources"] if s["color"] == "U"), None)
+    assert green_source is not None and green_source["count"] > 0
+    assert blue_source is not None and blue_source["count"] > 0
+
+
+
 def test_deck_panel_groups_by_type_and_shows_role_labels(monkeypatch):
     """Deck panel groups mirror the finished-deck summary's type order
     (Instant before Sorcery before Land), and each card is tagged with its

--- a/code/tests/test_rulebreaker_candidate_detection.py
+++ b/code/tests/test_rulebreaker_candidate_detection.py
@@ -1,0 +1,161 @@
+"""Tests for Roadmap 35 Milestone 9: unrecognized Rulebreaker candidate detection.
+
+Covers detect_unrecognized_rulebreakers() (tagger.py), build_candidate_issue_body()
+and lookup_existing_issue() (rulebreaker_report.py), and the /status/setup
+endpoint's rulebreaker_candidates field.
+"""
+import json
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from tagging.tagger import detect_unrecognized_rulebreakers
+from tagging.rulebreaker_report import build_candidate_issue_body, lookup_existing_issue
+from code.web.app import app
+
+
+def _cards_df():
+    return pd.DataFrame([
+        {
+            # One of the 8 known cards: must NOT be flagged even though it
+            # carries the ability word verbatim.
+            'name': 'Grizzlegom, Hurloon Hero',
+            'text': 'Rulebreaker \u2014 A deck with this commander can have any land cards.',
+        },
+        {
+            # Synthetic "future" card with the ability word and an
+            # unrecognized name: MUST be flagged.
+            'name': 'Fakko, Test Rulebreaker',
+            'text': 'Rulebreaker \u2014 A deck with this commander can have Goblin cards of any color identity.',
+        },
+        {
+            # Ordinary card with unrelated text: must NOT be flagged.
+            'name': 'Ordinary Bear',
+            'text': 'Whenever Ordinary Bear attacks, draw a card.',
+        },
+    ])
+
+
+def test_detect_unrecognized_rulebreakers_flags_only_unknown_ability_word_cards():
+    candidates = detect_unrecognized_rulebreakers(_cards_df())
+    names = {c['name'] for c in candidates}
+    assert names == {'Fakko, Test Rulebreaker'}
+    assert candidates[0]['matched_signal'] == 'Rulebreaker'
+
+
+def test_detect_unrecognized_rulebreakers_fallback_text_signal():
+    df = pd.DataFrame([{
+        'name': 'Someday Card',
+        'text': "This card's color identity is regardless of color identity for deckbuilding purposes.",
+    }])
+    candidates = detect_unrecognized_rulebreakers(df)
+    assert len(candidates) == 1
+    assert candidates[0]['name'] == 'Someday Card'
+    assert candidates[0]['matched_signal'] == 'regardless of color identity'
+
+
+def test_detect_unrecognized_rulebreakers_empty_df():
+    assert detect_unrecognized_rulebreakers(pd.DataFrame()) == []
+
+
+def test_build_candidate_issue_body_contains_name_text_and_registry_skeleton():
+    candidate = {
+        'name': 'Fakko, Test Rulebreaker',
+        'text_snippet': 'Rulebreaker \u2014 test text',
+        'matched_signal': 'Rulebreaker',
+    }
+    body = build_candidate_issue_body(candidate)
+    assert '### Card Name' in body
+    assert 'Fakko, Test Rulebreaker' in body
+    assert '### Oracle Text' in body
+    assert 'Rulebreaker \u2014 test text' in body
+    assert '### Proposed Registry Entry' in body
+    assert "'name': 'Fakko, Test Rulebreaker'" in body
+
+
+class _FakeResponse:
+    def __init__(self, status_code, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+def test_lookup_existing_issue_returns_url_on_match(monkeypatch):
+    def fake_get(url, params=None, timeout=None):
+        return _FakeResponse(200, {'items': [{'html_url': 'https://github.com/x/y/issues/42'}]})
+
+    monkeypatch.setattr('tagging.rulebreaker_report.requests.get', fake_get)
+    # bypass in-process cache from any prior test
+    import tagging.rulebreaker_report as rb_report
+    rb_report._lookup_cache.clear()
+    assert lookup_existing_issue('Some New Card') == 'https://github.com/x/y/issues/42'
+
+
+def test_lookup_existing_issue_returns_none_on_empty_result(monkeypatch):
+    def fake_get(url, params=None, timeout=None):
+        return _FakeResponse(200, {'items': []})
+
+    monkeypatch.setattr('tagging.rulebreaker_report.requests.get', fake_get)
+    import tagging.rulebreaker_report as rb_report
+    rb_report._lookup_cache.clear()
+    assert lookup_existing_issue('No Match Card') is None
+
+
+def test_lookup_existing_issue_returns_none_on_network_error(monkeypatch):
+    def fake_get(url, params=None, timeout=None):
+        raise ConnectionError('boom')
+
+    monkeypatch.setattr('tagging.rulebreaker_report.requests.get', fake_get)
+    import tagging.rulebreaker_report as rb_report
+    rb_report._lookup_cache.clear()
+    assert lookup_existing_issue('Network Error Card') is None
+
+
+def test_lookup_existing_issue_returns_none_on_rate_limit(monkeypatch):
+    def fake_get(url, params=None, timeout=None):
+        return _FakeResponse(403)
+
+    monkeypatch.setattr('tagging.rulebreaker_report.requests.get', fake_get)
+    import tagging.rulebreaker_report as rb_report
+    rb_report._lookup_cache.clear()
+    assert lookup_existing_issue('Rate Limited Card') is None
+
+
+@pytest.fixture
+def _status_setup_files(tmp_path, monkeypatch):
+    """Point /status/setup's file reads at a scratch directory so this test
+    never touches real csv_files/.setup_status.json or logs/rulebreaker_candidates.json."""
+    import os
+    monkeypatch.chdir(tmp_path)
+    os.makedirs('csv_files', exist_ok=True)
+    os.makedirs('logs', exist_ok=True)
+    with open('csv_files/.setup_status.json', 'w', encoding='utf-8') as f:
+        json.dump({'running': False, 'phase': 'done'}, f)
+    yield tmp_path
+
+
+def test_status_setup_includes_rulebreaker_candidates_when_present(monkeypatch, _status_setup_files):
+    with open('logs/rulebreaker_candidates.json', 'w', encoding='utf-8') as f:
+        json.dump([{'name': 'Fakko, Test Rulebreaker', 'text_snippet': 'Rulebreaker text', 'matched_signal': 'Rulebreaker'}], f)
+
+    monkeypatch.setattr('tagging.rulebreaker_report.lookup_existing_issue', lambda name: None)
+
+    client = TestClient(app)
+    resp = client.get('/status/setup')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert 'rulebreaker_candidates' in data
+    assert data['rulebreaker_candidates'][0]['name'] == 'Fakko, Test Rulebreaker'
+    assert 'issue_body' in data['rulebreaker_candidates'][0]
+
+
+def test_status_setup_omits_rulebreaker_candidates_when_absent(_status_setup_files):
+    client = TestClient(app)
+    resp = client.get('/status/setup')
+    assert resp.status_code == 200
+    data = resp.json()
+    assert 'rulebreaker_candidates' not in data
+

--- a/code/tests/test_rulebreaker_commanders.py
+++ b/code/tests/test_rulebreaker_commanders.py
@@ -1,0 +1,123 @@
+"""Tests for the Rulebreaker commander mechanic (Roadmap 35, Milestones 1-2)."""
+from types import SimpleNamespace
+
+import pandas as pd
+
+from deck_builder import builder_utils as bu
+from deck_builder.builder_constants import RULEBREAKER_ARCHETYPES
+from deck_builder.rulebreaker_rules import RULE_TYPE_PREDICATES, card_pool_exception
+from tagging.tagger import tag_for_rulebreakers
+
+
+def _cards_df(rows: list[dict]) -> pd.DataFrame:
+    df = pd.DataFrame(rows)
+    df['themeTags'] = [[] for _ in range(len(df))]
+    return df
+
+
+class DummyBuilder:
+    def __init__(self, commander_name=None, combined_commander=None):
+        self.commander_name = commander_name
+        if combined_commander is not None:
+            self.combined_commander = combined_commander
+
+
+def test_tag_for_rulebreakers_applies_marker_tag():
+    df = _cards_df([
+        {'name': 'Maular, the Next Evolution'},
+        {'name': 'Sol Ring'},
+    ])
+    tag_for_rulebreakers(df, 'g')
+    maular_tags = df.loc[df['name'] == 'Maular, the Next Evolution', 'themeTags'].iloc[0]
+    sol_ring_tags = df.loc[df['name'] == 'Sol Ring', 'themeTags'].iloc[0]
+    assert maular_tags == ['Rulebreaker: Maular, the Next Evolution']
+    assert sol_ring_tags == []
+
+
+def test_detect_active_rulebreakers_primary_match():
+    b = DummyBuilder(commander_name='Whtz, the Bibliophile')
+    results = bu.detect_active_rulebreakers(b)
+    assert [r['id'] for r in results] == ['whtz_the_bibliophile']
+    assert results[0]['no_max_deck_size'] is True
+
+
+def test_detect_active_rulebreakers_no_match():
+    b = DummyBuilder(commander_name='Sol Ring')
+    assert bu.detect_active_rulebreakers(b) == []
+
+
+def test_detect_active_rulebreakers_partner_pair():
+    combined = type('Combined', (), {'secondary_name': 'Tolabow, Loch Rascal'})()
+    b = DummyBuilder(commander_name='Maular, the Next Evolution', combined_commander=combined)
+    ids = {r['id'] for r in bu.detect_active_rulebreakers(b)}
+    assert ids == {'maular_next_evolution', 'tolabow_loch_rascal'}
+
+
+def test_rule_type_cmc_any_color_predicate():
+    predicate = RULE_TYPE_PREDICATES['type_cmc_any_color']
+    params = {'types': ['Creature'], 'mv_min': 7}
+    big_creature = {'type': 'Creature — Dragon', 'manaValue': 7}
+    small_creature = {'type': 'Creature — Elf', 'manaValue': 2}
+    non_creature = {'type': 'Sorcery', 'manaValue': 8}
+    assert predicate(big_creature, params) is True
+    assert predicate(small_creature, params) is False
+    assert predicate(non_creature, params) is False
+
+
+def test_rule_any_land_and_no_max_deck_size_predicates():
+    assert RULE_TYPE_PREDICATES['any_land']({'type': 'Land'}, {}) is True
+    assert RULE_TYPE_PREDICATES['any_land']({'type': 'Creature — Otter'}, {}) is False
+    # no_max_deck_size never contributes a card-pool match
+    assert RULE_TYPE_PREDICATES['no_max_deck_size']({'type': 'Creature'}, {}) is False
+
+
+# --- Milestone 3 integration tests -----------------------------------------
+# These exercise the exact functions setup_dataframes()/the land phases call
+# (card_pool_exception, resolve_basic_lands_scope) against the real
+# RULEBREAKER_ARCHETYPES entries, rather than a full CSV-backed DeckBuilder
+# build (per the roadmap's Milestone 3 Testing Plan scenarios).
+
+def test_maular_card_pool_exception_allows_big_offcolor_creature_only():
+    meta = RULEBREAKER_ARCHETYPES['maular_next_evolution']
+    active = [meta]
+    big_black_creature = {'type': 'Creature — Zombie', 'manaValue': 7, 'colorIdentity': ['B']}
+    small_black_creature = {'type': 'Creature — Zombie', 'manaValue': 3, 'colorIdentity': ['B']}
+    assert card_pool_exception(big_black_creature, active) is True
+    assert card_pool_exception(small_black_creature, active) is False
+    # Maular's basic_lands_scope is 'any': all 5 basics stay eligible.
+    assert bu.resolve_basic_lands_scope(SimpleNamespace(active_rulebreakers=active)) == 'any'
+
+
+def test_tolabow_card_pool_exception_offcolor_instant_only_with_extra_color():
+    meta = RULEBREAKER_ARCHETYPES['tolabow_loch_rascal']
+    active = [meta]
+    offcolor_instant = {'type': 'Instant', 'colorIdentity': ['R']}
+    offcolor_creature = {'type': 'Creature — Goblin', 'colorIdentity': ['R']}
+    assert card_pool_exception(offcolor_instant, active, extra_color='R') is True
+    assert card_pool_exception(offcolor_creature, active, extra_color='R') is False
+    # No extra color chosen: the off-color instant is no longer legal either.
+    assert card_pool_exception(offcolor_instant, active, extra_color=None) is False
+    # Tolabow's basic_lands_scope is 'any': all 5 basics stay eligible.
+    assert bu.resolve_basic_lands_scope(SimpleNamespace(active_rulebreakers=active)) == 'any'
+
+
+def test_whtz_card_pool_exception_never_bypasses_strict_color_identity():
+    meta = RULEBREAKER_ARCHETYPES['whtz_the_bibliophile']
+    active = [meta]
+    offcolor_creature = {'type': 'Creature — Dragon', 'manaValue': 5, 'colorIdentity': ['B']}
+    offcolor_land = {'type': 'Land', 'colorIdentity': []}
+    # no_max_deck_size only affects deck size, never the card-pool filter.
+    assert card_pool_exception(offcolor_creature, active) is False
+    assert card_pool_exception(offcolor_land, active) is False
+    assert bu.resolve_basic_lands_scope(SimpleNamespace(active_rulebreakers=active)) == 'strict'
+
+
+def test_grizzlegom_card_pool_exception_allows_offcolor_nonbasic_land():
+    meta = RULEBREAKER_ARCHETYPES['grizzlegom_hurloon_hero']
+    active = [meta]
+    offcolor_utility_land = {'type': 'Land', 'colorIdentity': ['U']}
+    offcolor_creature = {'type': 'Creature — Sphinx', 'colorIdentity': ['U']}
+    assert card_pool_exception(offcolor_utility_land, active) is True
+    assert card_pool_exception(offcolor_creature, active) is False
+    # Grizzlegom's basic_lands_scope is 'any_land': the superset scope.
+    assert bu.resolve_basic_lands_scope(SimpleNamespace(active_rulebreakers=active)) == 'any_land'

--- a/code/web/app.py
+++ b/code/web/app.py
@@ -2448,6 +2448,25 @@ async def setup_status():
                         data["log_tail"] = "".join(tail_lines).strip()
             except Exception:
                 pass
+            # Roadmap 35 Milestone 9: surface any unregistered Rulebreaker
+            # candidates found by the last tagging run (local-only alert path).
+            try:
+                candidates_path = Path("logs/rulebreaker_candidates.json")
+                if candidates_path.exists():
+                    with candidates_path.open("r", encoding="utf-8") as cf:
+                        candidates = _json.load(cf)
+                    if candidates:
+                        from tagging.rulebreaker_report import build_candidate_issue_body, lookup_existing_issue
+                        rendered = []
+                        for c in candidates:
+                            rendered.append({
+                                **c,
+                                "issue_body": build_candidate_issue_body(c),
+                                "existing_issue_url": lookup_existing_issue(c.get("name", "")),
+                            })
+                        data["rulebreaker_candidates"] = rendered
+            except Exception:
+                pass
             return JSONResponse(data)
         return JSONResponse({"running": False, "phase": "idle"})
     except Exception:

--- a/code/web/routes/api_v1/auth.py
+++ b/code/web/routes/api_v1/auth.py
@@ -20,8 +20,13 @@ from code.type_definitions import User
 from ...services.auth import check_and_record_rate_limit
 from ...services.user_db import verify_api_key
 
-# 60 req/min per API key, per the roadmap's Rate Limiting contract.
-_RATE_LIMIT_MAX = 60
+# Per-API-key rate limit. Deliberately generous: a single active build's
+# status polling alone (mobile app polls GET /builds/{id} every 2s = 30
+# req/min) needs to coexist with everything else a session does (guided-mode
+# advance/alternatives/replace calls, browsing commanders/cards, multiple
+# builds). 60/min left almost no headroom and caused builds to appear to
+# silently stall once a session's cumulative requests crossed that budget.
+_RATE_LIMIT_MAX = 240
 _RATE_LIMIT_WINDOW_S = 60
 
 # auto_error=False so we control the error shape (our {ok:false,...} envelope

--- a/code/web/routes/api_v1/builds.py
+++ b/code/web/routes/api_v1/builds.py
@@ -86,6 +86,11 @@ class CreateBuildRequest(BaseModel):
     partner_enabled: bool = False
     secondary_commander: Optional[str] = None
     background: Optional[str] = None
+    # Rulebreaker Commanders (Roadmap 35, Milestone 7): optional inputs for
+    # the two mechanics that need them (Tolabow's extra color, Whtz's target
+    # deck size). Ignored server-side for any other commander.
+    rulebreaker_extra_color: Optional[str] = None
+    rulebreaker_target_deck_size: Optional[int] = None
 
 
 class ReplaceCardRequest(BaseModel):
@@ -117,8 +122,13 @@ class ManualSetCountRequest(BaseModel):
 
 
 def _default_bracket() -> int:
+    # Match the web UI's "Build a New Deck" default (bracket 4/Optimized).
+    # NOT opts[0]["level"] -- that's bracket 1 (Exhibition, 0 Game Changers
+    # allowed), which gates/stalls almost any build via compliance FAIL the
+    # moment the deck-building algorithm adds a single Game Changer card.
     opts = orch.bracket_options()
-    return int(opts[0]["level"]) if opts else 1
+    levels = {int(o["level"]) for o in opts} if opts else set()
+    return 4 if 4 in levels else (int(opts[0]["level"]) if opts else 1)
 
 
 def _status_payload(build: Dict[str, Any]) -> Dict[str, Any]:
@@ -182,6 +192,11 @@ async def create_build(body: CreateBuildRequest, request: Request, user: User = 
         return err("commander is required.", "INVALID_COMMANDER", 400, _rid(request))
     if body.mode not in ("auto", "guided", "manual"):
         return err("mode must be 'auto', 'guided', or 'manual'.", "INVALID_MODE", 400, _rid(request))
+    rulebreaker_extra_color = (body.rulebreaker_extra_color or "").strip().upper() or None
+    if rulebreaker_extra_color is not None and rulebreaker_extra_color not in {"W", "U", "B", "R", "G"}:
+        return err("rulebreaker_extra_color must be one of W, U, B, R, G.", "INVALID_RULEBREAKER_COLOR", 400, _rid(request))
+    if body.rulebreaker_target_deck_size is not None and body.rulebreaker_target_deck_size < 100:
+        return err("rulebreaker_target_deck_size must be at least 100.", "INVALID_RULEBREAKER_DECK_SIZE", 400, _rid(request))
     bracket = body.bracket if body.bracket is not None else _default_bracket()
 
     deck_dir = str(_deck_dir(str(user["id"])))
@@ -209,6 +224,8 @@ async def create_build(body: CreateBuildRequest, request: Request, user: User = 
             "secondary_commander": body.secondary_commander,
             "background": body.background,
             "partner_enabled": bool(body.partner_enabled),
+            "rulebreaker_extra_color": rulebreaker_extra_color,
+            "rulebreaker_target_deck_size": body.rulebreaker_target_deck_size,
         }
         build_id = build_store.create_build(user["id"], body.model_dump())
         build_store.set_ctx(build_id, sess)
@@ -222,6 +239,11 @@ async def create_build(body: CreateBuildRequest, request: Request, user: User = 
     owned_names_list = owned_names_helper() if (body.owned_only or body.prefer_owned) else None
 
     ideals = orch.ideal_defaults()
+    # Whtz (no_max_deck_size): the web UI pre-scales ideal_counts client-side
+    # before submitting, but the mobile app / API clients don't -- scale the
+    # defaults here so an oversized deck isn't stuck with 100-card targets.
+    if body.rulebreaker_target_deck_size and body.rulebreaker_target_deck_size > 100:
+        ideals = bu.scale_ideal_counts_for_deck_size(ideals, body.rulebreaker_target_deck_size)
     if body.ideal_counts:
         ideals.update({k: int(v) for k, v in body.ideal_counts.items()})
     for key in ("creatures_min", "creatures_max", "on_theme_creatures"):
@@ -249,6 +271,8 @@ async def create_build(body: CreateBuildRequest, request: Request, user: User = 
             background_commander=body.background,
             creature_builder_mode=body.creature_builder_mode,
             creature_tolerance=body.creature_tolerance,
+            rulebreaker_extra_color=rulebreaker_extra_color,
+            rulebreaker_target_deck_size=body.rulebreaker_target_deck_size,
         )
     except ValueError as exc:
         return err(str(exc), "INVALID_BUILD_REQUEST", 400, _rid(request))
@@ -331,11 +355,20 @@ async def get_multi_copy_options(
 
 
 @router.get("/ideal-defaults", summary="Get default ideal counts")
-async def get_ideal_defaults(request: Request, user: User = Depends(get_api_user)):
+async def get_ideal_defaults(
+    request: Request,
+    rulebreaker_target_deck_size: Optional[int] = None,
+    user: User = Depends(get_api_user),
+):
     """Server-side defaults for the `ideal_counts` field of `POST /builds`
     (ramp, lands, basic_lands, creatures_min, creatures_max, on_theme_creatures,
     creature_tolerance_pct, removal, wipes, card_advantage, protection). Use
     these to pre-fill an editable form.
+
+    Pass `rulebreaker_target_deck_size` (Whtz, >100) to get defaults scaled
+    for that deck size instead of the flat 100-card baseline (mirrors the
+    web UI's client-side scaling, for clients like the mobile app that don't
+    reimplement that formula themselves).
     """
     # 'creatures' is a legacy read/write alias for 'creatures_max' (roadmap 33)
     # still accepted/returned by POST/GET build endpoints; dropped here so
@@ -345,6 +378,8 @@ async def get_ideal_defaults(request: Request, user: User = Depends(get_api_user
     labels = orch.ideal_labels()
     defaults.pop("creatures", None)
     labels.pop("creatures", None)
+    if rulebreaker_target_deck_size and rulebreaker_target_deck_size > 100:
+        defaults = bu.scale_ideal_counts_for_deck_size(defaults, rulebreaker_target_deck_size)
     return ok({"defaults": defaults, "labels": labels}, _rid(request))
 
 
@@ -868,6 +903,10 @@ def _manual_deck_state(sess: Dict[str, Any]) -> Dict[str, Any]:
         "deck": manual_builder_service.deck_panel_data(sess),
         "role_bar": manual_builder_service.role_bar_data(sess),
         "compliance": manual_builder_service.manual_compliance_report(sess),
+        # Tolabow's chosen extra color, if any, so a generic client (mobile)
+        # can display it -- the web template reads this straight off the
+        # session instead, via manual_session_state().
+        "rulebreaker_extra_color": sess.get("rulebreaker_extra_color"),
         **manual_builder_service.mana_overview_data(sess),
     }
 

--- a/code/web/routes/api_v1/commanders.py
+++ b/code/web/routes/api_v1/commanders.py
@@ -12,6 +12,7 @@ from typing import Any, Dict
 from fastapi import APIRouter, Query, Request
 from fastapi.encoders import jsonable_encoder
 
+from code.deck_builder import builder_constants as bc
 from ...services.commander_catalog_loader import (
     CommanderRecord,
     find_commander_record,
@@ -44,6 +45,18 @@ def _serialize_commander(record: CommanderRecord, *, full: bool = False) -> Dict
         "is_background": record.is_background,
     }
     if full:
+        # Rulebreaker Commanders (Roadmap 35, Milestone 7): expose archetype
+        # metadata so mobile can show the same optional color picker / deck
+        # size field the web UI shows, without hardcoding card names client-side.
+        rulebreaker_id = bc.RULEBREAKER_NAMES.get(record.display_name)
+        rulebreaker = bc.RULEBREAKER_ARCHETYPES.get(rulebreaker_id) if rulebreaker_id else None
+        data.update(
+            {
+                "is_rulebreaker": rulebreaker is not None,
+                "rulebreaker_rule_type": rulebreaker.get("rule_type") if rulebreaker else None,
+                "rulebreaker_no_max_deck_size": bool(rulebreaker.get("no_max_deck_size")) if rulebreaker else False,
+            }
+        )
         data.update(
             {
                 "oracle_text": record.oracle_text,

--- a/code/web/routes/build_multicopy.py
+++ b/code/web/routes/build_multicopy.py
@@ -42,7 +42,10 @@ def _rebuild_ctx_with_multicopy(sess: dict) -> None:
             return
         # Build fresh ctx with the same options, threading multi_copy explicitly
         opts = orch.bracket_options()
-        default_bracket = (opts[0]["level"] if opts else 1)
+        levels = {int(o["level"]) for o in opts} if opts else set()
+        # Match the web "Build a New Deck" default (bracket 4/Optimized), not
+        # opts[0] (bracket 1/Exhibition, 0 Game Changers allowed).
+        default_bracket = 4 if 4 in levels else (opts[0]["level"] if opts else 1)
         bracket_val = sess.get("bracket")
         try:
             safe_bracket = int(bracket_val) if bracket_val is not None else default_bracket

--- a/code/web/routes/build_newflow.py
+++ b/code/web/routes/build_newflow.py
@@ -271,6 +271,8 @@ async def build_new_inspect(request: Request, name: str = Query(...)) -> HTMLRes
         is_gc = False
     sid = request.cookies.get("sid") or new_sid()
     sess = get_session(sid)
+    rulebreaker_id = bc.RULEBREAKER_NAMES.get(info["name"])
+    active_rulebreaker = bc.RULEBREAKER_ARCHETYPES.get(rulebreaker_id) if rulebreaker_id else None
     ctx = {
         "request": request,
         "commander": {"name": info["name"], "exclusion": exclusion_detail},
@@ -285,6 +287,9 @@ async def build_new_inspect(request: Request, name: str = Query(...)) -> HTMLRes
         "printings": dict(sess.get("printings") or {}),
         "foils": dict(sess.get("foils") or {}),
         "brackets": orch.bracket_options(),
+        "active_rulebreaker": active_rulebreaker,
+        "rulebreaker_extra_color": sess.get("rulebreaker_extra_color"),
+        "rulebreaker_target_deck_size": sess.get("rulebreaker_target_deck_size"),
     }
     
     ctx.update(
@@ -503,6 +508,9 @@ async def build_new_submit(
     build_count: int = Form(1),
     # Quick Build flag
     quick_build: str | None = Form(None),
+    # Rulebreaker Commanders (Roadmap 35)
+    rulebreaker_extra_color: str | None = Form(None),
+    rulebreaker_target_deck_size: int | None = Form(None),
     # "manual" (roadmap_25) skips the auto-build pipeline entirely and redirects
     # to the manual deck builder view instead. Absent/anything else -> auto.
     mode: str | None = Form(None),
@@ -556,6 +564,8 @@ async def build_new_submit(
             "card_ceiling": card_ceiling,
             "pool_tolerance": pool_tolerance if pool_tolerance is not None else "15",
             "creature_builder_mode": "legacy" if creature_builder_mode == "legacy" else "modern",
+            "rulebreaker_extra_color": (rulebreaker_extra_color or "").strip().upper(),
+            "rulebreaker_target_deck_size": rulebreaker_target_deck_size,
         }
 
     commander_detail = lookup_commander_detail(commander)
@@ -639,6 +649,8 @@ async def build_new_submit(
             bracket = 3
     # Save to session
     sess["commander"] = primary_commander_name
+    sess["rulebreaker_extra_color"] = (rulebreaker_extra_color or "").strip().upper() or None
+    sess["rulebreaker_target_deck_size"] = max(100, int(rulebreaker_target_deck_size)) if rulebreaker_target_deck_size else None
     (
         partner_error,
         combined_payload,
@@ -819,13 +831,13 @@ async def build_new_submit(
     sess["tags"] = tags
     sess["tag_mode"] = (tag_mode or "AND").upper()
     try:
-        # Default to bracket 3 (Upgraded) when not provided
-        sess["bracket"] = int(bracket) if (bracket is not None) else 3
+        # Default to bracket 4 (Optimized) when not provided
+        sess["bracket"] = int(bracket) if (bracket is not None) else 4
     except Exception:
         try:
             sess["bracket"] = int(bracket)
         except Exception:
-            sess["bracket"] = 3
+            sess["bracket"] = 4
     # Ideals: use provided values if any, else defaults
     ideals = orch.ideal_defaults()
     overrides = {k: v for k, v in {
@@ -1143,7 +1155,7 @@ async def build_new_submit(
             "commander": sess.get("commander"),
             "tags": sess.get("tags", []),
             "tag_mode": sess.get("tag_mode", "AND"),
-            "bracket": sess.get("bracket", 3),
+            "bracket": sess.get("bracket", 4),
             "ideals": sess.get("ideals", {}),
             "prefer_combos": sess.get("prefer_combos", False),
             "combo_target_count": sess.get("combo_target_count"),

--- a/code/web/routes/manual_builder.py
+++ b/code/web/routes/manual_builder.py
@@ -290,11 +290,12 @@ async def manual_builder_save(request: Request, session_id: str) -> RedirectResp
         return templates.TemplateResponse("decks/_manual_deck_update.html", ctx, status_code=500)
 
     card_count = sum(manual_builder_service.deck_card_counts(sess).values()) + (1 if sess.get("commander") else 0)
+    deck_size_target = manual_builder_service.deck_panel_data(sess)["deck_size_target"]
     url = f"/decks/view?name={csv_name}"
-    if card_count != 100:
+    if card_count != deck_size_target:
         from urllib.parse import quote
 
-        url += f"&notice={quote(f'Deck has {card_count} cards (expected 100).')}"
+        url += f"&notice={quote(f'Deck has {card_count} cards (expected {deck_size_target}).')}"
     return RedirectResponse(url=url, status_code=303)
 
 

--- a/code/web/services/build_utils.py
+++ b/code/web/services/build_utils.py
@@ -57,6 +57,8 @@ def step5_base_ctx(request: Request, sess: dict, *, include_name: bool = True, i
     """
     include_cards = list(sess.get("include_cards", []) or [])
     exclude_cards = list(sess.get("exclude_cards", []) or [])
+    rulebreaker_id = bc.RULEBREAKER_NAMES.get(sess.get("commander") or "")
+    rulebreaker_meta = bc.RULEBREAKER_ARCHETYPES.get(rulebreaker_id) if rulebreaker_id else None
     ctx: Dict[str, Any] = {
         "request": request,
         "commander": sess.get("commander"),
@@ -72,6 +74,9 @@ def step5_base_ctx(request: Request, sess: dict, *, include_name: bool = True, i
         "partner_warnings": list(sess.get("partner_warnings", []) or []),
         "combined_commander": sess.get("combined_commander"),
         "partner_auto_note": sess.get("partner_auto_note"),
+        "rulebreaker": rulebreaker_meta,
+        "rulebreaker_extra_color": sess.get("rulebreaker_extra_color"),
+        "rulebreaker_target_deck_size": sess.get("rulebreaker_target_deck_size") or 100,
         "owned_set": owned_set(),
         "game_changers": bc.GAME_CHANGERS,
         "replace_mode": bool(sess.get("replace_mode", True)),
@@ -156,7 +161,10 @@ def start_ctx_from_session(sess: dict, *, set_on_session: bool = True, deck_dir:
     multi-copy selection, and combo preferences from the session and starts a build context.
     """
     opts = orch.bracket_options()
-    default_bracket = (opts[0]["level"] if opts else 1)
+    levels = {int(o["level"]) for o in opts} if opts else set()
+    # Match the web "Build a New Deck" default (bracket 4/Optimized), not
+    # opts[0] (bracket 1/Exhibition, 0 Game Changers allowed).
+    default_bracket = 4 if 4 in levels else (opts[0]["level"] if opts else 1)
     bracket_val = sess.get("bracket")
     try:
         safe_bracket = int(bracket_val) if bracket_val is not None else int(default_bracket)
@@ -198,6 +206,8 @@ def start_ctx_from_session(sess: dict, *, set_on_session: bool = True, deck_dir:
         printings=dict(sess.get("printings") or {}),
         creature_builder_mode=sess.get("creature_builder_mode", "modern"),
         creature_tolerance=sess.get("creature_tolerance"),
+        rulebreaker_extra_color=sess.get("rulebreaker_extra_color"),
+        rulebreaker_target_deck_size=sess.get("rulebreaker_target_deck_size"),
     )
     if set_on_session:
         sess["build_ctx"] = ctx

--- a/code/web/services/manual_builder_service.py
+++ b/code/web/services/manual_builder_service.py
@@ -23,6 +23,7 @@ from deck_builder.builder_utils import (
     compute_pip_density,
     fetch_land_allowed_for_colors,
     parse_theme_tags,
+    rulebreaker_pip_identity,
 )
 from deck_builder.brackets_compliance import (
     banned_category_names,
@@ -193,9 +194,68 @@ def resolve_color_identity(
     return [c.upper() for c in raw_ci if c.isalpha()]
 
 
+def _active_rulebreakers(sess: Dict[str, Any]) -> List[dict]:
+    """Return active Rulebreaker archetype entries (`bc.RULEBREAKER_ARCHETYPES`)
+    for the session's commander(s), by exact case-insensitive name match.
+
+    Lightweight, name-only counterpart to
+    `deck_builder.builder_utils.detect_active_rulebreakers` (which needs a
+    full `DeckBuilder` instance) - the manual builder session only ever has
+    plain commander name strings, not a builder object.
+    """
+    names: List[str] = []
+    commander = sess.get("commander")
+    if commander:
+        names.append(str(commander))
+    if sess.get("partner_enabled"):
+        secondary = sess.get("secondary_commander")
+        if secondary:
+            names.append(str(secondary))
+    name_lookup = {meta.get("name", "").casefold(): meta for meta in bc.RULEBREAKER_ARCHETYPES.values()}
+    out: List[dict] = []
+    seen_ids: set = set()
+    for name in names:
+        meta = name_lookup.get(name.strip().casefold())
+        if meta and meta.get("id") not in seen_ids:
+            out.append(dict(meta))
+            seen_ids.add(meta.get("id"))
+    return out
+
+
+_BASIC_LANDS_SCOPE_RANK = {"any_land": 2, "any": 1, "strict": 0}
+
+
+def _resolve_basic_lands_scope(active_rulebreakers: List[dict]) -> str:
+    """Return the least-restrictive `basic_lands_scope` among active Rulebreakers
+    (mirrors `builder_utils.resolve_basic_lands_scope`, without needing a builder)."""
+    best = "strict"
+    for meta in active_rulebreakers:
+        scope = meta.get("basic_lands_scope", "strict")
+        if _BASIC_LANDS_SCOPE_RANK.get(scope, 0) > _BASIC_LANDS_SCOPE_RANK.get(best, 0):
+            best = scope
+    return best
+
+
+def _effective_deck_size(sess: Dict[str, Any], active_rulebreakers: List[dict]) -> int:
+    """Total deck size target (including the commander), mirroring
+    `builder_utils.effective_deck_size`: 100 unless a `no_max_deck_size`
+    Rulebreaker (Whtz) is active and a valid `rulebreaker_target_deck_size`
+    (>=100) has been set in the session, in which case that target is used."""
+    default = bc.DECK_NON_COMMANDER_SLOTS + 1
+    if not any(meta.get("no_max_deck_size") for meta in active_rulebreakers):
+        return default
+    target = sess.get("rulebreaker_target_deck_size")
+    try:
+        target = int(target) if target is not None else default
+    except (TypeError, ValueError):
+        target = default
+    return target if target >= default else default
+
+
 def manual_session_state(sess: Dict[str, Any]) -> Dict[str, Any]:
     """Extract the manual-build session contract fields (roadmap_25 Key Contracts)."""
     budget_config = sess.get("budget_config") or {}
+    active_rulebreakers = _active_rulebreakers(sess)
     return {
         "mode": sess.get("mode"),
         "commander": sess.get("commander"),
@@ -206,6 +266,9 @@ def manual_session_state(sess: Dict[str, Any]) -> Dict[str, Any]:
         "bracket": sess.get("bracket"),
         "deck_cards": list(sess.get("deck_cards") or []),
         "edit_source_name": sess.get("edit_source_name"),
+        "rulebreaker": active_rulebreakers[0] if active_rulebreakers else None,
+        "rulebreaker_extra_color": sess.get("rulebreaker_extra_color"),
+        "rulebreaker_target_deck_size": sess.get("rulebreaker_target_deck_size") or 100,
     }
 
 
@@ -458,7 +521,20 @@ def get_card_pool(sess: Dict[str, Any]) -> pd.DataFrame:
     bracket = str(sess.get("bracket") or 2)
 
     df = _get_loader().load()
-    mask = df["colorIdentity"].apply(lambda c: _color_identity_subset(c, identity))
+    active_rulebreakers = _active_rulebreakers(sess)
+    if active_rulebreakers:
+        from deck_builder.rulebreaker_rules import card_pool_exception
+
+        extra_color = (sess.get("rulebreaker_extra_color") or None)
+
+        def _identity_ok(row: Any) -> bool:
+            if _color_identity_subset(row.get("colorIdentity"), identity):
+                return True
+            return card_pool_exception(row, active_rulebreakers, extra_color)
+
+        mask = df.apply(_identity_ok, axis=1)
+    else:
+        mask = df["colorIdentity"].apply(lambda c: _color_identity_subset(c, identity))
     pool = df[mask].copy()
     if commander:
         pool = pool[pool["name"].astype(str) != str(commander)]
@@ -1056,7 +1132,24 @@ def add_land_package(sess: Dict[str, Any]) -> Dict[str, Any]:
 
     ideals = sess.get("ideals") or {}
     basic_target = max(0, int(ideals.get("basic_lands") or bc.DEFAULT_BASIC_LAND_COUNT))
-    identity = [c for c in ["W", "U", "B", "R", "G"] if c in (sess.get("color_identity") or [])]
+    active_rulebreakers = _active_rulebreakers(sess)
+    extra_color_rule = next(
+        (m for m in active_rulebreakers if m.get("rule_type") == "instant_sorcery_extra_color"), None
+    )
+    if extra_color_rule is not None:
+        # Tolabow's exception only grants ONE extra color for instants/sorceries,
+        # so a full 5-color basic split is impractical even though its
+        # basic_lands_scope technically allows any basic land. Restrict the
+        # default package to the commander's own color(s) plus that one
+        # chosen extra color (or just the commander's colors if none chosen).
+        extra_color = (sess.get("rulebreaker_extra_color") or "").strip().upper()
+        identity = [c for c in ["W", "U", "B", "R", "G"] if c in (sess.get("color_identity") or [])]
+        if extra_color and extra_color not in identity:
+            identity.append(extra_color)
+    elif _resolve_basic_lands_scope(active_rulebreakers) in ("any", "any_land"):
+        identity = ["W", "U", "B", "R", "G"]
+    else:
+        identity = [c for c in ["W", "U", "B", "R", "G"] if c in (sess.get("color_identity") or [])]
     if not identity:
         identity = ["C"]
     base_count, remainder = divmod(basic_target, len(identity))
@@ -1119,8 +1212,9 @@ def deck_panel_data(sess: Dict[str, Any]) -> Dict[str, Any]:
         {"role": _DECK_TYPE_LABELS[t], "cards": groups[t]} for t in _DECK_TYPE_ORDER if groups.get(t)
     ]
     total_cards = sum(counts.values())
-    # +1 for the commander's own slot (never part of deck_cards itself).
-    deck_size_target = bc.DECK_NON_COMMANDER_SLOTS + 1
+    # +1 for the commander's own slot (never part of deck_cards itself);
+    # relaxed to rulebreaker_target_deck_size when Whtz's no_max_deck_size is active.
+    deck_size_target = _effective_deck_size(sess, _active_rulebreakers(sess))
     return {
         "groups": ordered_groups,
         "total_cards": total_cards,
@@ -1175,8 +1269,16 @@ def _mana_pip_and_source_summary(sess: Dict[str, Any]) -> Dict[str, Any]:
     """
     color_identity = [c for c in ("W", "U", "B", "R", "G") if c in (sess.get("color_identity") or [])]
     card_library, _rows = _mana_card_library(sess)
+    # Rulebreaker Commanders: Tolabow's off-color Instants/Sorceries (a fixed
+    # rulebreaker_extra_color) and type-based exceptions like Seluma's Angels
+    # or Grizzlegom's basics (any color) both need to be included here, or
+    # their pips/sources get zeroed out as "outside identity" despite being legal.
+    extra_color = sess.get("rulebreaker_extra_color")
+    pip_identity = rulebreaker_pip_identity(
+        card_library, color_identity, _active_rulebreakers(sess), extra_color
+    )
 
-    pip_density = compute_pip_density(card_library, color_identity)
+    pip_density = compute_pip_density(card_library, pip_identity)
     pip_counts: Dict[str, float] = {}
     for c in ("W", "U", "B", "R", "G"):
         d = pip_density[c]
@@ -1204,16 +1306,16 @@ def _mana_pip_and_source_summary(sess: Dict[str, Any]) -> Dict[str, Any]:
             for c in colors_for_card:
                 pip_cards[c].append({"name": name, "count": cnt})
     total_pips = sum(pip_counts.values())
-    if total_pips <= 0 and color_identity:
-        share = 1 / len(color_identity)
-        for c in color_identity:
+    if total_pips <= 0 and pip_identity:
+        share = 1 / len(pip_identity)
+        for c in pip_identity:
             pip_counts[c] = share
         total_pips = 1.0
     pip_weights = {c: (pip_counts[c] / total_pips if total_pips else 0.0) for c in pip_counts}
 
     full_df = _get_loader().load()
     scoped_df = full_df[full_df["name"].astype(str).isin(card_library.keys())]
-    matrix = compute_color_source_matrix(card_library, scoped_df)
+    matrix = compute_color_source_matrix(card_library, scoped_df, color_identity)
     source_counts: Dict[str, int] = {c: 0 for c in ("W", "U", "B", "R", "G", "C")}
     source_cards: Dict[str, List[Dict[str, Any]]] = {c: [] for c in ("W", "U", "B", "R", "G", "C")}
     for name, flags in matrix.items():
@@ -1239,35 +1341,48 @@ def mana_overview_data(sess: Dict[str, Any]) -> Dict[str, Any]:
     """
     color_identity = [c for c in ["W", "U", "B", "R", "G"] if c in (sess.get("color_identity") or [])]
     card_library, rows = _mana_card_library(sess)
+    # Rulebreaker Commanders: Tolabow's off-color Instants/Sorceries (a fixed
+    # rulebreaker_extra_color) and type-based exceptions like Seluma's Angels
+    # or Grizzlegom's basics (any color) both need to be included here, or
+    # their pips/sources get zeroed out as "outside identity" despite being legal.
+    extra_color = sess.get("rulebreaker_extra_color")
+    pip_identity = rulebreaker_pip_identity(
+        card_library, color_identity, _active_rulebreakers(sess), extra_color
+    )
 
-    pip_density = compute_pip_density(card_library, color_identity)
+    pip_density = compute_pip_density(card_library, pip_identity)
     pip_counts: Dict[str, float] = {}
     for c in ("W", "U", "B", "R", "G"):
         d = pip_density[c]
         pip_counts[c] = float(d["single"] + d["double"] * 2 + d["triple"] * 3 + d["phyrexian"])
     total_pips = sum(pip_counts.values())
-    if total_pips <= 0 and color_identity:
-        share = 100.0 / len(color_identity)
-        pips = [{"color": c, "count": 0, "pct": int(share) if c in color_identity else 0} for c in color_identity]
+    if total_pips <= 0 and pip_identity:
+        share = 100.0 / len(pip_identity)
+        pips = [{"color": c, "count": 0, "pct": int(share)} for c in pip_identity]
     else:
         pips = [
             {"color": c, "count": pip_counts.get(c, 0.0), "pct": int(round(pip_counts.get(c, 0.0) * 100 / total_pips))}
-            for c in color_identity
-        ] if total_pips else [{"color": c, "count": 0, "pct": 0} for c in color_identity]
+            for c in pip_identity
+        ] if total_pips else [{"color": c, "count": 0, "pct": 0} for c in pip_identity]
 
     full_df = _get_loader().load()
     # compute_color_source_matrix() does a full-table iterrows() to build its
     # name lookup -- scope it to just this deck's cards (a handful of rows)
     # instead of all ~32k cards, since this runs on every add/remove.
     scoped_df = full_df[full_df["name"].astype(str).isin(card_library.keys())]
-    matrix = compute_color_source_matrix(card_library, scoped_df)
+    matrix = compute_color_source_matrix(card_library, scoped_df, color_identity)
     source_counts = {c: 0 for c in ("W", "U", "B", "R", "G", "C")}
     for name, flags in matrix.items():
         copies = card_library.get(name, {}).get("Count", 1)
         for c in source_counts:
             if int(flags.get(c, 0)):
                 source_counts[c] += copies
-    source_colors = list(color_identity)
+    # Sources aren't limited to pip_identity: a Rulebreaker with an "any
+    # basic land" exception (Seluma, Grizzlegom, etc.) can have actual mana
+    # sources for a color with zero spell pips (e.g. lands added ahead of
+    # the matching off-color spells), so show any color that's actually
+    # producing mana, not just the ones with pips so far.
+    source_colors = [c for c in ("W", "U", "B", "R", "G") if c in pip_identity or source_counts.get(c, 0) > 0]
     if source_counts.get("C", 0) > 0:
         source_colors.append("C")
     max_source = max((source_counts.get(c, 0) for c in source_colors), default=0)
@@ -1373,13 +1488,28 @@ ROLE_BAR_LABELS: Dict[str, str] = {
     "Land": "Lands",
 }
 
+# Maps a role bar row to the matching key in sess["ideals"], which (via the
+# live deck-size-aware sliders in _new_deck_ideals.html) holds the real target
+# counts for the chosen deck size, not just the 100-card baseline defaults.
+ROLE_BAR_IDEAL_KEYS: Dict[str, str] = {
+    "Ramp": "ramp",
+    "Removal": "removal",
+    "Card Draw": "card_advantage",
+    "Protection": "protection",
+    "Board Wipe": "wipes",
+    "Land": "lands",
+}
+
 
 def _role_bar_status(role: str, actual: int, target: int) -> str:
     if role == "Land":
-        # Roadmap 25 M5: lands use fixed thresholds independent of the target.
-        if actual < 33:
+        # Roadmap 25 M5 baseline: red below 33, yellow up to 35, at a 35-land
+        # target. Scaled proportionally so oversized (Whtz) decks aren't stuck
+        # comparing against a fixed 100-card-baseline threshold.
+        red_ceiling = round(target * (33 / 35)) if target else 33
+        if actual < red_ceiling:
             return "red"
-        if actual <= 35:
+        if actual <= target:
             return "yellow"
         return "green"
     if actual >= target:
@@ -1391,6 +1521,7 @@ def _role_bar_status(role: str, actual: int, target: int) -> str:
 
 def role_bar_data(sess: Dict[str, Any]) -> Dict[str, Any]:
     """Live role counts vs. targets for the role health bar."""
+    ideals = sess.get("ideals") or {}
     counts = deck_card_counts(sess)
     rows = _lookup_card_rows(sess, list(counts.keys()))
     role_totals: Dict[str, int] = {r: 0 for r in ROLE_BAR_TARGETS}
@@ -1402,7 +1533,12 @@ def role_bar_data(sess: Dict[str, Any]) -> Dict[str, Any]:
 
     pills: List[Dict[str, Any]] = []
     warnings: List[str] = []
-    for role, target in ROLE_BAR_TARGETS.items():
+    for role, default_target in ROLE_BAR_TARGETS.items():
+        ideal_key = ROLE_BAR_IDEAL_KEYS.get(role)
+        try:
+            target = int(ideals[ideal_key]) if ideal_key and ideal_key in ideals else default_target
+        except (TypeError, ValueError):
+            target = default_target
         actual = role_totals[role]
         status = _role_bar_status(role, actual, target)
         label = ROLE_BAR_LABELS[role]
@@ -1512,6 +1648,22 @@ def _build_deck_rows(sess: Dict[str, Any]) -> List[Dict[str, Any]]:
     return rows
 
 
+def _rulebreaker_header_suffix(sess: Dict[str, Any]) -> List[str]:
+    """Extra "Rulebreaker: ..." export header lines, matching
+    `DeckBuilder`'s auto-build CSV/TXT export (`phase6_reporting.py`)."""
+    active_rulebreakers = _active_rulebreakers(sess)
+    if not active_rulebreakers:
+        return []
+    out = [f"Rulebreaker: {', '.join(m.get('name', '') for m in active_rulebreakers)}"]
+    extra_color = sess.get("rulebreaker_extra_color")
+    if extra_color:
+        out.append(f"Rulebreaker Extra Color: {extra_color}")
+    target_size = sess.get("rulebreaker_target_deck_size")
+    if target_size and int(target_size) > 100:
+        out.append(f"Rulebreaker Deck Size: {target_size}")
+    return out
+
+
 def build_deck_csv_text(sess: Dict[str, Any]) -> str:
     """Render the current session deck as CSV text (built-deck schema)."""
     import io
@@ -1521,7 +1673,7 @@ def build_deck_csv_text(sess: Dict[str, Any]) -> str:
     commander = sess.get("commander") or ""
     buf = io.StringIO()
     writer = _csv.writer(buf)
-    writer.writerow(_CSV_HEADERS + [f"Commanders: {commander}"])
+    writer.writerow(_CSV_HEADERS + [f"Commanders: {commander}"] + _rulebreaker_header_suffix(sess))
     for r in rows:
         if r["is_commander"]:
             role = "commander"
@@ -1544,7 +1696,7 @@ def build_deck_txt_text(sess: Dict[str, Any]) -> str:
     """Render the current session deck as plain text (one line per card)."""
     rows = _build_deck_rows(sess)
     commander = sess.get("commander") or ""
-    lines = [f"# Commanders: {commander}", ""]
+    lines = [f"# Commanders: {commander}"] + [f"# {s}" for s in _rulebreaker_header_suffix(sess)] + [""]
     for r in rows:
         lines.append(f"{r['count']} {r['name']}")
     return "\n".join(lines) + "\n"

--- a/code/web/services/multi_build_orchestrator.py
+++ b/code/web/services/multi_build_orchestrator.py
@@ -134,7 +134,7 @@ class MultiBuildOrchestrator:
             "commander": config.get("commander"),
             "tags": config.get("tags", []),
             "tag_mode": config.get("tag_mode", "AND"),
-            "bracket": config.get("bracket", 3),
+            "bracket": config.get("bracket", 4),
             "ideals": config.get("ideals", {}),
             "prefer_combos": config.get("prefer_combos", False),
             "combo_target_count": config.get("combo_target_count"),

--- a/code/web/services/orchestrator.py
+++ b/code/web/services/orchestrator.py
@@ -2623,6 +2623,8 @@ def start_build_ctx(
     printings: Dict[str, str] | None = None,
     creature_builder_mode: str | None = None,
     creature_tolerance: float | None = None,
+    rulebreaker_extra_color: str | None = None,
+    rulebreaker_target_deck_size: int | None = None,
 ) -> Dict[str, Any]:
     logs: List[str] = []
 
@@ -2737,6 +2739,15 @@ def start_build_ctx(
     except Exception:
         pass
 
+    # Rulebreaker Commanders (Roadmap 35, Milestone 5): apply before color
+    # identity/card-pool logic runs.
+    try:
+        b.rulebreaker_extra_color = (str(rulebreaker_extra_color).strip().upper() or None) if rulebreaker_extra_color else None
+        if rulebreaker_target_deck_size is not None:
+            b.rulebreaker_target_deck_size = max(100, int(rulebreaker_target_deck_size))
+    except Exception:
+        pass
+
     # Data load
     b.determine_color_identity()
     b.setup_dataframes()
@@ -2806,6 +2817,13 @@ def start_build_ctx(
         b.run_land_analysis()
     except Exception:
         pass
+    # Rulebreaker Commanders (Roadmap 35, Milestone 4): ideal counts are now
+    # scaled live in the web UI (see _new_deck_ideals.html) before submission,
+    # so `ideals` already reflects Whtz's chosen deck size here. No backend
+    # re-scale is applied for web builds (that would double-scale on top of
+    # the client-computed values); the CLI/headless path in
+    # builder.py::run_deck_build_step2() still applies
+    # scale_ideal_counts_for_deck_size() since it has no client UI to pre-scale from.
     stages = _make_stages(b)
     ctx = {
         "builder": b,
@@ -3513,7 +3531,9 @@ def run_stage(ctx: Dict[str, Any], rerun: bool = False, show_skipped: bool = Fal
         except Exception:
             total_cards = None
         try:
-            overflow = max(0, int(total_cards) - 100)
+            from deck_builder import builder_utils as _bu
+            deck_size_target = _bu.effective_deck_size(b)
+            overflow = max(0, int(total_cards) - deck_size_target)
             if overflow > 0 and added_cards:
                 # Trim from added cards without reducing below pre-stage counts; skip locked names
                 remaining = overflow
@@ -3553,7 +3573,7 @@ def run_stage(ctx: Dict[str, Any], rerun: bool = False, show_skipped: bool = Fal
                 added_cards = [x for x in added_cards if int(x.get('count', 0) or 0) > 0]
                 if clamped_overflow > 0:
                     try:
-                        logs.append(f"Clamped {clamped_overflow} card(s) from this stage to remain at 100.")
+                        logs.append(f"Clamped {clamped_overflow} card(s) from this stage to remain at {deck_size_target}.")
                     except Exception:
                         pass
         except Exception:

--- a/code/web/templates/build/_new_deck_ideals.html
+++ b/code/web/templates/build/_new_deck_ideals.html
@@ -2,6 +2,7 @@
   <legend>Ideal Counts</legend>
   <div class="muted" style="font-size:12px; margin-bottom:0.75rem;">
     Sliders start at recommended defaults. Adjust as needed for your deck strategy.
+    For Rulebreaker commanders with no deck-size maximum (e.g., Whtz), these defaults update automatically to match your chosen deck size, and stay adjustable after that.
     <span id="ideals-validation-warning" style="color:#f59e0b; display:none; margin-left:0.5rem;"></span>
   </div>
   <div class="muted" style="font-size:12px; margin-bottom:0.75rem;">
@@ -52,6 +53,9 @@
                 class="ideals-slider"
                 data-field="{{ field_name }}"
                 data-default="{{ default_val }}"
+                data-base-default="{{ default_val }}"
+                data-base-min="{{ min_val }}"
+                data-base-max="{{ max_val }}"
                 {% if field_name in legacy_disabled_fields and form and form.creature_builder_mode == 'legacy' %}disabled{% endif %}
                 style="flex:1; cursor:pointer;"
               />
@@ -72,6 +76,8 @@
               value="{{ form[field_name] if form and form[field_name] is not none else '' }}" 
               placeholder="{{ default_val }} (Default)"
               data-default="{{ default_val }}"
+              data-base-default="{{ default_val }}"
+              data-field="{{ field_name }}"
               {% if field_name in legacy_disabled_fields and form and form.creature_builder_mode == 'legacy' %}disabled{% endif %}
               style="width:100%; margin-top:0.25rem;"
             />
@@ -85,6 +91,76 @@
   </div>
   
   <script>
+    // Rulebreaker (Whtz) deck-size-aware ideal scaling: mirrors
+    // builder_utils.scale_ideal_counts_for_deck_size() so sliders can show
+    // real target numbers live, without a hidden backend re-scale at build time.
+    const DECK_SIZE_LAND_PREMIUM_K = 0.12;
+    const DECK_SIZE_LAND_PREMIUM_CAP = 0.48;
+    const IDEALS_SCALABLE_FIELDS = ['lands', 'basic_lands', 'creatures_max', 'creatures_min', 'on_theme_creatures', 'ramp', 'removal', 'wipes', 'card_advantage', 'protection'];
+    let currentTargetDeckSize = 100;
+
+    function scaledIdealDefault(baseDefault, targetSize) {
+      if (!targetSize || targetSize <= 100 || isNaN(baseDefault)) return baseDefault;
+      const ratio = targetSize / 100;
+      const premium = 1 + DECK_SIZE_LAND_PREMIUM_K * Math.log(ratio);
+      const effectivePct = Math.min((baseDefault / 100) * premium, DECK_SIZE_LAND_PREMIUM_CAP);
+      return Math.max(Math.round(baseDefault), Math.round(effectivePct * targetSize));
+    }
+
+    function scaledIdealBound(baseBound, targetSize) {
+      if (!targetSize || targetSize <= 100 || isNaN(baseBound)) return baseBound;
+      return Math.round(baseBound * (targetSize / 100));
+    }
+
+    // Always read the deck-size field directly rather than trusting the cached
+    // currentTargetDeckSize variable, so capacity checks can never go stale
+    // regardless of event ordering or how the field was last updated.
+    function getCurrentTargetDeckSize() {
+      const dsInput = document.querySelector('[name="rulebreaker_target_deck_size"]');
+      if (dsInput) {
+        const v = parseInt(dsInput.value, 10);
+        if (v && v > 0) return v;
+      }
+      return currentTargetDeckSize;
+    }
+
+    // Recompute every scalable slider/number-input's recommended default (and,
+    // for sliders, its min/max) for the given target deck size. Fields the user
+    // has already touched keep their current value; untouched fields update live.
+    function updateIdealsForDeckSize(targetSize) {
+      currentTargetDeckSize = targetSize && targetSize > 0 ? targetSize : 100;
+      document.querySelectorAll('[data-base-default]').forEach(input => {
+        const fieldName = input.dataset.field || input.getAttribute('name');
+        if (!IDEALS_SCALABLE_FIELDS.includes(fieldName)) return;
+        const baseDefault = parseFloat(input.dataset.baseDefault);
+        const newDefault = scaledIdealDefault(baseDefault, currentTargetDeckSize);
+        input.dataset.default = newDefault;
+
+        if (input.type === 'range') {
+          const baseMin = parseFloat(input.dataset.baseMin);
+          const baseMax = parseFloat(input.dataset.baseMax);
+          if (!isNaN(baseMin)) input.min = scaledIdealBound(baseMin, currentTargetDeckSize);
+          if (!isNaN(baseMax)) input.max = Math.max(scaledIdealBound(baseMax, currentTargetDeckSize), newDefault);
+        }
+
+        if (input.dataset.touched !== '1') {
+          input.value = newDefault;
+          const output = document.getElementById(fieldName + '_value');
+          if (output) output.textContent = newDefault;
+        }
+      });
+      updateCreatureBounds();
+      validateIdealCounts();
+    }
+
+    // Live-update as the Whtz deck-size field changes (delegated: that field
+    // may not exist yet, or may be swapped in later via the commander/tags HTMX fragment).
+    document.addEventListener('input', function(ev) {
+      if (ev.target && ev.target.name === 'rulebreaker_target_deck_size') {
+        updateIdealsForDeckSize(parseInt(ev.target.value, 10) || 100);
+      }
+    });
+
     // Validate ideal counts to prevent over-allocation
     function validateIdealCounts() {
       const warning = document.getElementById('ideals-validation-warning');
@@ -109,16 +185,19 @@
       const spells = ramp + removal + wipes + cardAdvantage + protection;
       const estimatedTotal = lands + creatures + Math.ceil(spells / 2);
       
-      // Check if estimated total exceeds deck size (99 for EDH)
-      if (estimatedTotal > 99) {
-        warning.textContent = '⚠ Estimated total ~' + estimatedTotal + ' cards (max 99). Reduce counts to avoid build issues.';
+      // Check if estimated total exceeds the non-commander card capacity (99 at
+      // the 100-card baseline; scales with the live deck-size field for Whtz).
+      const capacity = getCurrentTargetDeckSize() - 1;
+      if (estimatedTotal > capacity) {
+        warning.textContent = '⚠ Estimated total ~' + estimatedTotal + ' cards (max ' + capacity + '). Reduce counts to avoid build issues.';
         warning.style.display = 'inline';
         warning.style.color = '#ef4444'; // Red for hard conflict
-      } else if (estimatedTotal > 90) {
+      } else if (estimatedTotal > capacity * 0.9) {
         warning.textContent = '⚠ Estimated total ~' + estimatedTotal + ' cards. Deck may be tight on slots.';
         warning.style.display = 'inline';
         warning.style.color = '#f59e0b'; // Orange for warning
       } else {
+        warning.textContent = '';
         warning.style.display = 'none';
       }
     }
@@ -141,7 +220,7 @@
       // range input's value when its max is lowered, which would otherwise hide
       // the change from the paired <output> display.
       const lands = parseInt(landsInput.value) || 0;
-      const maxCeiling = Math.max(0, 99 - lands);
+      const maxCeiling = Math.max(0, (getCurrentTargetDeckSize() - 1) - lands);
       const prevMaxVal = parseInt(maxInput.value) || 0;
       maxInput.max = maxCeiling;
       const clampedMaxVal = Math.min(prevMaxVal, maxCeiling);
@@ -171,6 +250,7 @@
       const legacyCheckbox = document.querySelector('[name="creature_builder_mode"]');
       if (legacyCheckbox) legacyCheckbox.checked = false;
       document.querySelectorAll('[data-default]').forEach(input => {
+        delete input.dataset.touched;
         input.value = input.dataset.default;
         const output = document.getElementById(input.getAttribute('name') + '_value');
         if (output) output.textContent = input.dataset.default;
@@ -188,6 +268,7 @@
       
       // Update display on input
       slider.addEventListener('input', function() {
+        this.dataset.touched = '1';
         output.textContent = this.value;
         if (fieldName === 'lands' || fieldName === 'creatures_max') {
           updateCreatureBounds();
@@ -201,6 +282,7 @@
     {% else %}
     document.querySelectorAll('[name="ramp"], [name="lands"], [name="basic_lands"], [name="creatures_min"], [name="creatures_max"], [name="on_theme_creatures"], [name="creature_tolerance_pct"], [name="removal"], [name="wipes"], [name="card_advantage"], [name="protection"]').forEach(input => {
       input.addEventListener('input', function() {
+        this.dataset.touched = '1';
         if (input.name === 'lands' || input.name === 'creatures_max') {
           updateCreatureBounds();
         }
@@ -220,7 +302,26 @@
       idealsResetBtn.addEventListener('click', resetIdealsToDefaults);
     }
     
-    // Run initial computations
+    // Run initial computations. If a Whtz deck size >100 is already present
+    // (e.g. re-rendering after a validation error), widen bounds to match it
+    // without overwriting any already-submitted slider values.
+    (function initDeckSizeAwareIdeals() {
+      const dsInput = document.querySelector('[name="rulebreaker_target_deck_size"]');
+      const initialSize = dsInput ? (parseInt(dsInput.value, 10) || 100) : 100;
+      currentTargetDeckSize = initialSize;
+      if (initialSize > 100) {
+        document.querySelectorAll('[data-base-default]').forEach(input => {
+          const baseDefault = parseFloat(input.dataset.baseDefault);
+          input.dataset.default = scaledIdealDefault(baseDefault, initialSize);
+          if (input.type === 'range') {
+            const baseMin = parseFloat(input.dataset.baseMin);
+            const baseMax = parseFloat(input.dataset.baseMax);
+            if (!isNaN(baseMin)) input.min = scaledIdealBound(baseMin, initialSize);
+            if (!isNaN(baseMax)) input.max = scaledIdealBound(baseMax, initialSize);
+          }
+        });
+      }
+    })();
     updateCreatureBounds();
     updateLegacyDisabled();
     validateIdealCounts();

--- a/code/web/templates/build/_new_deck_modal.html
+++ b/code/web/templates/build/_new_deck_modal.html
@@ -63,7 +63,7 @@
             <select name="bracket">
               {% for b in brackets %}
                 {% if not gc_commander or b.level >= 3 %}
-                <option value="{{ b.level }}" {% if (form and form.bracket and form.bracket == b.level) or (not form and b.level == 3) %}selected{% endif %}>Bracket {{ b.level }}: {{ b.name }}</option>
+                <option value="{{ b.level }}" {% if (form.bracket if (form and form.bracket) else 4) == b.level %}selected{% endif %}>Bracket {{ b.level }}: {{ b.name }}</option>
                 {% endif %}
               {% endfor %}
             </select>

--- a/code/web/templates/build/_new_deck_tags.html
+++ b/code/web/templates/build/_new_deck_tags.html
@@ -182,6 +182,7 @@
 {% set partner_id_prefix = 'modal' %}
 {% set partner_scope = 'modal' %}
 {% include "build/_partner_controls.html" %}
+{% include "partials/rulebreaker_banner.html" %}
 
 {# Always update the bracket dropdown on commander change; hide 1–2 only when gc_commander is true #}
 <div id="newdeck-bracket-slot" hx-swap-oob="true">
@@ -189,7 +190,7 @@
     <select name="bracket">
       {% for b in brackets %}
         {% if not gc_commander or b.level >= 3 %}
-        <option value="{{ b.level }}" {% if b.level == 3 %}selected{% endif %}>Bracket {{ b.level }}: {{ b.name }}</option>
+        <option value="{{ b.level }}" {% if b.level == 4 %}selected{% endif %}>Bracket {{ b.level }}: {{ b.name }}</option>
         {% endif %}
       {% endfor %}
     </select>

--- a/code/web/templates/build/_step5.html
+++ b/code/web/templates/build/_step5.html
@@ -184,13 +184,16 @@
   <span class="ml-auto"><a href="/owned" target="_blank" rel="noopener" class="btn">Manage Owned Library</a></span>
       </div>
       <p>Bracket: {{ bracket }}</p>
+      {% if rulebreaker %}
+      <p>Rulebreaker: {{ rulebreaker.name }}{% if rulebreaker_extra_color %} (Extra color: {{ rulebreaker_extra_color }}){% endif %}</p>
+      {% endif %}
 
     <div class="flex items-center gap-2 flex-wrap my-1 mb-2">
         {% if i and n %}
           <span class="chip"><span class="dot"></span> Stage {{ i }}/{{ n }}</span>
         {% endif %}
   {% set deck_count = (total_cards if total_cards is not none else 0) %}
-  <span class="chip"><span class="dot dot-green"></span> Deck {{ deck_count }}/100</span>
+  <span class="chip"><span class="dot dot-green"></span> Deck {{ deck_count }}/{{ rulebreaker_target_deck_size or 100 }}</span>
   {% if added_total is not none %}
   <span class="chip"><span class="dot dot-blue"></span> Added {{ added_total }}</span>
   {% endif %}

--- a/code/web/templates/decks/_manual_mana_overview.html
+++ b/code/web/templates/decks/_manual_mana_overview.html
@@ -2,13 +2,14 @@
   <div class="mana-panel" style="padding:.4rem .5rem;">
     <div class="muted mana-panel-heading text-xs">Pips</div>
     {% if mana_overview.pips %}
-    <div class="chart-bars" style="height:50px; gap:4px; flex-wrap:wrap;">
+    <div class="chart-bars" style="height:auto; gap:4px; flex-wrap:wrap;">
       {% for p in mana_overview.pips %}
       <div class="chart-column">
         <div style="height:42px; display:flex; align-items:flex-end;">
           <div style="width:9px; min-height:2px; height:{{ p.pct }}%; background:#3b82f6; border-radius:2px 2px 0 0;"
                title="{{ p.color }}: {{ '%.1f'|format(p.count) }} pips ({{ p.pct }}%)"></div>
         </div>
+        <div class="muted text-xs">{{ p.count|round(1) if (p.count % 1) else p.count|int }}</div>
         <div class="muted text-xs">{{ p.color }}</div>
       </div>
       {% endfor %}
@@ -21,13 +22,14 @@
   <div class="mana-panel" style="padding:.4rem .5rem;">
     <div class="muted mana-panel-heading text-xs">Sources</div>
     {% if mana_overview.sources %}
-    <div class="chart-bars" style="height:50px; gap:4px; flex-wrap:wrap;">
+    <div class="chart-bars" style="height:auto; gap:4px; flex-wrap:wrap;">
       {% for s in mana_overview.sources %}
       <div class="chart-column">
         <div style="height:42px; display:flex; align-items:flex-end;">
           <div style="width:9px; min-height:2px; height:{{ s.pct }}%; background:#10b981; border-radius:2px 2px 0 0;"
                title="{{ s.color }}: {{ s.count }} sources"></div>
         </div>
+        <div class="muted text-xs">{{ s.count|int }}</div>
         <div class="muted text-xs">{{ s.color }}</div>
       </div>
       {% endfor %}
@@ -41,7 +43,7 @@
   <div class="mana-panel" style="padding:.4rem .5rem;">
     <div class="muted mana-panel-heading text-xs">Curve</div>
     {% if mana_overview.curve %}
-    <div class="chart-bars" style="height:50px; gap:3px; flex-wrap:wrap;">
+    <div class="chart-bars" style="height:auto; gap:3px; flex-wrap:wrap;">
       {% for c in mana_overview.curve %}
       <div class="chart-column">
         <div style="height:42px; display:flex; align-items:flex-end;">

--- a/code/web/templates/decks/manual_builder.html
+++ b/code/web/templates/decks/manual_builder.html
@@ -10,6 +10,9 @@
 <div class="muted">Bracket: {{ bracket }}
   {% if budget_total %} • Budget: ${{ '%.2f'|format(budget_total) }}{% endif %}
 </div>
+{% if rulebreaker %}
+<div class="muted">Rulebreaker: {{ rulebreaker.name }}{% if rulebreaker_extra_color %} (Extra color: {{ rulebreaker_extra_color }}){% endif %}</div>
+{% endif %}
 {% if edit_source_name %}
 <div class="muted text-sm" style="margin-top:.25rem;">Editing <strong>{{ edit_source_name }}</strong> (saving will overwrite this deck).</div>
 {% endif %}

--- a/code/web/templates/partials/rulebreaker_banner.html
+++ b/code/web/templates/partials/rulebreaker_banner.html
@@ -1,0 +1,36 @@
+{% set rb = active_rulebreaker if active_rulebreaker is defined else None %}
+{% if rb %}
+<fieldset style="margin-top:.75rem;">
+  <legend>Rulebreaker Commander <span class="help-tip"><button type="button" class="help-tip-btn" data-tip="This commander breaks a normal deckbuilding rule (color identity, deck size, etc.)." data-tip-href="/help/rulebreaker_commanders" aria-label="Rulebreaker Commanders help"><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true" width="11" height="11"><circle cx="8" cy="8" r="6.5"/><line x1="8" y1="7" x2="8" y2="10.5" stroke-linecap="round"/><circle cx="8" cy="4.5" r="0.75" fill="currentColor" stroke="none"/></svg></button></span></legend>
+  <div class="muted" style="font-size:12px; margin-bottom:.5rem;">
+    <strong>{{ rb.name }}</strong> breaks the normal rules for this deck.
+  </div>
+
+  {% if rb.rule_type == 'instant_sorcery_extra_color' %}
+    <label style="display:block; margin-bottom:.5rem;">
+      <span>Extra color for instants/sorceries</span>
+      <select name="rulebreaker_extra_color" id="modal_rulebreaker_extra_color">
+        <option value="">None (stay in color identity)</option>
+        {% for c, label in [('W','White'), ('U','Blue'), ('B','Black'), ('R','Red'), ('G','Green')] %}
+          {% if c not in rb.color_identity %}
+          <option value="{{ c }}" {% if rulebreaker_extra_color == c %}selected{% endif %}>{{ label }}</option>
+          {% endif %}
+        {% endfor %}
+      </select>
+    </label>
+    <div class="muted" style="font-size:12px;">Choose one extra color this commander may cast instants/sorceries from.</div>
+  {% endif %}
+
+  {% if rb.no_max_deck_size %}
+    <label style="display:block; margin-top:.5rem;">
+      <span>Deck size (100+)</span>
+      <input type="number" name="rulebreaker_target_deck_size" id="modal_rulebreaker_target_deck_size"
+             min="100" step="1" value="{{ rulebreaker_target_deck_size or 100 }}" style="width:6rem;" />
+    </label>
+    <div class="muted" style="font-size:12px;">This commander removes the 100-card maximum. Leave at 100 for a normal-size deck.</div>
+  {% endif %}
+</fieldset>
+{% else %}
+<input type="hidden" name="rulebreaker_extra_color" value="" />
+<input type="hidden" name="rulebreaker_target_deck_size" value="100" />
+{% endif %}

--- a/code/web/templates/setup/index.html
+++ b/code/web/templates/setup/index.html
@@ -70,6 +70,11 @@
     </div>
   </details>
 
+  <div id="rulebreaker-candidates" style="margin-top:.75rem; display:none; padding:1rem; border:1px solid #f59e0b; background:rgba(245,158,11,.08); border-radius:8px;">
+    <div style="font-weight:600; color:#f59e0b;">Possible new Rulebreaker card(s) detected</div>
+    <div id="rulebreaker-candidates-list" class="muted" style="margin-top:.5rem; font-size:.9rem;"></div>
+  </div>
+
   <details style="margin-top:1rem;">
     <summary>Download Pre-tagged Database from GitHub (Optional)</summary>
     <div style="margin-top:.5rem; padding:1rem; border:1px solid var(--border); background:var(--panel); border-radius:8px;">
@@ -271,6 +276,39 @@
   colorEl.style.display = 'none';
   if (logWrap) logWrap.style.display = 'none';
     }
+    updateRulebreakerCandidates(data);
+  }
+  function escapeHtml(s){
+    return String(s == null ? '' : s).replace(/[&<>"']/g, function(c){
+      return { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c];
+    });
+  }
+  function updateRulebreakerCandidates(data){
+    var wrap = document.getElementById('rulebreaker-candidates');
+    var list = document.getElementById('rulebreaker-candidates-list');
+    if (!wrap || !list) return;
+    var candidates = (data && data.rulebreaker_candidates) || [];
+    if (!candidates.length) {
+      wrap.style.display = 'none';
+      list.innerHTML = '';
+      return;
+    }
+    wrap.style.display = '';
+    list.innerHTML = candidates.map(function(c){
+      var name = escapeHtml(c.name || 'Unknown card');
+      var issueLine = c.existing_issue_url
+        ? '<div>An issue may already be open: <a href="' + escapeHtml(c.existing_issue_url) + '" target="_blank" rel="noopener">' + escapeHtml(c.existing_issue_url) + '</a></div>'
+        : '';
+      var newIssueUrl = 'https://github.com/mwisnowski/mtg_python_deckbuilder/issues/new?template=rulebreaker-card-report.md&title=' + encodeURIComponent('Rulebreaker: ' + (c.name || ''));
+      return (
+        '<div style="margin-bottom:1rem; padding-bottom:1rem; border-bottom:1px solid var(--border);">' +
+        '<div><strong>' + name + '</strong> isn\'t in the deckbuilder\'s rule registry yet.</div>' +
+        issueLine +
+        '<textarea readonly rows="6" style="width:100%; margin-top:.5rem; font-family:monospace; font-size:.8rem; background:var(--bg); border:1px solid var(--border); border-radius:6px; padding:.5rem;">' + escapeHtml(c.issue_body || '') + '</textarea>' +
+        '<div style="margin-top:.5rem;"><a href="' + newIssueUrl + '" target="_blank" rel="noopener">Open new issue on GitHub</a></div>' +
+        '</div>'
+      );
+    }).join('');
   }
   function poll(){
     fetch('/status/setup', { cache: 'no-store' })

--- a/code/web/validation/models.py
+++ b/code/web/validation/models.py
@@ -66,6 +66,10 @@ class BuildRequest(BaseModel):
     random_commander: bool = Field(default=False, description="Randomize commander")
     random_themes: bool = Field(default=False, description="Randomize themes")
     random_seed: Optional[int] = Field(default=None, ge=0, description="Random seed")
+
+    # Rulebreaker commanders (Roadmap 35)
+    rulebreaker_extra_color: Optional[str] = Field(default=None, min_length=1, max_length=1, description="Tolabow's chosen extra color (single WUBRG letter)")
+    rulebreaker_target_deck_size: Optional[int] = Field(default=None, ge=100, description="Whtz's chosen deck size (>=100, no upper bound)")
     
     @field_validator("commander")
     @classmethod
@@ -93,6 +97,17 @@ class BuildRequest(BaseModel):
         
         return unique
     
+    @field_validator("rulebreaker_extra_color")
+    @classmethod
+    def validate_rulebreaker_extra_color(cls, v: Optional[str]) -> Optional[str]:
+        """Ensure the extra color is a single valid WUBRG letter."""
+        if v is None:
+            return v
+        v = v.strip().upper()
+        if v not in {"W", "U", "B", "R", "G"}:
+            raise ValueError("rulebreaker_extra_color must be one of W, U, B, R, G")
+        return v
+
     @model_validator(mode="after")
     def validate_partner_consistency(self) -> "BuildRequest":
         """Validate partner configuration consistency."""

--- a/config/card_lists/banned_cards.json
+++ b/config/card_lists/banned_cards.json
@@ -84,7 +84,7 @@
     "Worldknit",
     "Yawgmoth's Bargain"
   ],
-  "list_version": "scryfall-2026-08-04",
-  "generated_at": "2026-08-04",
+  "list_version": "scryfall-2026-08-10",
+  "generated_at": "2026-08-10",
   "source": "scryfall bulk data (legalities.commander == banned)"
 }

--- a/config/card_lists/commander_illegal_cards.json
+++ b/config/card_lists/commander_illegal_cards.json
@@ -5381,7 +5381,6 @@
     "Tom van de Logt Bio (2001)",
     "Tom van de Logt Decklist (2000)",
     "Tom van de Logt Decklist (2001)",
-    "Tom, Bert, and William",
     "Tomakul Honor Guard // Tomakul Honor Guard",
     "Tomakul Phoenix",
     "Tomb of Annihilation",
@@ -6010,7 +6009,7 @@
     "Éomer of the Riddermark // Éomer of the Riddermark",
     "Éowyn, Fearless Knight // Éowyn, Fearless Knight"
   ],
-  "list_version": "scryfall-2026-08-04",
-  "generated_at": "2026-08-04",
+  "list_version": "scryfall-2026-08-10",
+  "generated_at": "2026-08-10",
   "source": "scryfall bulk data (legalities.commander == not_legal on every printing)"
 }

--- a/config/card_lists/game_changers.json
+++ b/config/card_lists/game_changers.json
@@ -54,7 +54,7 @@
     "Vampiric Tutor",
     "Worldly Tutor"
   ],
-  "list_version": "scryfall-2026-08-04",
-  "generated_at": "2026-08-04",
+  "list_version": "scryfall-2026-08-10",
+  "generated_at": "2026-08-10",
   "source": "scryfall bulk data (game_changer field)"
 }

--- a/config/themes/theme_list.json
+++ b/config/themes/theme_list.json
@@ -11,7 +11,8 @@
       "example_commanders": [
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
         "Rishkar, Peema Renegade - Synergy (Counters Matter)",
-        "Krenko, Tin Street Kingpin - Synergy (Counters Matter)"
+        "Krenko, Tin Street Kingpin - Synergy (Counters Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)"
       ],
       "example_cards": [
         "Dwarven Armorer",
@@ -39,7 +40,9 @@
       "example_commanders": [
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
         "Rishkar, Peema Renegade - Synergy (Counters Matter)",
-        "Krenko, Tin Street Kingpin - Synergy (Counters Matter)"
+        "Krenko, Tin Street Kingpin - Synergy (Counters Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)",
+        "Azusa, Lost but Seeking - Synergy (Toughness Matters)"
       ],
       "example_cards": [
         "Dwarven Armorer",
@@ -50,6 +53,10 @@
         "Consuming Ferocity",
         "Balduvian Hydra",
         "Clockwork Swarm"
+      ],
+      "synergy_commanders": [
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)",
+        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
       ],
       "popularity_bucket": "Rare",
       "description": "Accumulates +1/+0 counters to unlock scaling payoffs, removal triggers, or delayed value conversions."
@@ -86,6 +93,7 @@
       "synergy_commanders": [
         "Zegana, Utopian Speaker - Synergy (Adapt)",
         "Jetfire, Ingenious Scientist // Jetfire, Air Guardian - Synergy (Adapt)",
+        "Ray Fillet, Wave Warrior - Synergy (Evolve)",
         "Lonis, Genetics Expert - Synergy (Evolve)"
       ],
       "popularity_bucket": "Very Common",
@@ -100,7 +108,10 @@
       "primary_color": "Black",
       "secondary_color": "Green",
       "example_commanders": [
-        "Baron Sengir"
+        "Baron Sengir",
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)",
+        "Rishkar, Peema Renegade - Synergy (Counters Matter)"
       ],
       "example_cards": [
         "Soul Exchange",
@@ -126,7 +137,8 @@
       "example_commanders": [
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
         "Rishkar, Peema Renegade - Synergy (Counters Matter)",
-        "Krenko, Tin Street Kingpin - Synergy (Counters Matter)"
+        "Krenko, Tin Street Kingpin - Synergy (Counters Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)"
       ],
       "example_cards": [
         "Wall of Roots",
@@ -211,6 +223,26 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Syr Konrad, the Grim - Synergy (Knight Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Knight Kindred)",
+        "Danitha Capashen, Paragon - Synergy (Knight Kindred)",
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)",
+        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)"
+      ],
+      "example_cards": [
+        "Desecrate Reality",
+        "Foreboding Fruit",
+        "Once and Future",
+        "Rally for the Throne",
+        "Outmuscle",
+        "Cauldron's Gift",
+        "Unexplained Vision",
+        "Silverflame Ritual"
+      ],
+      "synergy_commanders": [
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around the Adamant theme and its supporting synergies."
     },
@@ -245,7 +277,7 @@
       ],
       "synergy_commanders": [
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
-        "Yahenni, Undying Partisan - Synergy (Counters Matter)",
+        "Bristly Bill, Spine Sower - Synergy (Counters Matter)",
         "Sram, Senior Edificer - Synergy (Voltron)"
       ],
       "popularity_bucket": "Rare",
@@ -279,7 +311,9 @@
         "Sphinx's Insight"
       ],
       "synergy_commanders": [
-        "Niv-Mizzet, Parun - Synergy (Spellslinger)"
+        "Avacyn, Angel of Hope - Synergy (Interaction)",
+        "Padeem, Consul of Innovation - Synergy (Interaction)",
+        "Mangara, the Diplomat - Synergy (Spellslinger)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Addendum leveraging synergies with Interaction and Spells Matter."
@@ -314,12 +348,12 @@
         "Danny Pink"
       ],
       "synergy_commanders": [
-        "Yawgmoth, Thran Physician - Synergy (-1/-1 Counters)",
-        "Vorinclex, Monstrous Raider - Synergy (-1/-1 Counters)",
-        "Lae'zel, Vlaakith's Champion - Synergy (-1/-1 Counters)",
-        "Toski, Bearer of Secrets - Synergy (Conditional Draw)",
-        "Kutzil, Malamet Exemplar - Synergy (Conditional Draw)",
-        "Syr Konrad, the Grim - Synergy (Human Kindred)"
+        "Deadpool, Trading Card - Synergy (Mutant Kindred)",
+        "Kuja, Genome Sorcerer // Trance Kuja, Fate Defied - Synergy (Mutant Kindred)",
+        "Agent Frank Horrigan - Synergy (Mutant Kindred)",
+        "Syr Konrad, the Grim - Synergy (Human Kindred)",
+        "Azusa, Lost but Seeking - Synergy (Human Kindred)",
+        "Toski, Bearer of Secrets - Synergy (Conditional Draw)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Advisor creatures into play with shared payoffs (e.g., -1/-1 Counters and Conditional Draw)."
@@ -358,7 +392,7 @@
         "Rankle, Master of Pranks - Synergy (Rogue Kindred)",
         "Ragavan, Nimble Pilferer - Synergy (Outlaw Kindred)",
         "Captain Lannery Storm - Synergy (Outlaw Kindred)",
-        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)"
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Aetherborn creatures into play with shared payoffs (e.g., Rogue Kindred and Outlaw Kindred)."
@@ -397,7 +431,7 @@
         "Goreclaw, Terror of Qal Sisma - Synergy (Cost Reduction)",
         "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (X Spells)",
         "Danitha Capashen, Paragon - Synergy (X Spells)",
-        "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)"
+        "Alibou, Ancient Witness - Synergy (Golem Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Reduces spell costs via board resource counts (Affinity) enabling explosive early multi-spell turns. Synergies like Cost Reduction and X Spells reinforce the plan."
@@ -429,7 +463,7 @@
         "Merciless Eternal"
       ],
       "synergy_commanders": [
-        "Emry, Lurker of the Loch - Synergy (Reanimate)"
+        "Six - Synergy (Reanimate)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Afflict leveraging synergies with Zombie Kindred and Burn."
@@ -464,7 +498,9 @@
         "Orzhov Racketeers"
       ],
       "synergy_commanders": [
-        "Sheoldred, the Apocalypse - Synergy (Aristocrats)"
+        "Thalisse, Reverent Medium - Synergy (Spirit Token)",
+        "Goro-Goro, Disciple of Ryusei - Synergy (Spirit Token)",
+        "Kykar, Wind's Fury - Synergy (Spirit Token)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Afterlife leveraging synergies with Spirit Kindred and Sacrifice Matters."
@@ -499,7 +535,9 @@
         "Rags // Riches"
       ],
       "synergy_commanders": [
-        "Lotho, Corrupt Shirriff - Synergy (Spells Matter)"
+        "Six - Synergy (Graveyard Recursion)",
+        "Muldrotha, the Gravetide - Synergy (Graveyard Recursion)",
+        "Uro, Titan of Nature's Wrath - Synergy (Graveyard Recursion)"
       ],
       "popularity_bucket": "Rare",
       "description": "Extracts two-phase value from split Aftermath spells, maximizing flexible sequencing."
@@ -533,9 +571,6 @@
         "Braid of Fire",
         "Cosima, God of the Voyage // The Omenkeel"
       ],
-      "synergy_commanders": [
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
-      ],
       "popularity_bucket": "Niche",
       "description": "Accumulates age counters to unlock scaling payoffs, removal triggers, or delayed value conversions."
     },
@@ -543,11 +578,11 @@
       "id": "aggro",
       "theme": "Aggro",
       "synergies": [
-        "Combat Matters",
         "Voltron",
         "+1/+1 Counters",
         "Auras",
-        "Equipment Matters"
+        "Equipment Matters",
+        "Trample"
       ],
       "primary_color": "Green",
       "secondary_color": "White",
@@ -570,8 +605,11 @@
       ],
       "synergy_commanders": [
         "Sram, Senior Edificer - Synergy (Voltron)",
-        "Rishkar, Peema Renegade - Synergy (Voltron)",
-        "Krenko, Tin Street Kingpin - Synergy (+1/+1 Counters)"
+        "Danitha Capashen, Paragon - Synergy (Voltron)",
+        "Yawgmoth, Thran Physician - Synergy (Voltron)",
+        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)",
+        "Krenko, Tin Street Kingpin - Synergy (+1/+1 Counters)",
+        "Kodama of the West Tree - Synergy (Auras)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Applies early pressure and combat tempo to close the game before slower value engines stabilize. Synergies like Combat Matters and Voltron reinforce the plan."
@@ -580,14 +618,36 @@
       "id": "airbend",
       "theme": "Airbend",
       "synergies": [
+        "Airbending",
         "Bending",
         "Ally Kindred",
         "Exile Matters",
-        "Leave the Battlefield",
-        "Flying"
+        "Leave the Battlefield"
       ],
       "primary_color": "White",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Appa, Steadfast Guardian",
+        "Aang, Swift Savior // Aang and La, Ocean's Fury",
+        "Aang, Airbending Master",
+        "Monk Gyatso",
+        "Aang, the Last Airbender"
+      ],
+      "example_cards": [
+        "Avatar's Wrath",
+        "Airbender Ascension",
+        "Appa, Steadfast Guardian",
+        "Aang, Swift Savior // Aang and La, Ocean's Fury",
+        "Airbending Lesson",
+        "Airbender's Reversal",
+        "The Legend of Yangchen // Avatar Yangchen",
+        "Aang, Airbending Master"
+      ],
+      "synergy_commanders": [
+        "Toph, Hardheaded Teacher - Synergy (Bending)",
+        "Toph, Earthbending Master - Synergy (Bending)",
+        "Drana, Liberator of Malakir - Synergy (Ally Kindred)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Airbend leveraging synergies with Airbending and Bending."
     },
@@ -597,16 +657,17 @@
       "synergies": [
         "Airbend",
         "Bending",
-        "Avatar Kindred",
         "Ally Kindred",
-        "Exile Matters"
+        "Exile Matters",
+        "Leave the Battlefield"
       ],
       "primary_color": "White",
       "example_commanders": [
         "Appa, Steadfast Guardian",
         "Aang, Airbending Master",
         "Avatar Aang // Aang, Master of Elements",
-        "Aang, the Last Airbender"
+        "Aang, the Last Airbender",
+        "Aang, Swift Savior // Aang and La, Ocean's Fury - Synergy (Airbend)"
       ],
       "example_cards": [
         "Appa, Steadfast Guardian",
@@ -614,6 +675,11 @@
         "Airbending Lesson",
         "Avatar Aang // Aang, Master of Elements",
         "Aang, the Last Airbender"
+      ],
+      "synergy_commanders": [
+        "Toph, Hardheaded Teacher - Synergy (Bending)",
+        "Toph, Earthbending Master - Synergy (Bending)",
+        "Muldrotha, the Gravetide - Synergy (Avatar Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around the Airbending theme and its supporting synergies."
@@ -648,12 +714,10 @@
         "Davros, Dalek Creator"
       ],
       "synergy_commanders": [
-        "Mondrak, Glory Dominus - Synergy (Clones)",
-        "Kiki-Jiki, Mirror Breaker - Synergy (Clones)",
-        "Sakashima of a Thousand Faces - Synergy (Clones)",
-        "Solphim, Mayhem Dominus - Synergy (Horror Kindred)",
-        "Zopandrel, Hunger Dominus - Synergy (Horror Kindred)",
-        "Etali, Primal Storm - Synergy (Exile Matters)"
+        "Vrestin, Menoptra Leader - Synergy (Alien Token)",
+        "Taigam, Master Opportunist - Synergy (Suspend)",
+        "Jhoira of the Ghitu - Synergy (Suspend)",
+        "Urabrask // The Great Work - Synergy (Lore Counters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Alien creatures into play with shared payoffs (e.g., Clones and Horror Kindred)."
@@ -670,6 +734,27 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Iraxxa, Empress of Mars",
+        "Vrestin, Menoptra Leader",
+        "Jenova, Ancient Calamity - Synergy (Alien Kindred)",
+        "Davros, Dalek Creator - Synergy (Alien Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Recon Craft Theta",
+        "Iraxxa, Empress of Mars",
+        "Vrestin, Menoptra Leader",
+        "Blink",
+        "The Sea Devils",
+        "Adipose Offspring",
+        "Fugitive of the Judoon",
+        "Alien Invasion"
+      ],
+      "synergy_commanders": [
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Alien Kindred and Creature Tokens reinforce the plan."
     },
@@ -703,8 +788,9 @@
         "Celebrity Fencer"
       ],
       "synergy_commanders": [
-        "Ayara, First of Locthwain - Synergy (Elf Kindred)",
-        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
+        "Deadpool, Trading Card - Synergy (Mutant Kindred)",
+        "Kuja, Genome Sorcerer // Trance Kuja, Fate Defied - Synergy (Mutant Kindred)",
+        "Agent Frank Horrigan - Synergy (Mutant Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Alliance leveraging synergies with Druid Kindred and Elf Kindred."
@@ -716,8 +802,8 @@
         "Rally",
         "Cohort",
         "Ally Token",
-        "Earthbend",
-        "Airbend"
+        "Airbending",
+        "Waterbending"
       ],
       "primary_color": "White",
       "secondary_color": "Green",
@@ -740,7 +826,7 @@
       ],
       "synergy_commanders": [
         "Munda, Ambush Leader - Synergy (Rally)",
-        "Toph, the First Metalbender - Synergy (Earthbending)"
+        "Appa, Steadfast Guardian - Synergy (Ally Token)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Focuses on getting a high number of Ally creatures into play with shared payoffs (e.g., Rally and Cohort)."
@@ -757,6 +843,31 @@
       ],
       "primary_color": "White",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Appa, Steadfast Guardian",
+        "Katara, Water Tribe's Hope",
+        "Aang, Airbending Master",
+        "Sokka, Tenacious Tactician",
+        "Suki, Courageous Rescuer"
+      ],
+      "example_cards": [
+        "Appa, Steadfast Guardian",
+        "Jasmine Dragon Tea Shop",
+        "Katara, Water Tribe's Hope",
+        "Aang, Airbending Master",
+        "Sokka, Tenacious Tactician",
+        "United Front",
+        "Retreat to Emeria",
+        "Suki, Courageous Rescuer"
+      ],
+      "synergy_commanders": [
+        "Drana, Liberator of Malakir - Synergy (Ally Kindred)",
+        "Mina and Denn, Wildborn - Synergy (Ally Kindred)",
+        "The Earth King - Synergy (Ally Kindred)",
+        "Toph, Hardheaded Teacher - Synergy (Bending)",
+        "Toph, Earthbending Master - Synergy (Bending)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Ally Kindred and Bending reinforce the plan."
     },
@@ -772,6 +883,16 @@
       ],
       "primary_color": "Green",
       "secondary_color": "White",
+      "example_cards": [
+        "Evolving Wilds",
+        "Terramorphic Expanse",
+        "Myriad Landscape",
+        "Fabled Passage",
+        "Prismatic Vista",
+        "Urza's Cave",
+        "Riveteers Overlook",
+        "Escape Tunnel"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Alt Fetchland leveraging synergies with Landscape Land and New Capenna Land."
     },
@@ -805,9 +926,9 @@
         "Eternal Skylord"
       ],
       "synergy_commanders": [
-        "Plargg and Nassari - Synergy (Orc Kindred)",
-        "Cadira, Caller of the Small - Synergy (Orc Kindred)",
-        "Neheb, the Eternal - Synergy (Zombie Kindred)"
+        "The Mouth of Sauron - Synergy (Army Token)",
+        "Saruman the White - Synergy (Orc Token)",
+        "Shagrat, Loot Bearer - Synergy (Orc Token)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Amass leveraging synergies with Army Kindred and Orc Kindred."
@@ -842,6 +963,7 @@
         "Glowering Rogon"
       ],
       "synergy_commanders": [
+        "Bristly Bill, Spine Sower - Synergy (Counters Matter)",
         "Sram, Senior Edificer - Synergy (Voltron)"
       ],
       "popularity_bucket": "Rare",
@@ -852,8 +974,8 @@
       "theme": "Angel Kindred",
       "synergies": [
         "Angel Token",
-        "Foretell",
         "Lifegain",
+        "Foretell",
         "Life Matters",
         "Flying"
       ],
@@ -877,12 +999,12 @@
         "Sephara, Sky's Blade"
       ],
       "synergy_commanders": [
-        "Loran of the Third Path - Synergy (Vigilance)",
-        "Adeline, Resplendent Cathar - Synergy (Vigilance)",
-        "Elesh Norn, Grand Cenobite - Synergy (Vigilance)",
-        "Tatyova, Benthic Druid - Synergy (Lifegain)",
+        "Jenson Carthalion, Druid Exile - Synergy (Angel Token)",
+        "Geist of Saint Traft - Synergy (Angel Token)",
+        "Saint Traft and Rem Karolus - Synergy (Angel Token)",
         "Sheoldred, the Apocalypse - Synergy (Lifegain)",
-        "Vito, Thorn of the Dusk Rose - Synergy (Life Matters)"
+        "Tatyova, Benthic Druid - Synergy (Lifegain)",
+        "Bohn, Beguiling Balladeer - Synergy (Foretell)"
       ],
       "popularity_bucket": "Common",
       "description": "Focuses on getting a high number of Angel creatures into play with shared payoffs (e.g., Lifegain and Life Matters)."
@@ -899,6 +1021,30 @@
       ],
       "primary_color": "White",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Jenson Carthalion, Druid Exile",
+        "Geist of Saint Traft",
+        "Saint Traft and Rem Karolus",
+        "Linvala, the Preserver",
+        "Avacyn, Angel of Hope - Synergy (Angel Kindred)"
+      ],
+      "example_cards": [
+        "Sigil of the Empty Throne",
+        "Court of Grace",
+        "Resplendent Angel",
+        "Valkyrie Harbinger",
+        "Finale of Glory",
+        "Emeria's Call // Emeria, Shattered Skyclave",
+        "Parhelion II",
+        "Luminarch Ascension"
+      ],
+      "synergy_commanders": [
+        "Aurelia, the Warleader - Synergy (Angel Kindred)",
+        "Gisela, Blade of Goldnight - Synergy (Angel Kindred)",
+        "God-Eternal Oketra - Synergy (Warrior Token)",
+        "Zurgo Stormrender - Synergy (Warrior Token)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Angel Kindred and Warrior Token reinforce the plan."
     },
@@ -916,7 +1062,10 @@
       "secondary_color": "Red",
       "example_commanders": [
         "Kozilek, Butcher of Truth",
-        "Ulamog, the Infinite Gyre"
+        "Ulamog, the Infinite Gyre",
+        "Ulamog, the Ceaseless Hunger - Synergy (Eldrazi Kindred)",
+        "Syr Konrad, the Grim - Synergy (Sacrifice Matters)",
+        "Braids, Arisen Nightmare - Synergy (Sacrifice Matters)"
       ],
       "example_cards": [
         "Artisan of Kozilek",
@@ -927,6 +1076,9 @@
         "Flayer of Loyalties",
         "Ulamog's Crusher",
         "Nulldrifter"
+      ],
+      "synergy_commanders": [
+        "Sheoldred, the Apocalypse - Synergy (Aristocrats)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around the Annihilator theme and its supporting synergies."
@@ -957,6 +1109,10 @@
         "Flycatcher Giraffid",
         "Ornery Kudu"
       ],
+      "synergy_commanders": [
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)",
+        "Loran of the Third Path - Synergy (Little Fellas)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Antelope creatures into play with shared payoffs (e.g., Toughness Matters and Little Fellas)."
     },
@@ -968,7 +1124,7 @@
         "Trample",
         "Removal",
         "Toughness Matters",
-        "Little Fellas"
+        "Big Mana"
       ],
       "primary_color": "Green",
       "secondary_color": "Black",
@@ -990,12 +1146,12 @@
         "Grunn, the Lonely King"
       ],
       "synergy_commanders": [
-        "Ulamog, the Infinite Gyre - Synergy (Removal)",
-        "Zacama, Primal Calamity - Synergy (Removal)",
-        "The Scarab God - Synergy (Removal)",
-        "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)",
-        "Loran of the Third Path - Synergy (Artifacts Matter)",
-        "Syr Konrad, the Grim - Synergy (Big Mana)"
+        "Six - Synergy (Reach)",
+        "Kodama of the West Tree - Synergy (Reach)",
+        "Kodama of the East Tree - Synergy (Reach)",
+        "Ghalta, Primal Hunger - Synergy (Trample)",
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Trample)",
+        "Ulamog, the Infinite Gyre - Synergy (Removal)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Ape creatures into play with shared payoffs (e.g., Big Mana and Artifacts Matter)."
@@ -1033,7 +1189,7 @@
         "Six - Synergy (Reach)",
         "Kodama of the West Tree - Synergy (Reach)",
         "Kodama of the East Tree - Synergy (Reach)",
-        "Karador, Ghost Chieftain - Synergy (Centaur Kindred)",
+        "Braulios of Pheres Band - Synergy (Centaur Kindred)",
         "Nikya of the Old Ways - Synergy (Centaur Kindred)",
         "Selvala, Heart of the Wilds - Synergy (Elf Kindred)"
       ],
@@ -1047,8 +1203,8 @@
         "Flying",
         "Big Mana",
         "Enchantments Matter",
-        "Blink",
-        "Enter the Battlefield"
+        "Stax",
+        "Blink"
       ],
       "primary_color": "White",
       "secondary_color": "Black",
@@ -1070,6 +1226,7 @@
         "Archon of Valor's Reach"
       ],
       "synergy_commanders": [
+        "Aurelia, the Warleader - Synergy (Flying)",
         "Syr Konrad, the Grim - Synergy (Big Mana)",
         "Etali, Primal Storm - Synergy (Big Mana)",
         "Selvala, Heart of the Wilds - Synergy (Blink)"
@@ -1155,9 +1312,8 @@
         "Saruman's Trickery"
       ],
       "synergy_commanders": [
-        "Plargg and Nassari - Synergy (Orc Kindred)",
-        "Cadira, Caller of the Small - Synergy (Orc Kindred)",
-        "Neheb, the Eternal - Synergy (Zombie Kindred)"
+        "Saruman the White - Synergy (Orc Token)",
+        "Shagrat, Loot Bearer - Synergy (Orc Token)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Army creatures into play with shared payoffs (e.g., Amass and Orc Kindred)."
@@ -1174,6 +1330,28 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Saruman, the White Hand",
+        "Gothmog, Morgul Lieutenant",
+        "The Mouth of Sauron",
+        "Saruman the White",
+        "Shagrat, Loot Bearer"
+      ],
+      "example_cards": [
+        "Dreadhorde Invasion",
+        "Lazotep Plating",
+        "Gleaming Overseer",
+        "Saruman, the White Hand",
+        "Gothmog, Morgul Lieutenant",
+        "Eternal Skylord",
+        "Saruman's Trickery",
+        "Orcish Medicine"
+      ],
+      "synergy_commanders": [
+        "Sauron, the Dark Lord - Synergy (Army Kindred)",
+        "Mauhúr, Uruk-hai Captain - Synergy (Army Kindred)",
+        "Sauron, Lord of the Rings - Synergy (Amass)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Orc Token and Army Kindred reinforce the plan."
     },
@@ -1207,9 +1385,11 @@
         "Pitiless Plunderer"
       ],
       "synergy_commanders": [
-        "Cayth, Famed Mechanist - Synergy (Servo Kindred)",
-        "Saheeli, the Gifted - Synergy (Servo Kindred)",
-        "Ashnod, Flesh Mechanist - Synergy (Powerstone Token)"
+        "Breya, Etherium Shaper - Synergy (Thopter Token)",
+        "Pia Nalaar, Consul of Revival - Synergy (Thopter Token)",
+        "Mr. House, President and CEO - Synergy (Robot Token)",
+        "Dyadrine, Synthesis Amalgam - Synergy (Robot Token)",
+        "Cayth, Famed Mechanist - Synergy (Servo Kindred)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Generates artifact tokens as modular resources—fueling sacrifice, draw, and cost-reduction engines. Synergies like Treasure and Servo Kindred reinforce the plan."
@@ -1245,8 +1425,8 @@
       ],
       "synergy_commanders": [
         "Old Gnawbone - Synergy (Treasure Token)",
-        "Kodama of the West Tree - Synergy (Equipment Matters)",
-        "Shorikai, Genesis Engine - Synergy (Vehicles)"
+        "Danitha Capashen, Paragon - Synergy (Equipment Matters)",
+        "Tannuk, Memorial Ensign - Synergy (Vehicles)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Leverages dense artifact counts for cost reduction, recursion, and modular scaling payoffs. Synergies like Treasure Token and Equipment Matters reinforce the plan."
@@ -1284,7 +1464,7 @@
         "Cayth, Famed Mechanist - Synergy (Fabricate)",
         "Saheeli, the Gifted - Synergy (Servo Kindred)",
         "Oviya Pashiri, Sage Lifecrafter - Synergy (Servo Kindred)",
-        "Liberator, Urza's Battlethopter - Synergy (Thopter Kindred)"
+        "Saheeli, Sublime Artificer - Synergy (Servo Token)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Focuses on getting a high number of Artificer creatures into play with shared payoffs (e.g., Fabricate and Servo Kindred)."
@@ -1319,9 +1499,8 @@
         "Vona's Hunger"
       ],
       "synergy_commanders": [
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Creature Tokens)",
-        "Mondrak, Glory Dominus - Synergy (Token Creation)",
-        "Lotho, Corrupt Shirriff - Synergy (Tokens Matter)"
+        "Urza, Lord High Artificer - Synergy (Creature Tokens)",
+        "Braids, Arisen Nightmare - Synergy (Card Draw)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Ascend leveraging synergies with Little Fellas."
@@ -1356,12 +1535,11 @@
         "Vein Ripper"
       ],
       "synergy_commanders": [
+        "Aya of Alexandria - Synergy (Assassin Token)",
+        "Ratonhnhaké꞉ton - Synergy (Assassin Token)",
         "Achilles Davenport - Synergy (Freerunning)",
         "Ezio Auditore da Firenze - Synergy (Freerunning)",
-        "Jacob Frye - Synergy (Freerunning)",
-        "Ragavan, Nimble Pilferer - Synergy (Outlaw Kindred)",
-        "Lotho, Corrupt Shirriff - Synergy (Outlaw Kindred)",
-        "Sheoldred, the Apocalypse - Synergy (Deathtouch)"
+        "Ragavan, Nimble Pilferer - Synergy (Outlaw Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Assassin creatures into play with shared payoffs (e.g., Freerunning and Outlaw Kindred)."
@@ -1378,6 +1556,29 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Queen Marchesa",
+        "Aya of Alexandria",
+        "Ratonhnhaké꞉ton",
+        "Massacre Girl - Synergy (Assassin Kindred)",
+        "Massacre Girl, Known Killer - Synergy (Assassin Kindred)"
+      ],
+      "example_cards": [
+        "Queen Marchesa",
+        "Aya of Alexandria",
+        "Rooftop Bypass",
+        "Vraska the Unseen",
+        "Ratonhnhaké꞉ton",
+        "Origin of the Hidden Ones",
+        "Vraska, Swarm's Eminence",
+        "Headsplitter"
+      ],
+      "synergy_commanders": [
+        "The Lord of Pain - Synergy (Assassin Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Assassin Kindred and Creature Tokens reinforce the plan."
     },
@@ -1392,6 +1593,13 @@
         "Big Mana"
       ],
       "primary_color": "White",
+      "example_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)",
+        "Loran of the Third Path - Synergy (Artifacts Matter)",
+        "Lotho, Corrupt Shirriff - Synergy (Artifacts Matter)",
+        "Mondrak, Glory Dominus - Synergy (Token Creation)",
+        "Adeline, Resplendent Cathar - Synergy (Token Creation)"
+      ],
       "example_cards": [
         "Academy Manufactor",
         "Mishra's Factory",
@@ -1401,6 +1609,9 @@
         "Arcbound Prototype",
         "Dutiful Replicator",
         "Cogwork Assembler"
+      ],
+      "synergy_commanders": [
+        "Talrand, Sky Summoner - Synergy (Tokens Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Assembly-Worker creatures into play with shared payoffs."
@@ -1435,9 +1646,10 @@
         "Skystreamer"
       ],
       "synergy_commanders": [
+        "Ghalta, Primal Hunger - Synergy (Big Mana)",
         "Selvala, Heart of the Wilds - Synergy (Blink)",
         "Sheoldred, Whispering One - Synergy (Blink)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)"
+        "Veyran, Voice of Duality - Synergy (Enter the Battlefield)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Assist leveraging synergies with Big Mana and Interaction."
@@ -1472,12 +1684,9 @@
         "Vanguard Suppressor"
       ],
       "synergy_commanders": [
-        "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)",
-        "Chatterfang, Squirrel General - Synergy (Warrior Kindred)",
-        "Moraug, Fury of Akoum - Synergy (Warrior Kindred)",
-        "Selvala, Heart of the Wilds - Synergy (Blink)",
-        "Sheoldred, Whispering One - Synergy (Blink)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)"
+        "God-Eternal Oketra - Synergy (Warrior Token)",
+        "Zurgo Stormrender - Synergy (Warrior Token)",
+        "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Astartes creatures into play with shared payoffs (e.g., Warrior Kindred and Blink)."
@@ -1494,6 +1703,27 @@
       ],
       "primary_color": "White",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Marneus Calgar",
+        "Mortarion, Daemon Primarch",
+        "Belisarius Cawl",
+        "Khârn the Betrayer - Synergy (Astartes Kindred)",
+        "Abaddon the Despoiler - Synergy (Astartes Kindred)"
+      ],
+      "example_cards": [
+        "Thunderhawk Gunship",
+        "Marneus Calgar",
+        "Inquisitorial Rosette",
+        "Birth of the Imperium",
+        "Defenders of Humanity",
+        "Mortarion, Daemon Primarch",
+        "Belisarius Cawl"
+      ],
+      "synergy_commanders": [
+        "God-Eternal Oketra - Synergy (Warrior Token)",
+        "Zurgo Stormrender - Synergy (Warrior Token)",
+        "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Astartes Kindred and Warrior Token reinforce the plan."
     },
@@ -1524,7 +1754,8 @@
         "Chronatog Totem"
       ],
       "synergy_commanders": [
-        "Toski, Bearer of Secrets - Synergy (Little Fellas)"
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)",
+        "Loran of the Third Path - Synergy (Little Fellas)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Atog creatures into play with shared payoffs (e.g., Toughness Matters and Little Fellas)."
@@ -1561,7 +1792,6 @@
       "synergy_commanders": [
         "Calix, Guided by Fate - Synergy (Constellation)",
         "Eutropia the Twice-Favored - Synergy (Constellation)",
-        "Rishkar, Peema Renegade - Synergy (Voltron)",
         "Purphoros, God of the Forge - Synergy (Enchantments Matter)"
       ],
       "popularity_bucket": "Very Common",
@@ -1611,12 +1841,28 @@
         "Body of Knowledge"
       ],
       "synergy_commanders": [
-        "Ojer Pakpatiq, Deepest Epoch // Temple of Cyclical Time - Synergy (Time Counters)",
-        "The Tenth Doctor - Synergy (Time Counters)",
-        "Braids, Arisen Nightmare - Synergy (Politics)"
+        "Appa, Steadfast Guardian - Synergy (Airbending)",
+        "Aang, Swift Savior // Aang and La, Ocean's Fury - Synergy (Airbending)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Avatar creatures into play with shared payoffs (e.g., Time Counters and Politics)."
+    },
+    {
+      "id": "avatar-token",
+      "theme": "Avatar Token",
+      "synergies": [],
+      "primary_color": "White",
+      "secondary_color": "Black",
+      "example_commanders": [
+        "Extus, Oriq Overlord // Awaken the Blood Avatar"
+      ],
+      "example_cards": [
+        "Ajani Goldmane",
+        "Extus, Oriq Overlord // Awaken the Blood Avatar",
+        "Ajani's Last Stand"
+      ],
+      "popularity_bucket": "Rare",
+      "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines."
     },
     {
       "id": "awaken",
@@ -1648,7 +1894,9 @@
         "Coastal Discovery"
       ],
       "synergy_commanders": [
-        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)"
+        "Omnath, Locus of Rage - Synergy (Elemental Kindred)",
+        "Muldrotha, the Gravetide - Synergy (Elemental Kindred)",
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Awaken leveraging synergies with Elemental Kindred and Lands Matter."
@@ -1666,7 +1914,10 @@
       "secondary_color": "Red",
       "example_commanders": [
         "Virtus the Veiled",
-        "Kels, Fight Fixer"
+        "Kels, Fight Fixer",
+        "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)",
+        "Moraug, Fury of Akoum - Synergy (Warrior Kindred)",
+        "Chatterfang, Squirrel General - Synergy (Warrior Kindred)"
       ],
       "example_cards": [
         "Mindblade Render",
@@ -1677,6 +1928,11 @@
         "Rushblade Commander",
         "Kels, Fight Fixer",
         "Blaring Captain"
+      ],
+      "synergy_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)",
+        "Azusa, Lost but Seeking - Synergy (Little Fellas)",
+        "Etali, Primal Storm - Synergy (Aggro)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Azra creatures into play with shared payoffs."
@@ -1711,9 +1967,9 @@
         "Noble Heritage"
       ],
       "synergy_commanders": [
-        "Ragavan, Nimble Pilferer - Synergy (Treasure)",
-        "Lotho, Corrupt Shirriff - Synergy (Treasure)",
-        "Old Gnawbone - Synergy (Treasure Token)"
+        "Sram, Senior Edificer - Synergy (Enchantments Matter)",
+        "Purphoros, God of the Forge - Synergy (Enchantments Matter)",
+        "Ragavan, Nimble Pilferer - Synergy (Treasure)"
       ],
       "popularity_bucket": "Niche",
       "description": "Pairs a Commander with Backgrounds for modular static buffs & class-style customization. Synergies like Choose a background and Enchantments Matter reinforce the plan."
@@ -1749,7 +2005,7 @@
       ],
       "synergy_commanders": [
         "Sheoldred, Whispering One - Synergy (Blink)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)"
+        "Veyran, Voice of Duality - Synergy (Enter the Battlefield)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Backup leveraging synergies with +1/+1 Counters and Blink."
@@ -1783,8 +2039,9 @@
         "Bog Badger"
       ],
       "synergy_commanders": [
-        "Kutzil, Malamet Exemplar - Synergy (Combat Matters)",
-        "Sheoldred, the Apocalypse - Synergy (Combat Matters)"
+        "Azusa, Lost but Seeking - Synergy (Lands Matter)",
+        "Tatyova, Benthic Druid - Synergy (Lands Matter)",
+        "Six - Synergy (Lands Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Badger creatures into play with shared payoffs."
@@ -1819,6 +2076,7 @@
         "Kjeldoran Knight"
       ],
       "synergy_commanders": [
+        "Glissa Sunslayer - Synergy (First strike)",
         "Anim Pakal, Thousandth Moon - Synergy (Soldier Kindred)",
         "Syr Konrad, the Grim - Synergy (Human Kindred)"
       ],
@@ -1855,12 +2113,12 @@
         "Balduvian Warlord"
       ],
       "synergy_commanders": [
+        "Danitha Capashen, Paragon - Synergy (First strike)",
+        "Gisela, Blade of Goldnight - Synergy (First strike)",
+        "Glissa Sunslayer - Synergy (First strike)",
         "Aurelia, the Warleader - Synergy (Haste)",
         "Yahenni, Undying Partisan - Synergy (Haste)",
-        "Kiki-Jiki, Mirror Breaker - Synergy (Haste)",
-        "Syr Konrad, the Grim - Synergy (Human Kindred)",
-        "Azusa, Lost but Seeking - Synergy (Human Kindred)",
-        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Discard Matters)"
+        "Syr Konrad, the Grim - Synergy (Human Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Barbarian creatures into play with shared payoffs (e.g., Human Kindred and Little Fellas)."
@@ -1895,12 +2153,12 @@
         "Narci, Fable Singer"
       ],
       "synergy_commanders": [
-        "Azusa, Lost but Seeking - Synergy (Toughness Matters)",
-        "Sheoldred, the Apocalypse - Synergy (Toughness Matters)",
-        "Vito, Thorn of the Dusk Rose - Synergy (Toughness Matters)",
-        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)",
-        "Toski, Bearer of Secrets - Synergy (Little Fellas)",
-        "Syr Konrad, the Grim - Synergy (Human Kindred)"
+        "Sram, Senior Edificer - Synergy (Dwarf Kindred)",
+        "Torbran, Thane of Red Fell - Synergy (Dwarf Kindred)",
+        "Tataru Taru - Synergy (Dwarf Kindred)",
+        "Jhoira, Weatherlight Captain - Synergy (Sagas Matter)",
+        "Urabrask // The Great Work - Synergy (Sagas Matter)",
+        "Wan Shi Tong, Librarian - Synergy (Bird Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Bard creatures into play with shared payoffs (e.g., Toughness Matters and Little Fellas)."
@@ -1935,9 +2193,11 @@
         "Brave the Wilds"
       ],
       "synergy_commanders": [
-        "Syr Konrad, the Grim - Synergy (Burn)",
-        "Braids, Arisen Nightmare - Synergy (Burn)",
-        "Lotho, Corrupt Shirriff - Synergy (Burn)"
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)",
+        "Lotho, Corrupt Shirriff - Synergy (Token Creation)",
+        "Mondrak, Glory Dominus - Synergy (Token Creation)",
+        "Adeline, Resplendent Cathar - Synergy (Tokens Matter)",
+        "Talrand, Sky Summoner - Synergy (Tokens Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Bargain leveraging synergies with Blink and Enter the Battlefield."
@@ -1958,7 +2218,8 @@
         "Monstrosity of the Lake - Synergy (Landcycling)",
         "The Balrog of Moria - Synergy (Cycling)",
         "Yidaro, Wandering Monster - Synergy (Cycling)",
-        "Baral, Chief of Compliance - Synergy (Loot)"
+        "Baral, Chief of Compliance - Synergy (Loot)",
+        "Rocksteady, Crash Courser - Synergy (Landcycling)"
       ],
       "example_cards": [
         "Ash Barrens",
@@ -1969,6 +2230,11 @@
         "Treacherous Terrain",
         "Grave Upheaval",
         "Topiary Panther"
+      ],
+      "synergy_commanders": [
+        "Jennika, Bad Apple Big Sister - Synergy (Landcycling)",
+        "Zog, Triceraton Castaway - Synergy (Typecycling)",
+        "Bebop, Warthog Warrior - Synergy (Typecycling)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Basic landcycling leveraging synergies with Landcycling and Cycling."
@@ -2002,6 +2268,7 @@
         "Stone-Tongue Basilisk"
       ],
       "synergy_commanders": [
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)",
         "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
       ],
       "popularity_bucket": "Rare",
@@ -2037,10 +2304,9 @@
         "Desecrated Tomb"
       ],
       "synergy_commanders": [
-        "Ludevic, Necro-Alchemist - Synergy (Lifeloss)",
-        "Lich's Mastery - Synergy (Lifeloss)",
-        "Marina Vendrell's Grimoire - Synergy (Lifeloss Triggers)",
-        "Tatyova, Benthic Druid - Synergy (Lifegain)"
+        "Timothar, Baron of Bats - Synergy (Bat Token)",
+        "Mister Negative - Synergy (Lifeloss)",
+        "Ludevic, Necro-Alchemist - Synergy (Lifeloss Triggers)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Bat creatures into play with shared payoffs (e.g., Lifeloss and Lifeloss Triggers)."
@@ -2057,6 +2323,27 @@
       ],
       "primary_color": "Black",
       "secondary_color": "White",
+      "example_commanders": [
+        "Aclazotz, Deepest Betrayal // Temple of the Dead",
+        "Timothar, Baron of Bats",
+        "Momo, Friendly Flier - Synergy (Bat Kindred)",
+        "Blech, Loafing Pest - Synergy (Bat Kindred)",
+        "Vito, Thorn of the Dusk Rose - Synergy (Vampire Kindred)"
+      ],
+      "example_cards": [
+        "Aclazotz, Deepest Betrayal // Temple of the Dead",
+        "Lunar Convocation",
+        "Desecrated Tomb",
+        "Timothar, Baron of Bats",
+        "Sanguine Evangelist",
+        "Regal Bloodlord",
+        "Greed's Gambit",
+        "Skeletal Vampire"
+      ],
+      "synergy_commanders": [
+        "Yahenni, Undying Partisan - Synergy (Vampire Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Bat Kindred and Vampire Kindred reinforce the plan."
     },
@@ -2092,7 +2379,7 @@
       "synergy_commanders": [
         "Boromir, Warden of the Tower - Synergy (Soldier Kindred)",
         "Anim Pakal, Thousandth Moon - Synergy (Soldier Kindred)",
-        "Thalia, Heretic Cathar - Synergy (Soldier Kindred)",
+        "Sephiroth, Fabled SOLDIER // Sephiroth, One-Winged Angel - Synergy (Soldier Kindred)",
         "Etali, Primal Storm - Synergy (Aggro)"
       ],
       "popularity_bucket": "Rare",
@@ -2127,9 +2414,10 @@
         "Loxodon Partisan"
       ],
       "synergy_commanders": [
-        "Toski, Bearer of Secrets - Synergy (Aggro)",
-        "Kutzil, Malamet Exemplar - Synergy (Combat Matters)",
-        "Sheoldred, the Apocalypse - Synergy (Combat Matters)"
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Urza, Lord High Artificer - Synergy (Creature Tokens)",
+        "Toski, Bearer of Secrets - Synergy (Combat Matters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Battle Cry leveraging synergies with Aggro and Combat Matters."
@@ -2164,7 +2452,8 @@
         "Invasion of Gobakhan // Lightshield Array"
       ],
       "synergy_commanders": [
-        "Syr Konrad, the Grim - Synergy (Burn)"
+        "Mondrak, Glory Dominus - Synergy (Protective Effects)",
+        "Tatyova, Benthic Druid - Synergy (Unconditional Draw)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Battles Matter leveraging synergies with Transform and Card Draw."
@@ -2199,12 +2488,10 @@
         "Wilson, Refined Grizzly"
       ],
       "synergy_commanders": [
+        "The Earth King - Synergy (Bear Token)",
         "Tatyova, Benthic Druid - Synergy (Druid Kindred)",
         "Rishkar, Peema Renegade - Synergy (Druid Kindred)",
-        "Jaheira, Friend of the Forest - Synergy (Druid Kindred)",
-        "Ghalta, Primal Hunger - Synergy (Trample)",
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Trample)",
-        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+        "Ghalta, Primal Hunger - Synergy (Trample)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Bear creatures into play with shared payoffs (e.g., Druid Kindred and Trample)."
@@ -2221,6 +2508,27 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "The Earth King",
+        "Goreclaw, Terror of Qal Sisma - Synergy (Bear Kindred)",
+        "Lumra, Bellow of the Woods - Synergy (Bear Kindred)",
+        "Surrak and Goreclaw - Synergy (Bear Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "The Earth King",
+        "Argoth, Sanctum of Nature // Titania, Gaea Incarnate",
+        "Titania's Command",
+        "Fade from History",
+        "Mother Bear",
+        "Ayula's Influence",
+        "Bearscape",
+        "Caller of the Claw"
+      ],
+      "synergy_commanders": [
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Bear Kindred and Creature Tokens reinforce the plan."
     },
@@ -2254,10 +2562,9 @@
         "Cultivator Colossus"
       ],
       "synergy_commanders": [
-        "Brokkos, Apex of Forever - Synergy (Mutate)",
-        "Illuna, Apex of Wishes - Synergy (Mutate)",
-        "Flopsie, Bumi's Buddy - Synergy (Goat Kindred)",
-        "Ilharg, the Raze-Boar - Synergy (Boar Kindred)"
+        "Toby, Beastie Befriender - Synergy (Beast Token)",
+        "Radagast, Wizard of Wilds - Synergy (Beast Token)",
+        "Garruk, Primal Hunter - Synergy (Beast Token)"
       ],
       "popularity_bucket": "Common",
       "description": "Focuses on getting a high number of Beast creatures into play with shared payoffs (e.g., Mutate and Boar Kindred)."
@@ -2274,6 +2581,28 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Toby, Beastie Befriender",
+        "Radagast, Wizard of Wilds",
+        "Loot, Exuberant Explorer - Synergy (Beast Kindred)",
+        "Kona, Rescue Beastie - Synergy (Beast Kindred)",
+        "Questing Beast - Synergy (Beast Kindred)"
+      ],
+      "example_cards": [
+        "Beast Within",
+        "Rampaging Baloths",
+        "Felidar Retreat",
+        "Ezuri's Predation",
+        "Quartzwood Crasher",
+        "Garruk, Primal Hunter",
+        "Primeval Bounty",
+        "Elder Gargaroth"
+      ],
+      "synergy_commanders": [
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Yawgmoth, Thran Physician - Synergy (Planeswalkers)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Beast Kindred and Creature Tokens reinforce the plan."
     },
@@ -2327,8 +2656,10 @@
         "Osseous Exhale"
       ],
       "synergy_commanders": [
-        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Spells Matter)",
-        "Talrand, Sky Summoner - Synergy (Spellslinger)"
+        "Lathliss, Dragon Queen - Synergy (Dragon Kindred)",
+        "Selvala, Heart of the Wilds - Synergy (Blink)",
+        "Sheoldred, Whispering One - Synergy (Blink)",
+        "Veyran, Voice of Duality - Synergy (Enter the Battlefield)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around the Behold theme and its supporting synergies."
@@ -2343,7 +2674,10 @@
       "secondary_color": "Red",
       "example_commanders": [
         "Karazikar, the Eye Tyrant",
-        "Xanathar, Guild Kingpin"
+        "Xanathar, Guild Kingpin",
+        "Syr Konrad, the Grim - Synergy (Big Mana)",
+        "Etali, Primal Storm - Synergy (Big Mana)",
+        "Ghalta, Primal Hunger - Synergy (Big Mana)"
       ],
       "example_cards": [
         "Karazikar, the Eye Tyrant",
@@ -2361,11 +2695,11 @@
       "id": "bending",
       "theme": "Bending",
       "synergies": [
-        "Firebend",
+        "Earthbending",
+        "Waterbending",
+        "Airbending",
         "Earthbend",
-        "Waterbend",
-        "Airbend",
-        "Firebending"
+        "Waterbend"
       ],
       "primary_color": "Blue",
       "secondary_color": "Green",
@@ -2387,9 +2721,10 @@
         "Earthbending Lesson"
       ],
       "synergy_commanders": [
-        "Katara, Water Tribe's Hope - Synergy (Waterbending)",
-        "Yue, the Moon Spirit - Synergy (Waterbending)",
-        "Fire Lord Zuko - Synergy (Firebending)"
+        "Toph, Hardheaded Teacher - Synergy (Earthbending)",
+        "Toph, Earthbending Master - Synergy (Earthbending)",
+        "Bumi, Unleashed - Synergy (Earthbend)",
+        "Fire Lord Azula - Synergy (Firebending)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Bending leveraging synergies with Earthbending and Waterbending."
@@ -2424,12 +2759,8 @@
         "Strong, the Brutish Thespian"
       ],
       "synergy_commanders": [
-        "Varragoth, Bloodsky Sire - Synergy (Boast)",
-        "Sigurd, Jarl of Ravensthorpe - Synergy (Boast)",
-        "Arni Brokenbrow - Synergy (Boast)",
-        "Ragavan, Nimble Pilferer - Synergy (Dash)",
-        "Kolaghan, the Storm's Fury - Synergy (Dash)",
-        "Sram, Senior Edificer - Synergy (Dwarf Kindred)"
+        "Fíli the Pathfinder - Synergy (Dwarf Token)",
+        "Varragoth, Bloodsky Sire - Synergy (Boast)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Berserker creatures into play with shared payoffs (e.g., Trample and Elf Kindred)."
@@ -2446,6 +2777,22 @@
       ],
       "primary_color": "Red",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Fíli the Pathfinder - Synergy (Dwarf Token)",
+        "Kardur, Doomscourge - Synergy (Berserker Kindred)",
+        "Alexios, Deimos of Kosmos - Synergy (Berserker Kindred)",
+        "Sram, Senior Edificer - Synergy (Dwarf Kindred)"
+      ],
+      "example_cards": [
+        "Rise of the Dread Marn",
+        "Reckless Crew",
+        "Fearless Liberator",
+        "Dwarven Hammer",
+        "Dwarven Reinforcements",
+        "Warchanter Skald",
+        "The Bloodsky Massacre",
+        "Draugr's Helm"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Dwarf Token and Berserker Kindred reinforce the plan."
     },
@@ -2480,7 +2827,8 @@
       ],
       "synergy_commanders": [
         "Sythis, Harvest's Hand - Synergy (Nymph Kindred)",
-        "Goldberry, River-Daughter - Synergy (Nymph Kindred)"
+        "Goldberry, River-Daughter - Synergy (Nymph Kindred)",
+        "Psemilla, Meletian Poet - Synergy (Nymph Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Bestow leveraging synergies with Equipment Matters and Auras."
@@ -2554,12 +2902,12 @@
         "Jhoira's Familiar"
       ],
       "synergy_commanders": [
+        "Hermes, Overseer of Elpis - Synergy (Bird Token)",
+        "The Raven Man - Synergy (Bird Token)",
+        "Gwaihir, Greatest of the Eagles - Synergy (Bird Token)",
         "Niv-Mizzet, Parun - Synergy (Flying)",
         "Avacyn, Angel of Hope - Synergy (Flying)",
-        "Old Gnawbone - Synergy (Flying)",
-        "Boromir, Warden of the Tower - Synergy (Soldier Kindred)",
-        "Anim Pakal, Thousandth Moon - Synergy (Soldier Kindred)",
-        "Yawgmoth, Thran Physician - Synergy (Protection)"
+        "Bello, Bard of the Brambles - Synergy (Bard Kindred)"
       ],
       "popularity_bucket": "Common",
       "description": "Focuses on getting a high number of Bird creatures into play with shared payoffs (e.g., Flying and Soldier Kindred)."
@@ -2576,6 +2924,31 @@
       ],
       "primary_color": "White",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Hermes, Overseer of Elpis",
+        "The Raven Man",
+        "Gwaihir, Greatest of the Eagles",
+        "Rendmaw, Creaking Nest",
+        "Riku of Many Paths"
+      ],
+      "example_cards": [
+        "Swan Song",
+        "Strix Serenade",
+        "Aether Channeler",
+        "Murmuring Mystic",
+        "Ravenform",
+        "Emeria Angel",
+        "Perch Protection",
+        "Chocobo Racetrack"
+      ],
+      "synergy_commanders": [
+        "Wan Shi Tong, Librarian - Synergy (Bird Kindred)",
+        "Teshar, Ancestor's Apostle - Synergy (Bird Kindred)",
+        "Breena, the Demagogue - Synergy (Bird Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Bird Kindred and Creature Tokens reinforce the plan."
     },
@@ -2603,6 +2976,29 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Red",
+      "example_commanders": [
+        "High Perfect Morcant",
+        "Auntie Ool, Cursewretch",
+        "Grub, Storied Matriarch // Grub, Notorious Auntie",
+        "Yawgmoth, Thran Physician - Synergy (-1/-1 Counters)",
+        "Vorinclex, Monstrous Raider - Synergy (-1/-1 Counters)"
+      ],
+      "example_cards": [
+        "High Perfect Morcant",
+        "Sinister Gnarlbark",
+        "Scuzzback Scrounger",
+        "Auntie Ool, Cursewretch",
+        "Dawnhand Dissident",
+        "Burning Curiosity",
+        "Grub, Storied Matriarch // Grub, Notorious Auntie",
+        "Bogslither's Embrace"
+      ],
+      "synergy_commanders": [
+        "Tekuthal, Inquiry Dominus - Synergy (-1/-1 Counters)",
+        "Saryth, the Viper's Fang - Synergy (Warlock Kindred)",
+        "Honest Rutstein - Synergy (Warlock Kindred)",
+        "Krenko, Tin Street Kingpin - Synergy (Goblin Kindred)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Blight leveraging synergies with -1/-1 Counters and Warlock Kindred."
     },
@@ -2636,6 +3032,7 @@
         "Mithril Coat"
       ],
       "synergy_commanders": [
+        "Veyran, Voice of Duality - Synergy (Enter the Battlefield)",
         "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
       ],
       "popularity_bucket": "Very Common",
@@ -2672,7 +3069,7 @@
       ],
       "synergy_commanders": [
         "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)",
-        "Chatterfang, Squirrel General - Synergy (Warrior Kindred)",
+        "Moraug, Fury of Akoum - Synergy (Warrior Kindred)",
         "Syr Konrad, the Grim - Synergy (Sacrifice Matters)"
       ],
       "popularity_bucket": "Rare",
@@ -2684,6 +3081,15 @@
       "synergies": [],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Rayami, First of the Fallen"
+      ],
+      "example_cards": [
+        "Font of Agonies",
+        "Rayami, First of the Fallen",
+        "Rakdos Riteknife",
+        "Bloodletter Quill"
+      ],
       "popularity_bucket": "Rare",
       "description": "Uses Blood tokens to loot, set up graveyard recursion, and trigger discard/madness payoffs."
     },
@@ -2749,6 +3155,7 @@
         "Scab-Clan Charger"
       ],
       "synergy_commanders": [
+        "Ivora, Insatiable Heir - Synergy (Blood Token)",
         "Toski, Bearer of Secrets - Synergy (Combat Matters)"
       ],
       "popularity_bucket": "Rare",
@@ -2784,8 +3191,9 @@
         "Skarrgan Pit-Skulk"
       ],
       "synergy_commanders": [
-        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)",
-        "Krenko, Tin Street Kingpin - Synergy (+1/+1 Counters)"
+        "Ivora, Insatiable Heir - Synergy (Blood Token)",
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)",
+        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Uses Blood tokens to loot, set up graveyard recursion, and trigger discard/madness payoffs. Synergies like Blood Token and Burn reinforce the plan."
@@ -2820,11 +3228,8 @@
         "Decimator of the Provinces"
       ],
       "synergy_commanders": [
-        "Questing Beast - Synergy (Beast Kindred)",
         "Kona, Rescue Beastie - Synergy (Beast Kindred)",
-        "Ghalta, Primal Hunger - Synergy (Trample)",
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Trample)",
-        "Ragavan, Nimble Pilferer - Synergy (Artifact Tokens)"
+        "Ghalta, Primal Hunger - Synergy (Trample)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Boar creatures into play with shared payoffs (e.g., Beast Kindred and Trample)."
@@ -2840,6 +3245,25 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Ilharg, the Raze-Boar - Synergy (Boar Kindred)",
+        "Yasharn, Implacable Earth - Synergy (Boar Kindred)",
+        "Spider-Ham, Peter Porker - Synergy (Boar Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Curse of the Swine",
+        "Contraband Livestock",
+        "Stampede Surfer",
+        "Wolf's Quarry",
+        "Brindle Shoat",
+        "Carefree Swinemaster",
+        "Rural Recruit"
+      ],
+      "synergy_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Boar Kindred and Creature Tokens reinforce the plan."
     },
@@ -2873,10 +3297,11 @@
         "Damnation"
       ],
       "synergy_commanders": [
-        "Elas il-Kor, Sadistic Pilgrim - Synergy (Pingers)",
-        "Niv-Mizzet, Parun - Synergy (Pingers)",
+        "Avacyn, Angel of Hope - Synergy (Interaction)",
         "Boromir, Warden of the Tower - Synergy (Interaction)",
-        "Urabrask // The Great Work - Synergy (Lore Counters)"
+        "Padeem, Consul of Innovation - Synergy (Interaction)",
+        "Urabrask // The Great Work - Synergy (Lore Counters)",
+        "Sheoldred // The True Scriptures - Synergy (Lore Counters)"
       ],
       "popularity_bucket": "Common",
       "description": "Builds around Board Wipes leveraging synergies with Pingers and Interaction."
@@ -2912,8 +3337,9 @@
       ],
       "synergy_commanders": [
         "Kardur, Doomscourge - Synergy (Berserker Kindred)",
-        "Magda, Brazen Outlaw - Synergy (Berserker Kindred)",
         "Alexios, Deimos of Kosmos - Synergy (Berserker Kindred)",
+        "Magda, Brazen Outlaw - Synergy (Berserker Kindred)",
+        "Moraug, Fury of Akoum - Synergy (Warrior Kindred)",
         "Syr Konrad, the Grim - Synergy (Human Kindred)"
       ],
       "popularity_bucket": "Rare",
@@ -2950,8 +3376,8 @@
       ],
       "synergy_commanders": [
         "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)",
-        "Samut, Voice of Dissent - Synergy (Combat Tricks)",
-        "Naru Meha, Master Wizard - Synergy (Combat Tricks)",
+        "The Wandering Rescuer - Synergy (Combat Tricks)",
+        "Ambrosia Whiteheart - Synergy (Combat Tricks)",
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
       ],
       "popularity_bucket": "Rare",
@@ -2967,7 +3393,9 @@
       "example_commanders": [
         "Shay Cormac",
         "Chevill, Bane of Monsters",
-        "Mathas, Fiend Seeker"
+        "Mathas, Fiend Seeker",
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)"
       ],
       "example_cards": [
         "Shay Cormac",
@@ -2976,6 +3404,9 @@
         "Chevill, Bane of Monsters",
         "Mathas, Fiend Seeker",
         "Bounty Hunter"
+      ],
+      "synergy_commanders": [
+        "Rishkar, Peema Renegade - Synergy (Counters Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Accumulates bounty counters to unlock scaling payoffs, removal triggers, or delayed value conversions."
@@ -2991,6 +3422,23 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Ghalta, Primal Hunger - Synergy (Trample)",
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Trample)",
+        "Ghalta, Stampede Tyrant - Synergy (Trample)",
+        "Syr Konrad, the Grim - Synergy (Big Mana)",
+        "Etali, Primal Storm - Synergy (Big Mana)"
+      ],
+      "example_cards": [
+        "Bringer of the Black Dawn",
+        "Bringer of the Blue Dawn",
+        "Bringer of the Red Dawn",
+        "Bringer of the White Dawn",
+        "Bringer of the Green Dawn"
+      ],
+      "synergy_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Aggro)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Bringer creatures into play with shared payoffs (e.g., Trample and Big Mana)."
     },
@@ -3148,10 +3596,18 @@
       "id": "camel-kindred",
       "theme": "Camel Kindred",
       "synergies": [
+        "Toughness Matters",
         "Little Fellas"
       ],
       "primary_color": "White",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Jandor, Fortuned Traveler",
+        "Azusa, Lost but Seeking - Synergy (Toughness Matters)",
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)",
+        "Sheoldred, the Apocalypse - Synergy (Toughness Matters)",
+        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
+      ],
       "example_cards": [
         "Tasseled Dromedary",
         "Steel Dromedary",
@@ -3161,6 +3617,9 @@
         "Wretched Camel",
         "Dromad Purebred",
         "Supply Caravan"
+      ],
+      "synergy_commanders": [
+        "Loran of the Third Path - Synergy (Little Fellas)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Camel creatures into play with shared payoffs."
@@ -3195,11 +3654,11 @@
         "Preordain"
       ],
       "synergy_commanders": [
+        "Erebos, God of the Dead - Synergy (Life to Draw)",
+        "Fixer, Techno Terror - Synergy (Life to Draw)",
+        "Arguel's Blood Fast // Temple of Aclazotz - Synergy (Life to Draw)",
         "Lonis, Cryptozoologist - Synergy (Clue Token)",
         "Astrid Peth - Synergy (Clue Token)",
-        "Piper Wright, Publick Reporter - Synergy (Clue Token)",
-        "Tivit, Seller of Secrets - Synergy (Investigate)",
-        "Kellan, Inquisitive Prodigy // Tail the Suspect - Synergy (Investigate)",
         "Tatyova, Benthic Druid - Synergy (Unconditional Draw)"
       ],
       "popularity_bucket": "Common",
@@ -3259,9 +3718,8 @@
       ],
       "synergy_commanders": [
         "Baral, Chief of Compliance - Synergy (Loot)",
-        "The Locust God - Synergy (Loot)",
-        "Malcolm, Alluring Scoundrel - Synergy (Loot)",
-        "Asmodeus the Archfiend - Synergy (Replacement Draw)"
+        "Ashling, Flame Dancer - Synergy (Loot)",
+        "Malcolm, Alluring Scoundrel - Synergy (Loot)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Builds around Card Draw leveraging synergies with Loot and Wheels."
@@ -3297,6 +3755,7 @@
       ],
       "synergy_commanders": [
         "Kellan, Daring Traveler // Journey On - Synergy (Map Token)",
+        "Thrór's Map - Synergy (Map Token)",
         "Selvala, Heart of the Wilds - Synergy (Scout Kindred)"
       ],
       "popularity_bucket": "Niche",
@@ -3357,8 +3816,8 @@
         "Etali, Primal Storm - Synergy (Exile Matters)",
         "Ragavan, Nimble Pilferer - Synergy (Exile Matters)",
         "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Exile Matters)",
-        "The Reality Chip - Synergy (Topdeck)",
         "Loot, Exuberant Explorer - Synergy (Topdeck)",
+        "The Reality Chip - Synergy (Topdeck)",
         "Syr Konrad, the Grim - Synergy (Big Mana)"
       ],
       "popularity_bucket": "Rare",
@@ -3421,6 +3880,7 @@
         "Dig Up the Body"
       ],
       "synergy_commanders": [
+        "Zada, Hedron Grinder - Synergy (Spell Copy)",
         "Sheoldred, the Apocalypse - Synergy (Aristocrats)"
       ],
       "popularity_bucket": "Rare",
@@ -3456,12 +3916,11 @@
         "Felidar Guardian"
       ],
       "synergy_commanders": [
+        "Brimaz, King of Oreskos - Synergy (Cat Token)",
+        "Arahbo, the First Fang - Synergy (Cat Token)",
         "Chatterfang, Squirrel General - Synergy (Forestwalk)",
         "Jedit Ojanen of Efrava - Synergy (Forestwalk)",
-        "Mirri, Cat Warrior - Synergy (Forestwalk)",
-        "Loran of the Third Path - Synergy (Vigilance)",
-        "Adeline, Resplendent Cathar - Synergy (Vigilance)",
-        "Dr. Madison Li - Synergy (Energy Counters)"
+        "Nethroi, Apex of Death - Synergy (Mutate)"
       ],
       "popularity_bucket": "Common",
       "description": "Focuses on getting a high number of Cat creatures into play with shared payoffs (e.g., Forestwalk and Landfall)."
@@ -3474,10 +3933,35 @@
         "Warrior Token",
         "Creature Tokens",
         "Lifelink",
-        "Token Creation"
+        "Planeswalkers"
       ],
       "primary_color": "White",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Jolrael, Mwonvuli Recluse",
+        "Brimaz, King of Oreskos",
+        "Arahbo, the First Fang",
+        "Jinnie Fay, Jetmir's Second",
+        "Ajani, Nacatl Pariah // Ajani, Nacatl Avenger"
+      ],
+      "example_cards": [
+        "Felidar Retreat",
+        "Ocelot Pride",
+        "Jolrael, Mwonvuli Recluse",
+        "Esika's Chariot",
+        "Regal Caracal",
+        "Brimaz, King of Oreskos",
+        "Ajani, Strength of the Pride",
+        "Leonin Warleader"
+      ],
+      "synergy_commanders": [
+        "Kutzil, Malamet Exemplar - Synergy (Cat Kindred)",
+        "Jetmir, Nexus of Revels - Synergy (Cat Kindred)",
+        "Ygra, Eater of All - Synergy (Cat Kindred)",
+        "God-Eternal Oketra - Synergy (Warrior Token)",
+        "Zurgo Stormrender - Synergy (Warrior Token)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Cat Kindred and Warrior Token reinforce the plan."
     },
@@ -3511,8 +3995,9 @@
         "Hidden Nursery"
       ],
       "synergy_commanders": [
+        "Aloy, Savior of Meridian - Synergy (Discover)",
         "Karametra, God of Harvests - Synergy (Land Types Matter)",
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Transform)"
+        "Azusa, Lost but Seeking - Synergy (Lands Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Caves Matter leveraging synergies with Discover and Land Types Matter."
@@ -3544,6 +4029,11 @@
         "Belligerent of the Ball",
         "Tuinvale Guide"
       ],
+      "synergy_commanders": [
+        "Loran of the Third Path - Synergy (Little Fellas)",
+        "Etali, Primal Storm - Synergy (Aggro)",
+        "Kutzil, Malamet Exemplar - Synergy (Combat Matters)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around the Celebration theme and its supporting synergies."
     },
@@ -3554,8 +4044,8 @@
         "Centaur Token",
         "Threshold",
         "Archer Kindred",
-        "Druid Kindred",
-        "Shaman Kindred"
+        "Shaman Kindred",
+        "Druid Kindred"
       ],
       "primary_color": "Green",
       "secondary_color": "White",
@@ -3577,12 +4067,8 @@
         "Nikya of the Old Ways"
       ],
       "synergy_commanders": [
-        "Legolas Greenleaf - Synergy (Archer Kindred)",
-        "Finneas, Ace Archer - Synergy (Archer Kindred)",
-        "Tor Wauki the Younger - Synergy (Archer Kindred)",
-        "Selvala, Heart of the Wilds - Synergy (Scout Kindred)",
-        "Delney, Streetwise Lookout - Synergy (Scout Kindred)",
-        "Tatyova, Benthic Druid - Synergy (Druid Kindred)"
+        "Kiora, the Rising Tide - Synergy (Threshold)",
+        "Finneas, Ace Archer - Synergy (Archer Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Centaur creatures into play with shared payoffs (e.g., Archer Kindred and Shaman Kindred)."
@@ -3599,6 +4085,26 @@
       ],
       "primary_color": "Green",
       "secondary_color": "White",
+      "example_commanders": [
+        "Braulios of Pheres Band - Synergy (Centaur Kindred)",
+        "Nikya of the Old Ways - Synergy (Centaur Kindred)",
+        "Karador, Ghost Chieftain - Synergy (Centaur Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Hunted Horror",
+        "Rampage of the Clans",
+        "Vitu-Ghazi Guildmage",
+        "Call of the Conclave",
+        "Alive // Well",
+        "Centaur Glade",
+        "Centaur's Herald",
+        "Coursers' Accord"
+      ],
+      "synergy_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Centaur Kindred and Creature Tokens reinforce the plan."
     },
@@ -3627,6 +4133,9 @@
         "Changeling Titan",
         "Boggart Mob",
         "Changeling Hero"
+      ],
+      "synergy_commanders": [
+        "Sram, Senior Edificer - Synergy (Combat Matters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Champion leveraging synergies with Aggro and Combat Matters."
@@ -3661,7 +4170,10 @@
         "Crib Swap"
       ],
       "synergy_commanders": [
-        "Naru Meha, Master Wizard - Synergy (Combat Tricks)",
+        "Chameleon, Master of Disguise - Synergy (Shapeshifter Kindred)",
+        "Irma, Part-Time Mutant - Synergy (Shapeshifter Kindred)",
+        "The Wandering Rescuer - Synergy (Combat Tricks)",
+        "Ambrosia Whiteheart - Synergy (Combat Tricks)",
         "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
       ],
       "popularity_bucket": "Rare",
@@ -3735,9 +4247,8 @@
         "Umezawa's Jitte"
       ],
       "synergy_commanders": [
-        "Codsworth, Handy Helper - Synergy (Mana Rock)",
-        "Karn, Legacy Reforged - Synergy (Mana Rock)",
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
+        "The Eternity Elevator - Synergy (Station)",
+        "Codsworth, Handy Helper - Synergy (Mana Rock)"
       ],
       "popularity_bucket": "Niche",
       "description": "Accumulates charge counters to unlock scaling payoffs, removal triggers, or delayed value conversions."
@@ -3769,7 +4280,8 @@
         "Gnostro, Voice of the Crags",
         "Syr Konrad, the Grim - Synergy (Big Mana)",
         "Etali, Primal Storm - Synergy (Big Mana)",
-        "Tatyova, Benthic Druid - Synergy (Big Mana)"
+        "Tatyova, Benthic Druid - Synergy (Big Mana)",
+        "Niv-Mizzet, Parun - Synergy (Flying)"
       ],
       "example_cards": [
         "Apex Devastator",
@@ -3780,6 +4292,13 @@
         "Spellheart Chimera",
         "Embermouth Sentinel",
         "Riptide Chimera"
+      ],
+      "synergy_commanders": [
+        "Avacyn, Angel of Hope - Synergy (Flying)",
+        "Aurelia, the Warleader - Synergy (Flying)",
+        "Loot, Exuberant Explorer - Synergy (Topdeck)",
+        "The Reality Chip - Synergy (Topdeck)",
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Chimera creatures into play with shared payoffs (e.g., Big Mana)."
@@ -3814,8 +4333,8 @@
         "Gale, Waterdeep Prodigy"
       ],
       "synergy_commanders": [
-        "Selvala, Heart of the Wilds - Synergy (Elf Kindred)",
-        "Rishkar, Peema Renegade - Synergy (Elf Kindred)",
+        "Sram, Senior Edificer - Synergy (Enchantments Matter)",
+        "Purphoros, God of the Forge - Synergy (Enchantments Matter)",
         "Vito, Thorn of the Dusk Rose - Synergy (Cleric Kindred)"
       ],
       "popularity_bucket": "Rare",
@@ -3867,7 +4386,11 @@
         "Hands of Binding"
       ],
       "synergy_commanders": [
-        "Lotho, Corrupt Shirriff - Synergy (Spells Matter)"
+        "Lotho, Corrupt Shirriff - Synergy (Spells Matter)",
+        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Spells Matter)",
+        "Mangara, the Diplomat - Synergy (Spells Matter)",
+        "Niv-Mizzet, Parun - Synergy (Spellslinger)",
+        "Talrand, Sky Summoner - Synergy (Spellslinger)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Cipher leveraging synergies with Aggro and Combat Matters."
@@ -3902,11 +4425,11 @@
         "Dockside Chef"
       ],
       "synergy_commanders": [
+        "Silk, Web Weaver - Synergy (Citizen Token)",
+        "Phabine, Boss's Confidant - Synergy (Citizen Token)",
+        "Kitt Kanto, Mayhem Diva - Synergy (Citizen Token)",
         "Lotho, Corrupt Shirriff - Synergy (Halfling Kindred)",
-        "Rosie Cotton of South Lane - Synergy (Halfling Kindred)",
-        "Samwise Gamgee - Synergy (Food Token)",
-        "Farmer Cotton - Synergy (Food Token)",
-        "Syr Ginger, the Meal Ender - Synergy (Food)"
+        "Falco Spara, Pactweaver - Synergy (Shield Counters)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Citizen creatures into play with shared payoffs (e.g., Halfling Kindred and Food Token)."
@@ -3923,6 +4446,30 @@
       ],
       "primary_color": "White",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Silk, Web Weaver",
+        "Phabine, Boss's Confidant",
+        "Kitt Kanto, Mayhem Diva",
+        "Spider-Girl, Legacy Hero",
+        "Peregrin Took - Synergy (Citizen Kindred)"
+      ],
+      "example_cards": [
+        "Grand Crescendo",
+        "Halo Fountain",
+        "Master of Ceremonies",
+        "Prosperous Partnership",
+        "Boss's Chauffeur",
+        "Planewide Celebration",
+        "Cabaretti Charm",
+        "Sanctuary Warden"
+      ],
+      "synergy_commanders": [
+        "The Cabbage Merchant - Synergy (Citizen Kindred)",
+        "Ms. Bumbleflower - Synergy (Citizen Kindred)",
+        "Ragavan, Nimble Pilferer - Synergy (Treasure)",
+        "Lotho, Corrupt Shirriff - Synergy (Treasure)",
+        "Old Gnawbone - Synergy (Treasure Token)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Citizen Kindred and Treasure reinforce the plan."
     },
@@ -3956,8 +4503,8 @@
         "Whirlpool Whelm"
       ],
       "synergy_commanders": [
-        "Sheoldred, Whispering One - Synergy (Control)",
-        "Ulamog, the Infinite Gyre - Synergy (Removal)"
+        "Mangara, the Diplomat - Synergy (Control)",
+        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Spells Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Clash leveraging synergies with Warrior Kindred and Control."
@@ -4021,9 +4568,9 @@
         "Selfless Spirit"
       ],
       "synergy_commanders": [
-        "Tatyova, Benthic Druid - Synergy (Lifegain)",
-        "Sheoldred, the Apocalypse - Synergy (Lifegain)",
-        "Pearl-Ear, Imperial Advisor - Synergy (Fox Kindred)"
+        "Heliod, God of the Sun - Synergy (Cleric Token)",
+        "Clavileño, First of the Blessed - Synergy (Demon Token)",
+        "Tasha, the Witch Queen - Synergy (Demon Token)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Focuses on getting a high number of Cleric creatures into play with shared payoffs (e.g., Lifegain and Life Matters)."
@@ -4038,8 +4585,27 @@
         "Life Matters",
         "Token Creation"
       ],
-      "primary_color": "Black",
-      "secondary_color": "White",
+      "primary_color": "White",
+      "secondary_color": "Black",
+      "example_commanders": [
+        "Heliod, God of the Sun",
+        "Vito, Thorn of the Dusk Rose - Synergy (Cleric Kindred)",
+        "Elas il-Kor, Sadistic Pilgrim - Synergy (Cleric Kindred)",
+        "Mangara, the Diplomat - Synergy (Cleric Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Westvale Abbey // Ormendahl, Profane Prince",
+        "Hallowed Haunting",
+        "Heliod, God of the Sun",
+        "Hanweir Militia Captain // Westvale Cult Leader",
+        "Rite of Belzenlok",
+        "Deathpact Angel"
+      ],
+      "synergy_commanders": [
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Sheoldred, the Apocalypse - Synergy (Lifegain)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Cleric Kindred and Creature Tokens reinforce the plan."
     },
@@ -4072,8 +4638,10 @@
         "Veiled Ascension"
       ],
       "synergy_commanders": [
+        "Valgavoth, Terror Eater - Synergy (Ward)",
         "Toski, Bearer of Secrets - Synergy (Protective Effects)",
-        "Mondrak, Glory Dominus - Synergy (Protective Effects)"
+        "Mondrak, Glory Dominus - Synergy (Protective Effects)",
+        "Lotho, Corrupt Shirriff - Synergy (Spells Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around the Cloak theme and its supporting synergies."
@@ -4109,8 +4677,6 @@
       ],
       "synergy_commanders": [
         "The Master, Multiplied - Synergy (Myriad)",
-        "Trostani, Selesnya's Voice - Synergy (Populate)",
-        "Cayth, Famed Mechanist - Synergy (Populate)",
         "Temmet, Vizier of Naktamun - Synergy (Embalm)"
       ],
       "popularity_bucket": "Common",
@@ -4140,6 +4706,7 @@
         "Robo-Piñata"
       ],
       "synergy_commanders": [
+        "Kilo, Apogee Mind - Synergy (Robot Kindred)",
         "Loran of the Third Path - Synergy (Artifacts Matter)"
       ],
       "popularity_bucket": "Rare",
@@ -4175,8 +4742,9 @@
         "Disorder in the Court"
       ],
       "synergy_commanders": [
-        "Tivit, Seller of Secrets - Synergy (Investigate)",
         "Kellan, Inquisitive Prodigy // Tail the Suspect - Synergy (Investigate)",
+        "Tivit, Seller of Secrets - Synergy (Investigate)",
+        "G'raha Tia, Scion Reborn - Synergy (Gates Matter)",
         "Nelly Borca, Impulsive Accuser - Synergy (Detective Kindred)"
       ],
       "popularity_bucket": "Niche",
@@ -4222,6 +4790,9 @@
         "Spawnbinder Mage",
         "Zulaport Chainmage"
       ],
+      "synergy_commanders": [
+        "The Earth King - Synergy (Ally Kindred)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Cohort leveraging synergies with Ally Kindred."
     },
@@ -4255,8 +4826,8 @@
         "Conspiracy Unraveler"
       ],
       "synergy_commanders": [
-        "Emry, Lurker of the Loch - Synergy (Mill)",
-        "Etali, Primal Storm - Synergy (Big Mana)"
+        "Six - Synergy (Graveyard Recursion)",
+        "Muldrotha, the Gravetide - Synergy (Graveyard Recursion)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Collect evidence leveraging synergies with Detective Kindred and Mill."
@@ -4292,8 +4863,8 @@
       ],
       "synergy_commanders": [
         "Sram, Senior Edificer - Synergy (Voltron)",
-        "Rishkar, Peema Renegade - Synergy (Voltron)",
-        "Krenko, Tin Street Kingpin - Synergy (+1/+1 Counters)"
+        "Danitha Capashen, Paragon - Synergy (Voltron)",
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Builds around Combat Matters leveraging synergies with Aggro and Voltron."
@@ -4329,7 +4900,7 @@
       ],
       "synergy_commanders": [
         "Liberator, Urza's Battlethopter - Synergy (Flash)",
-        "Jin-Gitaxias, Core Augur - Synergy (Flash)",
+        "Wan Shi Tong, Librarian - Synergy (Flash)",
         "Malcolm, Alluring Scoundrel - Synergy (Flash)"
       ],
       "popularity_bucket": "Very Common",
@@ -4343,6 +4914,28 @@
       ],
       "primary_color": "White",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Lurrus of the Dream-Den",
+        "Zirda, the Dawnwaker",
+        "Jegantha, the Wellspring",
+        "Gyruda, Doom of Depths",
+        "Yorion, Sky Nomad"
+      ],
+      "example_cards": [
+        "Lurrus of the Dream-Den",
+        "Zirda, the Dawnwaker",
+        "Jegantha, the Wellspring",
+        "Gyruda, Doom of Depths",
+        "Yorion, Sky Nomad",
+        "Kaheera, the Orphanguard",
+        "Keruga, the Macrosage",
+        "Obosh, the Preypiercer"
+      ],
+      "synergy_commanders": [
+        "Syr Konrad, the Grim - Synergy (Big Mana)",
+        "Etali, Primal Storm - Synergy (Big Mana)",
+        "Ghalta, Primal Hunger - Synergy (Big Mana)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Companion leveraging synergies with Big Mana."
     },
@@ -4357,6 +4950,13 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Ral, Monsoon Mage // Ral, Leyline Prodigy - Synergy (Loyalty Counters)",
+        "Jeska, Thrice Reborn - Synergy (Loyalty Counters)",
+        "Commodore Guff - Synergy (Loyalty Counters)",
+        "Adeline, Resplendent Cathar - Synergy (Planeswalkers)",
+        "Yawgmoth, Thran Physician - Synergy (Planeswalkers)"
+      ],
       "example_cards": [
         "Vraska, Betrayal's Sting",
         "Nissa, Ascended Animist",
@@ -4365,6 +4965,9 @@
         "Tamiyo, Compleated Sage",
         "Lukka, Bound to Ruin",
         "Nahiri, the Unforgiving"
+      ],
+      "synergy_commanders": [
+        "Vorinclex, Monstrous Raider - Synergy (Superfriends)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around the Compleated theme and its supporting synergies."
@@ -4402,9 +5005,9 @@
         "Mendicant Core, Guidelight - Synergy (Max speed)",
         "Vnwxt, Verbose Host - Synergy (Max speed)",
         "Zahur, Glory's Past - Synergy (Max speed)",
-        "The Speed Demon - Synergy (Start your engines!)",
-        "Hazoret, Godseeker - Synergy (Start your engines!)",
-        "Jaxis, the Troublemaker - Synergy (Blitz)"
+        "Raffine, Scheming Seer - Synergy (Connive)",
+        "Norman Osborn // Green Goblin - Synergy (Connive)",
+        "The Speed Demon - Synergy (Start your engines!)"
       ],
       "popularity_bucket": "Common",
       "description": "Builds around Conditional Draw leveraging synergies with Start your engines! and Max speed."
@@ -4440,11 +5043,11 @@
       ],
       "synergy_commanders": [
         "Baral, Chief of Compliance - Synergy (Loot)",
-        "The Locust God - Synergy (Loot)",
+        "Ashling, Flame Dancer - Synergy (Loot)",
         "Malcolm, Alluring Scoundrel - Synergy (Loot)",
-        "Lotho, Corrupt Shirriff - Synergy (Rogue Kindred)",
-        "Sakashima of a Thousand Faces - Synergy (Rogue Kindred)",
-        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Discard Matters)"
+        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Discard Matters)",
+        "Yawgmoth, Thran Physician - Synergy (Discard Matters)",
+        "Lotho, Corrupt Shirriff - Synergy (Rogue Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Uses Connive looting + counters to sculpt hands, grow threats, and feed recursion lines. Synergies like Loot and Discard Matters reinforce the plan."
@@ -4477,7 +5080,8 @@
         "Traitor's Roar"
       ],
       "synergy_commanders": [
-        "Niv-Mizzet, Parun - Synergy (Spellslinger)"
+        "Zada, Hedron Grinder - Synergy (Spell Copy)",
+        "Mangara, the Diplomat - Synergy (Spellslinger)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Conspire leveraging synergies with Spell Copy and Spells Matter."
@@ -4514,7 +5118,7 @@
       "synergy_commanders": [
         "Sythis, Harvest's Hand - Synergy (Nymph Kindred)",
         "Goldberry, River-Daughter - Synergy (Nymph Kindred)",
-        "Kestia, the Cultivator - Synergy (Nymph Kindred)",
+        "Psemilla, Meletian Poet - Synergy (Nymph Kindred)",
         "Azusa, Lost but Seeking - Synergy (Toughness Matters)"
       ],
       "popularity_bucket": "Rare",
@@ -4550,7 +5154,7 @@
         "Steel Overseer"
       ],
       "synergy_commanders": [
-        "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)"
+        "Tri-Sentinel, Act of Vengeance - Synergy (Unearth)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Construct creatures into play with shared payoffs (e.g., Prototype and Unearth)."
@@ -4567,6 +5171,28 @@
       ],
       "primary_color": "Red",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Urza, Lord High Artificer",
+        "Jan Jansen, Chaos Crafter",
+        "Urza, Chief Artificer",
+        "Oviya Pashiri, Sage Lifecrafter",
+        "Traxos, Scourge of Kroog - Synergy (Construct Kindred)"
+      ],
+      "example_cards": [
+        "Urza's Saga",
+        "Urza, Lord High Artificer",
+        "Simulacrum Synthesizer",
+        "Ancient Stone Idol",
+        "Metallurgic Summonings",
+        "Jan Jansen, Chaos Crafter",
+        "Retrofitter Foundry",
+        "Urza, Chief Artificer"
+      ],
+      "synergy_commanders": [
+        "Loran of the Third Path - Synergy (Artificer Kindred)",
+        "Sai, Master Thopterist - Synergy (Artificer Kindred)",
+        "Ragavan, Nimble Pilferer - Synergy (Artifact Tokens)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Construct Kindred and Artificer Kindred reinforce the plan."
     },
@@ -4600,9 +5226,9 @@
         "Fierce Guardianship"
       ],
       "synergy_commanders": [
+        "Tivit, Seller of Secrets - Synergy (Council's dilemma)",
         "Tovolar, Dire Overlord // Tovolar, the Midnight Scourge - Synergy (Daybound)",
-        "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury - Synergy (Daybound)",
-        "Tivit, Seller of Secrets - Synergy (Council's dilemma)"
+        "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury - Synergy (Daybound)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Trades efficiently, accrues card advantage, and wins via inevitability once the board is stabilized. Synergies like Daybound and Nightbound reinforce the plan."
@@ -4637,7 +5263,12 @@
         "Skyrider Elf"
       ],
       "synergy_commanders": [
-        "Syr Konrad, the Grim - Synergy (Big Mana)"
+        "Muldrotha, the Gravetide - Synergy (Avatar Kindred)",
+        "Sephiroth, Fabled SOLDIER // Sephiroth, One-Winged Angel - Synergy (Avatar Kindred)",
+        "Multani, Yavimaya's Avatar - Synergy (Avatar Kindred)",
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)",
+        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)",
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Converge leveraging synergies with Spells Matter and Spellslinger."
@@ -4682,8 +5313,8 @@
       "theme": "Convoke",
       "synergies": [
         "Big Mana",
-        "Vigilance",
         "Knight Kindred",
+        "Vigilance",
         "Elemental Kindred",
         "Combat Tricks"
       ],
@@ -4708,10 +5339,10 @@
       ],
       "synergy_commanders": [
         "Etali, Primal Storm - Synergy (Big Mana)",
-        "Tatyova, Benthic Druid - Synergy (Big Mana)",
-        "Adeline, Resplendent Cathar - Synergy (Knight Kindred)",
-        "Danitha Capashen, Paragon - Synergy (Knight Kindred)",
-        "Junji, the Midnight Sky - Synergy (Toolbox)"
+        "Ghalta, Primal Hunger - Synergy (Big Mana)",
+        "Loran of the Third Path - Synergy (Vigilance)",
+        "Adeline, Resplendent Cathar - Synergy (Vigilance)",
+        "Danitha Capashen, Paragon - Synergy (Knight Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Converts creature presence into mana (Convoke) accelerating large or off-color spells. Synergies like Big Mana and Knight Kindred reinforce the plan."
@@ -4774,10 +5405,10 @@
       "theme": "Cost Reduction",
       "synergies": [
         "Affinity",
+        "Waterbending",
         "Freerunning",
         "Undaunted",
-        "Waterbend",
-        "X Spells"
+        "Waterbend"
       ],
       "primary_color": "Blue",
       "secondary_color": "Green",
@@ -4801,9 +5432,9 @@
       "synergy_commanders": [
         "Urza, Chief Artificer - Synergy (Affinity)",
         "Nahiri, Forged in Fury - Synergy (Affinity)",
-        "Achilles Davenport - Synergy (Freerunning)",
-        "Ezio Auditore da Firenze - Synergy (Freerunning)",
-        "Katara, Water Tribe's Hope - Synergy (Waterbending)"
+        "The Unagi of Kyoshi Island - Synergy (Waterbending)",
+        "Aang, Swift Savior // Aang and La, Ocean's Fury - Synergy (Waterbending)",
+        "Katara, Water Tribe's Hope - Synergy (Waterbend)"
       ],
       "popularity_bucket": "Common",
       "description": "Builds around Cost Reduction leveraging synergies with Affinity and Freerunning."
@@ -4866,7 +5497,7 @@
         "Orchard Elemental"
       ],
       "synergy_commanders": [
-        "Sheoldred, Whispering One - Synergy (Control)",
+        "Mangara, the Diplomat - Synergy (Control)",
         "Kutzil, Malamet Exemplar - Synergy (Stax)"
       ],
       "popularity_bucket": "Rare",
@@ -4939,11 +5570,11 @@
       ],
       "synergy_commanders": [
         "Lotho, Corrupt Shirriff - Synergy (Control)",
+        "Mangara, the Diplomat - Synergy (Control)",
         "Sheoldred, Whispering One - Synergy (Control)",
-        "Niv-Mizzet, Parun - Synergy (Control)",
         "Kutzil, Malamet Exemplar - Synergy (Stax)",
-        "Talrand, Sky Summoner - Synergy (Stax)",
-        "Syr Konrad, the Grim - Synergy (Interaction)"
+        "Niv-Mizzet, Parun - Synergy (Stax)",
+        "Avacyn, Angel of Hope - Synergy (Interaction)"
       ],
       "popularity_bucket": "Common",
       "description": "Builds around Counterspells leveraging synergies with Control and Stax."
@@ -4980,7 +5611,7 @@
       "synergy_commanders": [
         "Selvala, Heart of the Wilds - Synergy (Blink)",
         "Sheoldred, Whispering One - Synergy (Blink)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)"
+        "Veyran, Voice of Duality - Synergy (Enter the Battlefield)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Coven leveraging synergies with Human Kindred and Blink."
@@ -4995,13 +5626,20 @@
       "primary_color": "Red",
       "secondary_color": "Black",
       "example_commanders": [
-        "Norin, Swift Survivalist"
+        "Norin, Swift Survivalist",
+        "Valgavoth, Terror Eater - Synergy (Ward)",
+        "Adrix and Nev, Twincasters - Synergy (Ward)",
+        "Miirym, Sentinel Wyrm - Synergy (Ward)",
+        "Toski, Bearer of Secrets - Synergy (Protective Effects)"
       ],
       "example_cards": [
         "Reprobation",
         "Boldwyr Intimidator",
         "Craven Hulk",
         "Scared Stiff"
+      ],
+      "synergy_commanders": [
+        "Mondrak, Glory Dominus - Synergy (Protective Effects)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Coward creatures into play with shared payoffs."
@@ -5049,9 +5687,11 @@
         "Hard Evidence"
       ],
       "synergy_commanders": [
-        "Toski, Bearer of Secrets - Synergy (Protective Effects)",
-        "Mondrak, Glory Dominus - Synergy (Protective Effects)",
-        "Syr Konrad, the Grim - Synergy (Mill)"
+        "Liberator, Urza's Battlethopter - Synergy (Flash)",
+        "Wan Shi Tong, Librarian - Synergy (Flash)",
+        "Malcolm, Alluring Scoundrel - Synergy (Flash)",
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)",
+        "Toski, Bearer of Secrets - Synergy (Protective Effects)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Crab creatures into play with shared payoffs (e.g., Toughness Matters and Protective Effects)."
@@ -5086,6 +5726,7 @@
         "Master's Guide-Mural // Master's Manufactory"
       ],
       "synergy_commanders": [
+        "Veyran, Voice of Duality - Synergy (Transform)",
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Transform)"
       ],
       "popularity_bucket": "Rare",
@@ -5122,8 +5763,8 @@
       ],
       "synergy_commanders": [
         "Ragavan, Nimble Pilferer - Synergy (Token Creation)",
-        "Mondrak, Glory Dominus - Synergy (Token Creation)",
         "Lotho, Corrupt Shirriff - Synergy (Token Creation)",
+        "Mondrak, Glory Dominus - Synergy (Token Creation)",
         "Trostani, Selesnya's Voice - Synergy (Populate)",
         "Cayth, Famed Mechanist - Synergy (Populate)"
       ],
@@ -5136,8 +5777,8 @@
       "synergies": [
         "Vehicles",
         "Exhaust",
-        "Treasure Token",
         "Artifacts Matter",
+        "Treasure Token",
         "Treasure"
       ],
       "primary_color": "Blue",
@@ -5161,9 +5802,11 @@
       ],
       "synergy_commanders": [
         "Sram, Senior Edificer - Synergy (Vehicles)",
-        "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)",
-        "Loran of the Third Path - Synergy (Artifacts Matter)",
-        "Lotho, Corrupt Shirriff - Synergy (Treasure Token)"
+        "Tannuk, Memorial Ensign - Synergy (Vehicles)",
+        "Cid, Freeflier Pilot - Synergy (Vehicles)",
+        "Redshift, Rocketeer Chief - Synergy (Exhaust)",
+        "Loot, the Pathfinder - Synergy (Exhaust)",
+        "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)"
       ],
       "popularity_bucket": "Niche",
       "description": "Uses under-costed Vehicles and efficient crew bodies—turning transient artifacts into evasive, hard-to-wipe threats."
@@ -5198,9 +5841,11 @@
         "Algae Gharial"
       ],
       "synergy_commanders": [
-        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)",
-        "Yahenni, Undying Partisan - Synergy (+1/+1 Counters)",
-        "Azusa, Lost but Seeking - Synergy (Toughness Matters)"
+        "Neheb, the Eternal - Synergy (Zombie Kindred)",
+        "Mikaeus, the Unhallowed - Synergy (Zombie Kindred)",
+        "Jadar, Ghoulcaller of Nephalia - Synergy (Zombie Kindred)",
+        "Toski, Bearer of Secrets - Synergy (Protective Effects)",
+        "Mondrak, Glory Dominus - Synergy (Protective Effects)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Crocodile creatures into play with shared payoffs (e.g., Counters Matter and +1/+1 Counters)."
@@ -5211,6 +5856,9 @@
       "synergies": [],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_cards": [
+        "Prism Array"
+      ],
       "popularity_bucket": "Rare",
       "description": "Accumulates crystal counters to unlock scaling payoffs, removal triggers, or delayed value conversions."
     },
@@ -5245,7 +5893,7 @@
       ],
       "synergy_commanders": [
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
-        "Rishkar, Peema Renegade - Synergy (Counters Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)",
         "Sram, Senior Edificer - Synergy (Enchantments Matter)"
       ],
       "popularity_bucket": "Niche",
@@ -5263,8 +5911,26 @@
       ],
       "primary_color": "Blue",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Ellivere of the Wild Court - Synergy (Role token)",
+        "Gylwain, Casting Director - Synergy (Role token)",
+        "Syr Armont, the Redeemer - Synergy (Role token)",
+        "Heliod, God of the Sun - Synergy (Enchantment Tokens)",
+        "Go-Shintai of Life's Origin - Synergy (Enchantment Tokens)"
+      ],
+      "example_cards": [
+        "Asinine Antics",
+        "Vantress Transmuter // Croaking Curse",
+        "Gadwick's First Duel",
+        "Spiteful Hexmage",
+        "Cursed Courtier",
+        "Diminisher Witch"
+      ],
+      "synergy_commanders": [
+        "Sram, Senior Edificer - Synergy (Equipment Matters)"
+      ],
       "popularity_bucket": "Rare",
-      "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Role Token and Enchantment Tokens reinforce the plan."
+      "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Role token and Enchantment Tokens reinforce the plan."
     },
     {
       "id": "custodes-kindred",
@@ -5288,7 +5954,9 @@
       "example_commanders": [
         "The Cyber-Controller",
         "Missy",
-        "Ashad, the Lone Cyberman"
+        "Ashad, the Lone Cyberman",
+        "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)",
+        "Loran of the Third Path - Synergy (Artifacts Matter)"
       ],
       "example_cards": [
         "Cybermen Squadron",
@@ -5299,6 +5967,9 @@
         "Death in Heaven",
         "Missy",
         "Ashad, the Lone Cyberman"
+      ],
+      "synergy_commanders": [
+        "Lotho, Corrupt Shirriff - Synergy (Artifacts Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Cyberman creatures into play with shared payoffs."
@@ -5331,6 +6002,12 @@
         "Raffine's Tower",
         "Indatha Triome",
         "Xander's Lounge"
+      ],
+      "synergy_commanders": [
+        "Rocksteady, Crash Courser - Synergy (Typecycling)",
+        "Jennika, Bad Apple Big Sister - Synergy (Typecycling)",
+        "Zog, Triceraton Castaway - Synergy (Landcycling)",
+        "Bebop, Warthog Warrior - Synergy (Landcycling)"
       ],
       "popularity_bucket": "Common",
       "description": "Builds around Cycling leveraging synergies with Landcycling and Basic landcycling."
@@ -5365,11 +6042,11 @@
         "Bolrac-Clan Basher"
       ],
       "synergy_commanders": [
-        "Etali, Primal Storm - Synergy (Big Mana)",
-        "Tatyova, Benthic Druid - Synergy (Big Mana)",
-        "Selvala, Heart of the Wilds - Synergy (Blink)",
-        "Sheoldred, Whispering One - Synergy (Blink)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)"
+        "Ghalta, Primal Hunger - Synergy (Trample)",
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Trample)",
+        "Ghalta, Stampede Tyrant - Synergy (Trample)",
+        "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)",
+        "Moraug, Fury of Akoum - Synergy (Warrior Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Cyclops creatures into play with shared payoffs (e.g., Big Mana)."
@@ -5383,7 +6060,10 @@
       "primary_color": "Black",
       "example_commanders": [
         "The Dalek Emperor",
-        "Cult of Skaro"
+        "Cult of Skaro",
+        "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)",
+        "Loran of the Third Path - Synergy (Artifacts Matter)",
+        "Lotho, Corrupt Shirriff - Synergy (Artifacts Matter)"
       ],
       "example_cards": [
         "Dalek Squadron",
@@ -5409,6 +6089,26 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Davros, Dalek Creator",
+        "The Dalek Emperor",
+        "Cult of Skaro",
+        "Ragavan, Nimble Pilferer - Synergy (Artifact Tokens)",
+        "Lotho, Corrupt Shirriff - Synergy (Artifact Tokens)"
+      ],
+      "example_cards": [
+        "Davros, Dalek Creator",
+        "Genesis of the Daleks",
+        "Doomsday Confluence",
+        "The Dalek Emperor",
+        "Cult of Skaro"
+      ],
+      "synergy_commanders": [
+        "Peregrin Took - Synergy (Artifact Tokens)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Mondrak, Glory Dominus - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Artifact Tokens and Creature Tokens reinforce the plan."
     },
@@ -5443,10 +6143,10 @@
       ],
       "synergy_commanders": [
         "Plargg and Nassari - Synergy (Orc Kindred)",
+        "Zurgo Stormrender - Synergy (Orc Kindred)",
         "Cadira, Caller of the Small - Synergy (Orc Kindred)",
-        "Saruman, the White Hand - Synergy (Orc Kindred)",
         "Kardur, Doomscourge - Synergy (Berserker Kindred)",
-        "Magda, Brazen Outlaw - Synergy (Berserker Kindred)"
+        "Alexios, Deimos of Kosmos - Synergy (Berserker Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Dash leveraging synergies with Warrior Kindred and Little Fellas."
@@ -5464,7 +6164,9 @@
       "example_commanders": [
         "Etali, Primal Storm - Synergy (Aggro)",
         "Ragavan, Nimble Pilferer - Synergy (Aggro)",
-        "Toski, Bearer of Secrets - Synergy (Combat Matters)"
+        "Toski, Bearer of Secrets - Synergy (Combat Matters)",
+        "The Weaver King - Synergy (Shadow)",
+        "Lyna, Veil of Vengeance - Synergy (Shadow)"
       ],
       "example_cards": [
         "Dauthi Voidwalker",
@@ -5475,6 +6177,9 @@
         "Dauthi Warlord",
         "Dauthi Cutthroat",
         "Dauthi Marauder"
+      ],
+      "synergy_commanders": [
+        "Boss Uramon, Shadow's Reach - Synergy (Shadow)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Dauthi creatures into play with shared payoffs (e.g., Shadow and Aggro)."
@@ -5507,6 +6212,9 @@
         "Kessig Naturalist // Lord of the Ulvenwald",
         "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury",
         "Hound Tamer // Untamed Pup"
+      ],
+      "synergy_commanders": [
+        "Veyran, Voice of Duality - Synergy (Transform)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Daybound leveraging synergies with Nightbound and Werewolf Kindred."
@@ -5543,6 +6251,7 @@
       "synergy_commanders": [
         "Magda, the Hoardmaster - Synergy (Scorpion Kindred)",
         "Akul the Unrepentant - Synergy (Scorpion Kindred)",
+        "Scorpion, Seething Striker - Synergy (Scorpion Kindred)",
         "Vraska, the Silencer - Synergy (Gorgon Kindred)"
       ],
       "popularity_bucket": "Uncommon",
@@ -5578,8 +6287,8 @@
         "Flumph"
       ],
       "synergy_commanders": [
-        "Rammas Echor, Ancient Shield - Synergy (Wall Kindred)",
-        "Teyo, Geometric Tactician - Synergy (Wall Kindred)",
+        "The Walls of Ba Sing Se - Synergy (Wall Kindred)",
+        "Invisible Woman, Sue Storm - Synergy (Wall Kindred)",
         "Atla Palani, Nest Tender - Synergy (Egg Kindred)",
         "Bristly Bill, Spine Sower - Synergy (Plant Kindred)"
       ],
@@ -5642,11 +6351,11 @@
         "The Swarmweaver"
       ],
       "synergy_commanders": [
-        "Emry, Lurker of the Loch - Synergy (Reanimate)",
-        "Six - Synergy (Reanimate)",
-        "Sheoldred, Whispering One - Synergy (Mill)",
-        "Kozilek, Butcher of Truth - Synergy (Mill)",
-        "Mondrak, Glory Dominus - Synergy (Horror Kindred)"
+        "Six - Synergy (Mill)",
+        "Emry, Lurker of the Loch - Synergy (Mill)",
+        "Mondrak, Glory Dominus - Synergy (Horror Kindred)",
+        "Solphim, Mayhem Dominus - Synergy (Horror Kindred)",
+        "Sheoldred, Whispering One - Synergy (Reanimate)"
       ],
       "popularity_bucket": "Niche",
       "description": "Diversifies graveyard card types to unlock Delirium power thresholds. Synergies like Reanimate and Mill reinforce the plan."
@@ -5681,9 +6390,9 @@
         "Become Immense"
       ],
       "synergy_commanders": [
-        "Etali, Primal Storm - Synergy (Big Mana)",
-        "Tatyova, Benthic Druid - Synergy (Big Mana)",
-        "Lotho, Corrupt Shirriff - Synergy (Spells Matter)"
+        "Six - Synergy (Mill)",
+        "The Gitrog Monster - Synergy (Reanimate)",
+        "Etali, Primal Storm - Synergy (Big Mana)"
       ],
       "popularity_bucket": "Rare",
       "description": "Exiles graveyard cards to pay for Delve spells, converting stocked yard into mana efficiency. Synergies like Mill and Big Mana reinforce the plan."
@@ -5717,11 +6426,12 @@
         "Tymaret, Chosen from Death"
       ],
       "synergy_commanders": [
-        "Adrix and Nev, Twincasters - Synergy (Ward)",
-        "Miirym, Sentinel Wyrm - Synergy (Ward)",
-        "Toski, Bearer of Secrets - Synergy (Protective Effects)",
-        "Mondrak, Glory Dominus - Synergy (Protective Effects)",
-        "Sram, Senior Edificer - Synergy (Enchantments Matter)"
+        "Sram, Senior Edificer - Synergy (Enchantments Matter)",
+        "Purphoros, God of the Forge - Synergy (Enchantments Matter)",
+        "Danitha Capashen, Paragon - Synergy (Enchantments Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Voltron)",
+        "Kodama of the West Tree - Synergy (Voltron)",
+        "Etali, Primal Storm - Synergy (Aggro)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Demigod creatures into play with shared payoffs (e.g., Ward and Protective Effects)."
@@ -5756,12 +6466,12 @@
         "Archfiend of Depravity"
       ],
       "synergy_commanders": [
-        "Kazuul, Tyrant of the Cliffs - Synergy (Ogre Kindred)",
-        "Heartless Hidetsugu - Synergy (Ogre Kindred)",
-        "Ruric Thar, the Unbowed - Synergy (Ogre Kindred)",
-        "Ghalta, Primal Hunger - Synergy (Trample)",
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Trample)",
-        "Niv-Mizzet, Parun - Synergy (Flying)"
+        "Clavileño, First of the Blessed - Synergy (Demon Token)",
+        "Tasha, the Witch Queen - Synergy (Demon Token)",
+        "Vito, Fanatic of Aclazotz - Synergy (Demon Token)",
+        "Elenda, the Dusk Rose - Synergy (Vampire Token)",
+        "Ghalta and Mavren - Synergy (Vampire Token)",
+        "Etali, Primal Storm - Synergy (Elder Kindred)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Focuses on getting a high number of Demon creatures into play with shared payoffs (e.g., Ogre Kindred and Trample)."
@@ -5778,8 +6488,33 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Clavileño, First of the Blessed",
+        "Tasha, the Witch Queen",
+        "Vito, Fanatic of Aclazotz",
+        "Ob Nixilis of the Black Oath",
+        "Tivash, Gloom Summoner"
+      ],
+      "example_cards": [
+        "Unholy Annex // Ritual Chamber",
+        "Clavileño, First of the Blessed",
+        "Tasha, the Witch Queen",
+        "March of the Canonized",
+        "Great Unclean One",
+        "Promise of Aclazotz // Foul Rebirth",
+        "Nurgle's Rot",
+        "Demonic Covenant"
+      ],
+      "synergy_commanders": [
+        "Elenda, the Dusk Rose - Synergy (Vampire Token)",
+        "Ghalta and Mavren - Synergy (Vampire Token)",
+        "Edgar Markov - Synergy (Vampire Token)",
+        "Kardur, Doomscourge - Synergy (Demon Kindred)",
+        "Vilis, Broker of Blood - Synergy (Demon Kindred)",
+        "Vito, Thorn of the Dusk Rose - Synergy (Vampire Kindred)"
+      ],
       "popularity_bucket": "Rare",
-      "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Demon Kindred and Creature Tokens reinforce the plan."
+      "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Vampire Token and Demon Kindred reinforce the plan."
     },
     {
       "id": "demonstrate",
@@ -5806,7 +6541,8 @@
         "Excavation Technique"
       ],
       "synergy_commanders": [
-        "Niv-Mizzet, Parun - Synergy (Spellslinger)"
+        "Zada, Hedron Grinder - Synergy (Spell Copy)",
+        "Mangara, the Diplomat - Synergy (Spellslinger)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Demonstrate leveraging synergies with Spell Copy and Spells Matter."
@@ -5838,7 +6574,8 @@
         "Lava Tubes"
       ],
       "synergy_commanders": [
-        "Sheoldred, Whispering One - Synergy (Lands Matter)"
+        "Six - Synergy (Lands Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Accumulates depletion counters to unlock scaling payoffs, removal triggers, or delayed value conversions."
@@ -5873,9 +6610,10 @@
         "Wail of the Forgotten"
       ],
       "synergy_commanders": [
-        "Six - Synergy (Reanimate)",
-        "Sheoldred, Whispering One - Synergy (Mill)",
-        "Kozilek, Butcher of Truth - Synergy (Mill)"
+        "Kodama of the West Tree - Synergy (Spirit Kindred)",
+        "Kodama of the East Tree - Synergy (Spirit Kindred)",
+        "Junji, the Midnight Sky - Synergy (Spirit Kindred)",
+        "Six - Synergy (Mill)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Descend leveraging synergies with Reanimate and Mill."
@@ -5959,8 +6697,9 @@
         "Archon of the Triumvirate"
       ],
       "synergy_commanders": [
+        "Mangara, the Diplomat - Synergy (Stax)",
         "Sheoldred, Whispering One - Synergy (Blink)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)"
+        "Veyran, Voice of Duality - Synergy (Enter the Battlefield)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Detain leveraging synergies with Stax and Blink."
@@ -5995,9 +6734,7 @@
         "Detective of the Month"
       ],
       "synergy_commanders": [
-        "Izoni, Center of the Web - Synergy (Collect evidence)",
-        "Tivit, Seller of Secrets - Synergy (Investigate)",
-        "Lonis, Cryptozoologist - Synergy (Clue Token)"
+        "Izoni, Center of the Web - Synergy (Collect evidence)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Detective creatures into play with shared payoffs (e.g., Collect evidence and Investigate)."
@@ -6013,6 +6750,26 @@
       ],
       "primary_color": "White",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Kellan, Inquisitive Prodigy // Tail the Suspect - Synergy (Detective Kindred)",
+        "Nelly Borca, Impulsive Accuser - Synergy (Detective Kindred)",
+        "Piper Wright, Publick Reporter - Synergy (Detective Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Detective of the Month",
+        "Felonious Rage",
+        "Chalk Outline",
+        "Unyielding Gatekeeper",
+        "Drag the Canal",
+        "Inside Source",
+        "Person of Interest",
+        "Museum Nightwatch"
+      ],
+      "synergy_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Detective Kindred and Creature Tokens reinforce the plan."
     },
@@ -6043,7 +6800,7 @@
         "Marchesa's Emissary"
       ],
       "synergy_commanders": [
-        "Yahenni, Undying Partisan - Synergy (Counters Matter)",
+        "Bristly Bill, Spine Sower - Synergy (Counters Matter)",
         "Sram, Senior Edificer - Synergy (Voltron)"
       ],
       "popularity_bucket": "Rare",
@@ -6079,12 +6836,10 @@
         "Henzie \"Toolbox\" Torre"
       ],
       "synergy_commanders": [
+        "Zariel, Archduke of Avernus - Synergy (Devil Token)",
         "Syr Konrad, the Grim - Synergy (Pingers)",
         "Elas il-Kor, Sadistic Pilgrim - Synergy (Pingers)",
-        "Niv-Mizzet, Parun - Synergy (Pingers)",
-        "Aurelia, the Warleader - Synergy (Haste)",
-        "Yahenni, Undying Partisan - Synergy (Haste)",
-        "Toski, Bearer of Secrets - Synergy (Conditional Draw)"
+        "Aurelia, the Warleader - Synergy (Haste)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Devil creatures into play with shared payoffs (e.g., Big Mana)."
@@ -6101,6 +6856,26 @@
       ],
       "primary_color": "Red",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Zurzoth, Chaos Rider",
+        "Raphael, Fiendish Savior",
+        "Mahadi, Emporium Master - Synergy (Devil Kindred)",
+        "Syr Konrad, the Grim - Synergy (Pingers)",
+        "Elas il-Kor, Sadistic Pilgrim - Synergy (Pingers)"
+      ],
+      "example_cards": [
+        "Spiked Corridor // Torture Pit",
+        "Zurzoth, Chaos Rider",
+        "Raphael, Fiendish Savior",
+        "Zariel, Archduke of Avernus",
+        "Burn Down the House",
+        "Ob Nixilis, the Adversary",
+        "Tibalt, Rakish Instigator",
+        "Dance with Devils"
+      ],
+      "synergy_commanders": [
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Devil Kindred and Pingers reinforce the plan."
     },
@@ -6176,7 +6951,7 @@
         "Gluttonous Slime"
       ],
       "synergy_commanders": [
-        "Yahenni, Undying Partisan - Synergy (Counters Matter)",
+        "Bristly Bill, Spine Sower - Synergy (Counters Matter)",
         "Sram, Senior Edificer - Synergy (Voltron)"
       ],
       "popularity_bucket": "Rare",
@@ -6212,10 +6987,12 @@
         "Bonehoard Dracosaur"
       ],
       "synergy_commanders": [
+        "Ghalta and Mavren - Synergy (Dinosaur Token)",
+        "Huatli, Poet of Unity // Roar of the Fifth People - Synergy (Dinosaur Token)",
+        "Gavi, Nest Warden - Synergy (Dinosaur Token)",
         "Strong, the Brutish Thespian - Synergy (Enrage)",
         "Indoraptor, the Perfect Hybrid - Synergy (Enrage)",
-        "Vrondiss, Rage of Ancients - Synergy (Enrage)",
-        "Kogla, the Titan Ape - Synergy (Fight)"
+        "Nethroi, Apex of Death - Synergy (Mutate)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Focuses on getting a high number of Dinosaur creatures into play with shared payoffs (e.g., Enrage and Elder Kindred)."
@@ -6232,6 +7009,29 @@
       ],
       "primary_color": "Red",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Ghalta and Mavren",
+        "Huatli, Poet of Unity // Roar of the Fifth People",
+        "Gavi, Nest Warden",
+        "Etali, Primal Storm - Synergy (Dinosaur Kindred)",
+        "Ghalta, Primal Hunger - Synergy (Dinosaur Kindred)"
+      ],
+      "example_cards": [
+        "Bonehoard Dracosaur",
+        "The Skullspore Nexus",
+        "Ghalta and Mavren",
+        "Quartzwood Crasher",
+        "Regisaur Alpha",
+        "Palani's Hatcher",
+        "Dinosaurs on a Spaceship",
+        "Welcome to . . . // Jurassic Park"
+      ],
+      "synergy_commanders": [
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Dinosaur Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Dinosaur Kindred and Creature Tokens reinforce the plan."
     },
@@ -6244,6 +7044,30 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Rat King, Verminister",
+        "Krang & Shredder",
+        "Pizza Face, Gastromancer",
+        "Michelangelo, Game Master",
+        "Lord Dregg, Insect Invader"
+      ],
+      "example_cards": [
+        "Rat King, Verminister",
+        "Krang & Shredder",
+        "Pizza Face, Gastromancer",
+        "Michelangelo, Game Master",
+        "Foot Mystic",
+        "Lord Dregg, Insect Invader",
+        "West Wind Avatar",
+        "Insectoid Exterminator"
+      ],
+      "synergy_commanders": [
+        "Etali, Primal Storm - Synergy (Aggro)",
+        "Ragavan, Nimble Pilferer - Synergy (Aggro)",
+        "Toski, Bearer of Secrets - Synergy (Aggro)",
+        "Kutzil, Malamet Exemplar - Synergy (Combat Matters)",
+        "Sram, Senior Edificer - Synergy (Combat Matters)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Disappear leveraging synergies with Aggro and Combat Matters."
     },
@@ -6277,7 +7101,7 @@
         "Raffine's Tower"
       ],
       "synergy_commanders": [
-        "The Locust God - Synergy (Loot)",
+        "Ashling, Flame Dancer - Synergy (Loot)",
         "Malcolm, Alluring Scoundrel - Synergy (Loot)",
         "Braids, Arisen Nightmare - Synergy (Wheels)",
         "Loran of the Third Path - Synergy (Wheels)"
@@ -6317,9 +7141,9 @@
       "synergy_commanders": [
         "Gemstone Caverns - Synergy (Caves Matter)",
         "Brass's Tunnel-Grinder // Tecutlan, the Searing Rift - Synergy (Caves Matter)",
-        "Vorinclex // The Grand Evolution - Synergy (Land Types Matter)",
-        "Karametra, God of Harvests - Synergy (Land Types Matter)",
-        "Etali, Primal Storm - Synergy (Exile Matters)"
+        "Etali, Primal Storm - Synergy (Exile Matters)",
+        "Ragavan, Nimble Pilferer - Synergy (Exile Matters)",
+        "Karametra, God of Harvests - Synergy (Land Types Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Leverages Discover to cheat spell mana values, chaining free cascade-like board development. Synergies like Caves Matter and Land Types Matter reinforce the plan."
@@ -6354,7 +7178,7 @@
         "Boltbender"
       ],
       "synergy_commanders": [
-        "Daxos, Blessed by the Sun - Synergy (Ward)",
+        "Valgavoth, Terror Eater - Synergy (Ward)",
         "Kellan, Inquisitive Prodigy // Tail the Suspect - Synergy (Detective Kindred)",
         "Nelly Borca, Impulsive Accuser - Synergy (Detective Kindred)",
         "Toski, Bearer of Secrets - Synergy (Protective Effects)"
@@ -6392,9 +7216,11 @@
         "Dennick, Pious Apprentice // Dennick, Pious Apparition"
       ],
       "synergy_commanders": [
+        "Valgavoth, Terror Eater - Synergy (Graveyard Hate)",
+        "The Scarab God - Synergy (Graveyard Hate)",
+        "Urabrask // The Great Work - Synergy (Graveyard Hate)",
         "Veyran, Voice of Duality - Synergy (Transform)",
-        "Kodama of the West Tree - Synergy (Spirit Kindred)",
-        "Kodama of the East Tree - Synergy (Spirit Kindred)"
+        "Kodama of the West Tree - Synergy (Spirit Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Disturb leveraging synergies with Transform and Spirit Kindred."
@@ -6432,7 +7258,7 @@
         "Purphoros, God of the Forge - Synergy (Indestructible)",
         "Kodama of the West Tree - Synergy (Spirit Kindred)",
         "Kodama of the East Tree - Synergy (Spirit Kindred)",
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Protective Effects)"
+        "Avacyn, Angel of Hope - Synergy (Protective Effects)"
       ],
       "popularity_bucket": "Rare",
       "description": "Accumulates divinity counters to unlock scaling payoffs, removal triggers, or delayed value conversions."
@@ -6469,9 +7295,9 @@
       "synergy_commanders": [
         "Kitsa, Otterball Elite - Synergy (Prowess)",
         "Bria, Riptide Rogue - Synergy (Prowess)",
-        "Eris, Roar of the Storm - Synergy (Prowess)",
+        "Lyse Hext - Synergy (Prowess)",
         "Azusa, Lost but Seeking - Synergy (Monk Kindred)",
-        "Narset, Enlightened Exile - Synergy (Monk Kindred)",
+        "Tifa Lockhart - Synergy (Monk Kindred)",
         "Niv-Mizzet, Parun - Synergy (Flying)"
       ],
       "popularity_bucket": "Niche",
@@ -6511,7 +7337,7 @@
         "Adric, Mathematical Genius - Synergy (Doctor's Companion)",
         "Martha Jones - Synergy (Doctor's companion)",
         "Sarah Jane Smith - Synergy (Doctor's companion)",
-        "Jhoira, Weatherlight Captain - Synergy (Sagas Matter)"
+        "Kellan, Inquisitive Prodigy // Tail the Suspect - Synergy (Investigate)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Doctor creatures into play with shared payoffs (e.g., Doctor's Companion and Doctor's companion)."
@@ -6598,12 +7424,10 @@
         "Jinnie Fay, Jetmir's Second"
       ],
       "synergy_commanders": [
+        "Mordenkainen - Synergy (Dog Token)",
         "Junji, the Midnight Sky - Synergy (Menace)",
-        "Kozilek, the Great Distortion - Synergy (Menace)",
-        "Massacre Girl - Synergy (Menace)",
-        "Ashaya, Soul of the Wild - Synergy (Elemental Kindred)",
-        "Titania, Protector of Argoth - Synergy (Elemental Kindred)",
-        "Selvala, Heart of the Wilds - Synergy (Scout Kindred)"
+        "Tergrid, God of Fright // Tergrid's Lantern - Synergy (Menace)",
+        "Ashaya, Soul of the Wild - Synergy (Elemental Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Dog creatures into play with shared payoffs (e.g., Scout Kindred and Indestructible)."
@@ -6619,6 +7443,28 @@
       ],
       "primary_color": "White",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Jinnie Fay, Jetmir's Second",
+        "Rin and Seri, Inseparable",
+        "Phelia, Exuberant Shepherd - Synergy (Dog Kindred)",
+        "K-9, Mark I - Synergy (Dog Kindred)",
+        "Yoshimaru, Ever Faithful - Synergy (Dog Kindred)"
+      ],
+      "example_cards": [
+        "Jinnie Fay, Jetmir's Second",
+        "Rin and Seri, Inseparable",
+        "Hunted Bonebrute",
+        "Release the Dogs",
+        "Mordenkainen",
+        "Krovod Haunch",
+        "Mongrel Pack",
+        "Dog Walker"
+      ],
+      "synergy_commanders": [
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Dog Kindred and Creature Tokens reinforce the plan."
     },
@@ -6653,10 +7499,10 @@
       ],
       "synergy_commanders": [
         "Tatyova, Benthic Druid - Synergy (Lands Matter)",
-        "Sheoldred, Whispering One - Synergy (Lands Matter)",
-        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Ramp)",
+        "Six - Synergy (Lands Matter)",
+        "Lotho, Corrupt Shirriff - Synergy (Ramp)",
         "Selvala, Heart of the Wilds - Synergy (Ramp)",
-        "The Reality Chip - Synergy (Topdeck)"
+        "Ghalta, Primal Hunger - Synergy (Cost Reduction)"
       ],
       "popularity_bucket": "Rare",
       "description": "Assembles multiple basic land types rapidly to scale Domain-based effects. Synergies like Lands Matter and Ramp reinforce the plan."
@@ -6682,11 +7528,36 @@
         "Berserker Kindred",
         "Mutant Kindred",
         "Landfall",
-        "Hero Kindred",
-        "+1/+1 Counters"
+        "Dinosaur Kindred",
+        "Hero Kindred"
       ],
       "primary_color": "Green",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Solphim, Mayhem Dominus",
+        "Bristly Bill, Spine Sower",
+        "Gisela, Blade of Goldnight",
+        "Zopandrel, Hunger Dominus",
+        "Lightning, Army of One"
+      ],
+      "example_cards": [
+        "Unnatural Growth",
+        "Mossborn Hydra",
+        "Twinflame Tyrant",
+        "Solphim, Mayhem Dominus",
+        "Bristly Bill, Spine Sower",
+        "Kalonian Hydra",
+        "Gisela, Blade of Goldnight",
+        "Zopandrel, Hunger Dominus"
+      ],
+      "synergy_commanders": [
+        "Kardur, Doomscourge - Synergy (Berserker Kindred)",
+        "Alexios, Deimos of Kosmos - Synergy (Berserker Kindred)",
+        "Magda, Brazen Outlaw - Synergy (Berserker Kindred)",
+        "Deadpool, Trading Card - Synergy (Mutant Kindred)",
+        "Kuja, Genome Sorcerer // Trance Kuja, Fate Defied - Synergy (Mutant Kindred)",
+        "Tatyova, Benthic Druid - Synergy (Landfall)"
+      ],
       "popularity_bucket": "Uncommon",
       "description": "Builds around Double leveraging synergies with Berserker Kindred and Mutant Kindred."
     },
@@ -6720,12 +7591,12 @@
         "Éomer, King of Rohan"
       ],
       "synergy_commanders": [
-        "Syr Konrad, the Grim - Synergy (Knight Kindred)",
-        "Adeline, Resplendent Cathar - Synergy (Knight Kindred)",
-        "Danitha Capashen, Paragon - Synergy (Knight Kindred)",
-        "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)",
-        "Chatterfang, Squirrel General - Synergy (Warrior Kindred)",
-        "Etali, Primal Storm - Synergy (Aggro)"
+        "Sram, Senior Edificer - Synergy (Dwarf Kindred)",
+        "Torbran, Thane of Red Fell - Synergy (Dwarf Kindred)",
+        "Tataru Taru - Synergy (Dwarf Kindred)",
+        "Ayara, First of Locthwain - Synergy (Noble Kindred)",
+        "Loot, Exuberant Explorer - Synergy (Noble Kindred)",
+        "Deadpool, Trading Card - Synergy (Hero Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Builds around Double strike leveraging synergies with Knight Kindred and Warrior Kindred."
@@ -6760,9 +7631,11 @@
         "Balefire Dragon"
       ],
       "synergy_commanders": [
-        "Sarkhan, Dragon Ascendant - Synergy (Behold)",
+        "Magda, the Hoardmaster - Synergy (Dragon Token)",
+        "Goro-Goro, Disciple of Ryusei - Synergy (Dragon Token)",
         "Etali, Primal Storm - Synergy (Elder Kindred)",
-        "Ghalta, Primal Hunger - Synergy (Elder Kindred)"
+        "Ghalta, Primal Hunger - Synergy (Elder Kindred)",
+        "Alela, Cunning Conqueror - Synergy (Faerie Token)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Focuses on getting a high number of Dragon creatures into play with shared payoffs (e.g., Elder Kindred and Haste)."
@@ -6779,6 +7652,31 @@
       ],
       "primary_color": "Red",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Lathliss, Dragon Queen",
+        "Magda, the Hoardmaster",
+        "Goro-Goro, Disciple of Ryusei",
+        "Rith, Liberated Primeval",
+        "Eris, Roar of the Storm"
+      ],
+      "example_cards": [
+        "Lathliss, Dragon Queen",
+        "Utvara Hellkite",
+        "Dragonmaster Outcast",
+        "Magda, the Hoardmaster",
+        "Ancient Gold Dragon",
+        "Rite of the Dragoncaller",
+        "Goro-Goro, Disciple of Ryusei",
+        "Nesting Dragon"
+      ],
+      "synergy_commanders": [
+        "Alela, Cunning Conqueror - Synergy (Faerie Token)",
+        "Oona, Queen of the Fae - Synergy (Faerie Token)",
+        "Alela, Artful Provocateur - Synergy (Faerie Token)",
+        "Niv-Mizzet, Parun - Synergy (Dragon Kindred)",
+        "Old Gnawbone - Synergy (Dragon Kindred)",
+        "Rankle, Master of Pranks - Synergy (Faerie Kindred)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Faerie Token and Dragon Kindred reinforce the plan."
     },
@@ -6812,6 +7710,7 @@
         "Loyal Drake"
       ],
       "synergy_commanders": [
+        "Aurelia, the Warleader - Synergy (Flying)",
         "Mondrak, Glory Dominus - Synergy (Phyrexian Kindred)",
         "Sheoldred, the Apocalypse - Synergy (Phyrexian Kindred)",
         "Ghalta, Primal Hunger - Synergy (Cost Reduction)"
@@ -6829,6 +7728,26 @@
       ],
       "primary_color": "Blue",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Talrand, Sky Summoner",
+        "Alandra, Sky Dreamer",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Urza, Lord High Artificer - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
+      "example_cards": [
+        "Talrand, Sky Summoner",
+        "Alandra, Sky Dreamer",
+        "Drake Haven",
+        "Drake Hatcher",
+        "Talrand's Invocation",
+        "Roost of Drakes",
+        "Leafdrake Roost"
+      ],
+      "synergy_commanders": [
+        "Lotho, Corrupt Shirriff - Synergy (Token Creation)",
+        "Mondrak, Glory Dominus - Synergy (Tokens Matter)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Creature Tokens and Token Creation reinforce the plan."
     },
@@ -6852,6 +7771,15 @@
       "synergies": [],
       "primary_color": "Blue",
       "secondary_color": "White",
+      "example_commanders": [
+        "Rasputin, the Oneiromancer",
+        "Rasputin Dreamweaver"
+      ],
+      "example_cards": [
+        "Goliath Daydreamer",
+        "Rasputin, the Oneiromancer",
+        "Rasputin Dreamweaver"
+      ],
       "popularity_bucket": "Rare",
       "description": "Accumulates dream counters to unlock scaling payoffs, removal triggers, or delayed value conversions."
     },
@@ -6885,7 +7813,9 @@
         "Necroplasm"
       ],
       "synergy_commanders": [
-        "Braids, Arisen Nightmare - Synergy (Card Draw)"
+        "Six - Synergy (Graveyard Recursion)",
+        "Muldrotha, the Gravetide - Synergy (Graveyard Recursion)",
+        "Uro, Titan of Nature's Wrath - Synergy (Graveyard Recursion)"
       ],
       "popularity_bucket": "Rare",
       "description": "Loads high-impact cards into the graveyard early and reanimates them for explosive tempo or combo loops. Synergies like Unconditional Draw and Reanimate reinforce the plan."
@@ -6926,6 +7856,12 @@
       "synergies": [],
       "primary_color": "Blue",
       "secondary_color": "Black",
+      "example_cards": [
+        "Pinnacle Emissary",
+        "Kaito, Dancing Shadow",
+        "Desculpting Blast",
+        "Station Monitor"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines."
     },
@@ -6959,8 +7895,11 @@
         "Arbor Elf"
       ],
       "synergy_commanders": [
+        "Freyalise, Llanowar's Fury - Synergy (Druid Token)",
+        "Teval, the Balanced Scale - Synergy (Druid Token)",
+        "The Sibsig Ceremony - Synergy (Druid Token)",
         "Galadriel, Light of Valinor - Synergy (Alliance)",
-        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Mana Dork)",
+        "Slash, Reptile Rampager - Synergy (Alliance)",
         "Selvala, Heart of the Wilds - Synergy (Mana Dork)"
       ],
       "popularity_bucket": "Common",
@@ -6978,6 +7917,28 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Freyalise, Llanowar's Fury",
+        "Teval, the Balanced Scale",
+        "Jadar, Ghoulcaller of Nephalia - Synergy (Zombie Token)",
+        "God-Eternal Oketra - Synergy (Zombie Token)",
+        "Ghoulcaller Gisa - Synergy (Zombie Token)"
+      ],
+      "example_cards": [
+        "Teval's Judgment",
+        "Freyalise, Llanowar's Fury",
+        "Teval, the Balanced Scale",
+        "Welcome the Dead",
+        "Essence Anchor",
+        "The Sibsig Ceremony",
+        "Llanowar Mentor",
+        "Sultai Monument"
+      ],
+      "synergy_commanders": [
+        "Tatyova, Benthic Druid - Synergy (Druid Kindred)",
+        "Rishkar, Peema Renegade - Synergy (Druid Kindred)",
+        "Neheb, the Eternal - Synergy (Zombie Kindred)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Zombie Token and Druid Kindred reinforce the plan."
     },
@@ -7015,7 +7976,7 @@
         "Mirri, Cat Warrior - Synergy (Forestwalk)",
         "Sheoldred, Whispering One - Synergy (Landwalk)",
         "Wrexial, the Risen Deep - Synergy (Landwalk)",
-        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Mana Dork)"
+        "Tatyova, Benthic Druid - Synergy (Druid Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Dryad creatures into play with shared payoffs (e.g., Forestwalk and Landwalk)."
@@ -7050,11 +8011,8 @@
         "Cayth, Famed Mechanist"
       ],
       "synergy_commanders": [
-        "Cayth, Famed Mechanist - Synergy (Servo Kindred)",
-        "Saheeli, the Gifted - Synergy (Servo Kindred)",
-        "Oviya Pashiri, Sage Lifecrafter - Synergy (Servo Kindred)",
-        "Kardur, Doomscourge - Synergy (Berserker Kindred)",
-        "Loran of the Third Path - Synergy (Artificer Kindred)"
+        "Fíli the Pathfinder - Synergy (Dwarf Token)",
+        "Cayth, Famed Mechanist - Synergy (Servo Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Dwarf creatures into play with shared payoffs (e.g., Servo Kindred and Artificer Kindred)."
@@ -7071,6 +8029,22 @@
       ],
       "primary_color": "Red",
       "secondary_color": "White",
+      "example_commanders": [
+        "Fíli the Pathfinder",
+        "Sram, Senior Edificer - Synergy (Dwarf Kindred)",
+        "Torbran, Thane of Red Fell - Synergy (Dwarf Kindred)",
+        "Kardur, Doomscourge - Synergy (Berserker Kindred)"
+      ],
+      "example_cards": [
+        "Dwarven Mine",
+        "Reckless Crew",
+        "Fearless Liberator",
+        "Dwarven Hammer",
+        "Dwarven Reinforcements",
+        "Warchanter Skald",
+        "The Lonely Mountain",
+        "An Unexpected Party // At the Door"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Berserker Token and Dwarf Kindred reinforce the plan."
     },
@@ -7078,14 +8052,36 @@
       "id": "earthbend",
       "theme": "Earthbend",
       "synergies": [
+        "Earthbending",
         "Bending",
         "Landfall",
         "Ally Kindred",
-        "Lands Matter",
-        "+1/+1 Counters"
+        "Lands Matter"
       ],
       "primary_color": "Green",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Toph, Hardheaded Teacher",
+        "Toph, Earthbending Master",
+        "Toph, the Blind Bandit",
+        "Toph, the First Metalbender",
+        "Bumi, Unleashed"
+      ],
+      "example_cards": [
+        "Badgermole Cub",
+        "Ba Sing Se",
+        "Earthbender Ascension",
+        "Toph, Hardheaded Teacher",
+        "Toph, Earthbending Master",
+        "Toph, the Blind Bandit",
+        "The Legend of Kyoshi // Avatar Kyoshi",
+        "Toph, the First Metalbender"
+      ],
+      "synergy_commanders": [
+        "The Unagi of Kyoshi Island - Synergy (Bending)",
+        "Appa, Steadfast Guardian - Synergy (Bending)",
+        "Tatyova, Benthic Druid - Synergy (Landfall)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Builds around Earthbend leveraging synergies with Earthbending and Bending."
     },
@@ -7119,11 +8115,11 @@
         "Badgermole"
       ],
       "synergy_commanders": [
+        "Toph, Hardheaded Teacher - Synergy (Earthbend)",
+        "Toph, Earthbending Master - Synergy (Earthbend)",
+        "The Unagi of Kyoshi Island - Synergy (Bending)",
         "Appa, Steadfast Guardian - Synergy (Bending)",
-        "Aang, Airbending Master - Synergy (Bending)",
-        "Tatyova, Benthic Druid - Synergy (Landfall)",
-        "Aesi, Tyrant of Gyre Strait - Synergy (Landfall)",
-        "Drana, Liberator of Malakir - Synergy (Ally Kindred)"
+        "Tatyova, Benthic Druid - Synergy (Landfall)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Earthbending leveraging synergies with Bending and Landfall."
@@ -7160,7 +8156,7 @@
       "synergy_commanders": [
         "Aurelia, the Warleader - Synergy (Haste)",
         "Yahenni, Undying Partisan - Synergy (Haste)",
-        "Kiki-Jiki, Mirror Breaker - Synergy (Haste)",
+        "Captain Lannery Storm - Synergy (Haste)",
         "Krenko, Tin Street Kingpin - Synergy (Goblin Kindred)",
         "Krenko, Mob Boss - Synergy (Goblin Kindred)",
         "Ashaya, Soul of the Wild - Synergy (Elemental Kindred)"
@@ -7197,6 +8193,9 @@
         "Optimistic Scavenger",
         "Scrabbling Skullcrab"
       ],
+      "synergy_commanders": [
+        "Niv-Mizzet, Parun - Synergy (Flying)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Eerie leveraging synergies with Rooms Matter and Enchantments Matter."
     },
@@ -7232,10 +8231,10 @@
       "synergy_commanders": [
         "Niv-Mizzet, Parun - Synergy (Flying)",
         "Avacyn, Angel of Hope - Synergy (Flying)",
-        "Old Gnawbone - Synergy (Flying)",
+        "Aurelia, the Warleader - Synergy (Flying)",
         "Syr Konrad, the Grim - Synergy (Burn)",
         "Braids, Arisen Nightmare - Synergy (Burn)",
-        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
+        "Boromir, Warden of the Tower - Synergy (Interaction)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Efreet creatures into play with shared payoffs (e.g., Flying)."
@@ -7246,6 +8245,14 @@
       "synergies": [],
       "primary_color": "Black",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Xira, the Golden Sting",
+        "Darigaaz Reincarnated"
+      ],
+      "example_cards": [
+        "Xira, the Golden Sting",
+        "Darigaaz Reincarnated"
+      ],
       "popularity_bucket": "Rare",
       "description": "Accumulates egg counters to unlock scaling payoffs, removal triggers, or delayed value conversions."
     },
@@ -7279,9 +8286,9 @@
         "The Dragon-Kami Reborn // Dragon-Kami's Egg"
       ],
       "synergy_commanders": [
-        "The Pride of Hull Clade - Synergy (Defender)",
+        "The Walls of Ba Sing Se - Synergy (Defender)",
         "Sokrates, Athenian Teacher - Synergy (Defender)",
-        "Pramikon, Sky Rampart - Synergy (Defender)",
+        "The Pride of Hull Clade - Synergy (Defender)",
         "Syr Konrad, the Grim - Synergy (Sacrifice Matters)",
         "Braids, Arisen Nightmare - Synergy (Sacrifice Matters)"
       ],
@@ -7294,6 +8301,16 @@
       "synergies": [],
       "primary_color": "Red",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Atla Palani, Nest Tender",
+        "Xira, the Golden Sting"
+      ],
+      "example_cards": [
+        "Nesting Dragon",
+        "Palani's Hatcher",
+        "Atla Palani, Nest Tender",
+        "Xira, the Golden Sting"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines."
     },
@@ -7329,7 +8346,8 @@
       "synergy_commanders": [
         "Niv-Mizzet, Parun - Synergy (Dragon Kindred)",
         "Old Gnawbone - Synergy (Dragon Kindred)",
-        "Avacyn, Angel of Hope - Synergy (Flying)"
+        "Lathliss, Dragon Queen - Synergy (Dragon Kindred)",
+        "Kardur, Doomscourge - Synergy (Demon Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Elder creatures into play with shared payoffs (e.g., Dragon Kindred and Dinosaur Kindred)."
@@ -7363,9 +8381,6 @@
         "Kozilek, the Great Distortion",
         "Glaring Fleshraker"
       ],
-      "synergy_commanders": [
-        "Magnus the Red - Synergy (Spawn Kindred)"
-      ],
       "popularity_bucket": "Uncommon",
       "description": "Focuses on getting a high number of Eldrazi creatures into play with shared payoffs (e.g., Ingest and Processor Kindred)."
     },
@@ -7381,6 +8396,20 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Kiora, the Rising Tide - Synergy (Scion Kindred)",
+        "Magnus the Red - Synergy (Spawn Token)"
+      ],
+      "example_cards": [
+        "Idol of Oblivion",
+        "Glaring Fleshraker",
+        "Awakening Zone",
+        "Pawn of Ulamog",
+        "Warping Wail",
+        "Basking Broodscale",
+        "Kozilek's Command",
+        "Glimpse the Impossible"
+      ],
       "popularity_bucket": "Niche",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Scion Token and Scion Kindred reinforce the plan."
     },
@@ -7413,9 +8442,6 @@
         "Ashaya, Soul of the Wild",
         "Nyxbloom Ancient"
       ],
-      "synergy_commanders": [
-        "Idris, Soul of the TARDIS - Synergy (Incarnation Kindred)"
-      ],
       "popularity_bucket": "Common",
       "description": "Focuses on getting a high number of Elemental creatures into play with shared payoffs (e.g., Evoke and Awaken)."
     },
@@ -7431,7 +8457,31 @@
       ],
       "primary_color": "Red",
       "secondary_color": "Blue",
-      "popularity_bucket": "Niche",
+      "example_commanders": [
+        "Omnath, Locus of Rage",
+        "Titania, Protector of Argoth",
+        "Lagomos, Hand of Hatred",
+        "Titania, Nature's Force",
+        "The Wandering Minstrel"
+      ],
+      "example_cards": [
+        "Young Pyromancer",
+        "Resculpt",
+        "Omnath, Locus of Rage",
+        "Titania, Protector of Argoth",
+        "Zendikar's Roil",
+        "Tempt with Vengeance",
+        "Lagomos, Hand of Hatred",
+        "Rite of the Raging Storm"
+      ],
+      "synergy_commanders": [
+        "Ashaya, Soul of the Wild - Synergy (Elemental Kindred)",
+        "Muldrotha, the Gravetide - Synergy (Elemental Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Kiki-Jiki, Mirror Breaker - Synergy (Shaman Kindred)"
+      ],
+      "popularity_bucket": "Uncommon",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Elemental Kindred and Creature Tokens reinforce the plan."
     },
     {
@@ -7464,12 +8514,9 @@
         "March of the World Ooze"
       ],
       "synergy_commanders": [
-        "Ghalta, Primal Hunger - Synergy (Trample)",
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Trample)",
-        "Ghalta, Stampede Tyrant - Synergy (Trample)",
         "Vito, Thorn of the Dusk Rose - Synergy (Cleric Kindred)",
         "Elas il-Kor, Sadistic Pilgrim - Synergy (Cleric Kindred)",
-        "Boromir, Warden of the Tower - Synergy (Soldier Kindred)"
+        "Ghalta, Primal Hunger - Synergy (Trample)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Elephant creatures into play with shared payoffs (e.g., Trample and Cleric Kindred)."
@@ -7485,7 +8532,27 @@
         "Spells Matter"
       ],
       "primary_color": "Green",
-      "secondary_color": "Blue",
+      "secondary_color": "Red",
+      "example_commanders": [
+        "Losheel, Clockwork Scholar - Synergy (Elephant Kindred)",
+        "Hamza, Guardian of Arashin - Synergy (Elephant Kindred)",
+        "Quintorius, Loremaster - Synergy (Elephant Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Generous Gift",
+        "Terastodon",
+        "March of the World Ooze",
+        "Roar of Endless Song",
+        "Kazandu Tuskcaller",
+        "Autarch Mammoth",
+        "Temur Monument",
+        "Elephant Guide"
+      ],
+      "synergy_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Elephant Kindred and Creature Tokens reinforce the plan."
     },
@@ -7519,9 +8586,11 @@
         "Evolution Sage"
       ],
       "synergy_commanders": [
-        "Galadriel, Light of Valinor - Synergy (Alliance)",
+        "Freyalise, Llanowar's Fury - Synergy (Elf Token)",
+        "Rhys the Redeemed - Synergy (Elf Token)",
+        "Nadier, Agent of the Duskenel - Synergy (Elf Token)",
         "Tatyova, Benthic Druid - Synergy (Druid Kindred)",
-        "Halana and Alena, Partners - Synergy (Ranger Kindred)"
+        "Galadriel, Light of Valinor - Synergy (Alliance)"
       ],
       "popularity_bucket": "Common",
       "description": "Focuses on getting a high number of Elf creatures into play with shared payoffs (e.g., Alliance and Druid Kindred)."
@@ -7538,6 +8607,31 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Freyalise, Llanowar's Fury",
+        "Rhys the Redeemed",
+        "Nadier, Agent of the Duskenel",
+        "Nath of the Gilt-Leaf",
+        "Thranduil the Strategist"
+      ],
+      "example_cards": [
+        "Imperious Perfect",
+        "Elvish Warmaster",
+        "Galadhrim Ambush",
+        "Lys Alana Huntmaster",
+        "Freyalise, Llanowar's Fury",
+        "Elven Ambush",
+        "Wolverine Riders",
+        "Elvish Promenade"
+      ],
+      "synergy_commanders": [
+        "God-Eternal Oketra - Synergy (Warrior Token)",
+        "Zurgo Stormrender - Synergy (Warrior Token)",
+        "Maja, Bretagard Protector - Synergy (Warrior Token)",
+        "Selvala, Heart of the Wilds - Synergy (Elf Kindred)",
+        "Ayara, First of Locthwain - Synergy (Elf Kindred)",
+        "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Warrior Token and Elf Kindred reinforce the plan."
     },
@@ -7571,10 +8665,12 @@
         "Beza, the Bounding Spring"
       ],
       "synergy_commanders": [
-        "Vito, Thorn of the Dusk Rose - Synergy (Lifegain)",
-        "Elas il-Kor, Sadistic Pilgrim - Synergy (Life Matters)",
-        "Mangara, the Diplomat - Synergy (Life Matters)",
-        "Selvala, Heart of the Wilds - Synergy (Blink)"
+        "Ashaya, Soul of the Wild - Synergy (Elemental Kindred)",
+        "Omnath, Locus of Rage - Synergy (Elemental Kindred)",
+        "Muldrotha, the Gravetide - Synergy (Elemental Kindred)",
+        "Ghalta, Primal Hunger - Synergy (Trample)",
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Trample)",
+        "Toski, Bearer of Secrets - Synergy (Protective Effects)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Elk creatures into play with shared payoffs (e.g., Lifegain and Life Matters)."
@@ -7610,7 +8706,7 @@
       ],
       "synergy_commanders": [
         "Mikaeus, the Unhallowed - Synergy (Zombie Kindred)",
-        "Syr Konrad, the Grim - Synergy (Reanimate)"
+        "Six - Synergy (Graveyard Recursion)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Embalm leveraging synergies with Clones and Zombie Kindred."
@@ -7652,9 +8748,34 @@
     {
       "id": "eminence",
       "theme": "Eminence",
-      "synergies": [],
+      "synergies": [
+        "Aggro",
+        "Combat Matters"
+      ],
       "primary_color": "Black",
       "secondary_color": "White",
+      "example_commanders": [
+        "The Ur-Dragon",
+        "Edgar Markov",
+        "Sidar Jabari of Zhalfir",
+        "Arahbo, Roar of the World",
+        "Inalla, Archmage Ritualist"
+      ],
+      "example_cards": [
+        "The Ur-Dragon",
+        "Edgar Markov",
+        "Sidar Jabari of Zhalfir",
+        "Arahbo, Roar of the World",
+        "Inalla, Archmage Ritualist",
+        "Sahir, Visitor in Darkness"
+      ],
+      "synergy_commanders": [
+        "Etali, Primal Storm - Synergy (Aggro)",
+        "Ragavan, Nimble Pilferer - Synergy (Aggro)",
+        "Toski, Bearer of Secrets - Synergy (Aggro)",
+        "Kutzil, Malamet Exemplar - Synergy (Combat Matters)",
+        "Sram, Senior Edificer - Synergy (Combat Matters)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around the Eminence theme and its supporting synergies."
     },
@@ -7692,7 +8813,7 @@
         "Spinnerette, Arachnobat - Synergy (Open an Attraction)",
         "Selvala, Heart of the Wilds - Synergy (Blink)",
         "Sheoldred, Whispering One - Synergy (Blink)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)"
+        "Veyran, Voice of Duality - Synergy (Enter the Battlefield)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Employee creatures into play with shared payoffs (e.g., Open an Attraction and Blink)."
@@ -7713,7 +8834,8 @@
         "Katilda, Dawnhart Martyr // Katilda's Rising Dawn",
         "Dorothea, Vengeful Victim // Dorothea's Retribution",
         "Sram, Senior Edificer - Synergy (Auras)",
-        "Kodama of the West Tree - Synergy (Auras)"
+        "Kodama of the West Tree - Synergy (Auras)",
+        "Danitha Capashen, Paragon - Synergy (Auras)"
       ],
       "example_cards": [
         "Wild Growth",
@@ -7758,9 +8880,7 @@
         "Lord Skitter's Blessing"
       ],
       "synergy_commanders": [
-        "Syr Armont, the Redeemer - Synergy (Role token)",
-        "King Macar, the Gold-Cursed - Synergy (Inspired)",
-        "Deadpool, Trading Card - Synergy (Hero Kindred)"
+        "Syr Armont, the Redeemer - Synergy (Role token)"
       ],
       "popularity_bucket": "Niche",
       "description": "Stacks enchantment-based engines (cost reduction, constellation, aura recursion) for relentless value accrual. Synergies like Role token and Equipment Matters reinforce the plan."
@@ -7832,8 +8952,7 @@
         "Coastline Marauders"
       ],
       "synergy_commanders": [
-        "Captain Lannery Storm - Synergy (Pirate Kindred)",
-        "Lotho, Corrupt Shirriff - Synergy (Outlaw Kindred)"
+        "Idris, Soul of the TARDIS - Synergy (Incarnation Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Encore leveraging synergies with Politics and Outlaw Kindred."
@@ -7868,7 +8987,9 @@
         "Dusyut Earthcarver"
       ],
       "synergy_commanders": [
-        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Thalisse, Reverent Medium - Synergy (Spirit Token)",
+        "Goro-Goro, Disciple of Ryusei - Synergy (Spirit Token)",
+        "Kykar, Wind's Fury - Synergy (Spirit Token)",
         "Boromir, Warden of the Tower - Synergy (Soldier Kindred)"
       ],
       "popularity_bucket": "Rare",
@@ -7904,7 +9025,8 @@
         "Decoction Module"
       ],
       "synergy_commanders": [
-        "Cayth, Famed Mechanist - Synergy (Servo Kindred)"
+        "Nissa, Worldsoul Speaker - Synergy (Energy Counters)",
+        "Saheeli, the Gifted - Synergy (Servo Token)"
       ],
       "popularity_bucket": "Niche",
       "description": "Accumulates Energy counters as a parallel resource spent for tempo spikes, draw, or scalable removal. Synergies like Resource Engine and Energy Counters reinforce the plan."
@@ -7939,7 +9061,8 @@
         "Izzet Generatorium"
       ],
       "synergy_commanders": [
-        "Cayth, Famed Mechanist - Synergy (Servo Kindred)"
+        "Nissa, Worldsoul Speaker - Synergy (Resource Engine)",
+        "Saheeli, the Gifted - Synergy (Servo Token)"
       ],
       "popularity_bucket": "Niche",
       "description": "Accumulates Energy counters as a parallel resource spent for tempo spikes, draw, or scalable removal. Synergies like Energy and Resource Engine reinforce the plan."
@@ -7974,6 +9097,7 @@
         "Coalition Skyknight"
       ],
       "synergy_commanders": [
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)",
         "Ragavan, Nimble Pilferer - Synergy (Aggro)",
         "Toski, Bearer of Secrets - Synergy (Combat Matters)"
       ],
@@ -8011,9 +9135,9 @@
       ],
       "synergy_commanders": [
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Dinosaur Kindred)",
-        "Syr Konrad, the Grim - Synergy (Big Mana)",
-        "Tatyova, Benthic Druid - Synergy (Big Mana)",
-        "Azusa, Lost but Seeking - Synergy (Toughness Matters)"
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)",
+        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)",
+        "Krenko, Tin Street Kingpin - Synergy (Counters Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Enrage leveraging synergies with Dinosaur Kindred and Toughness Matters."
@@ -8048,8 +9172,9 @@
         "Mithril Coat"
       ],
       "synergy_commanders": [
+        "Veyran, Voice of Duality - Synergy (Blink)",
         "Syr Konrad, the Grim - Synergy (Reanimate)",
-        "Emry, Lurker of the Loch - Synergy (Reanimate)",
+        "Six - Synergy (Reanimate)",
         "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
       ],
       "popularity_bucket": "Very Common",
@@ -8085,8 +9210,8 @@
         "Dream's Grip"
       ],
       "synergy_commanders": [
-        "Samut, Voice of Dissent - Synergy (Combat Tricks)",
-        "Naru Meha, Master Wizard - Synergy (Combat Tricks)"
+        "The Wandering Rescuer - Synergy (Combat Tricks)",
+        "Ambrosia Whiteheart - Synergy (Combat Tricks)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Entwine leveraging synergies with Toolbox and Spells Matter."
@@ -8129,6 +9254,7 @@
         "Neverending Torment"
       ],
       "synergy_commanders": [
+        "Mangara, the Diplomat - Synergy (Stax)",
         "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Spells Matter)"
       ],
       "popularity_bucket": "Rare",
@@ -8148,7 +9274,8 @@
       "secondary_color": "Black",
       "example_commanders": [
         "Halvar, God of Battle // Sword of the Realms",
-        "Kaldra Compleat - Synergy (Living weapon)"
+        "Kaldra Compleat - Synergy (Living weapon)",
+        "Bitterthorn, Nissa's Animus - Synergy (Living weapon)"
       ],
       "example_cards": [
         "Swiftfoot Boots",
@@ -8192,6 +9319,9 @@
         "Blackblade Reforged",
         "Whispersilk Cloak"
       ],
+      "synergy_commanders": [
+        "Kaldra Compleat - Synergy (Living weapon)"
+      ],
       "popularity_bucket": "Uncommon",
       "description": "Tutors and reuses equipment to stack stats/keywords onto resilient bodies for persistent pressure. Synergies like Equip and Job select reinforce the plan."
     },
@@ -8227,8 +9357,8 @@
       "synergy_commanders": [
         "Halvar, God of Battle // Sword of the Realms - Synergy (Equipment)",
         "Toralf, God of Fury // Toralf's Hammer - Synergy (Equipment)",
-        "Mithril Coat - Synergy (Equip)",
         "Sword of the Animist - Synergy (Equip)",
+        "Mithril Coat - Synergy (Equip)",
         "Ellivere of the Wild Court - Synergy (Role token)"
       ],
       "popularity_bucket": "Very Common",
@@ -8262,7 +9392,9 @@
         "Borrowed Malevolence"
       ],
       "synergy_commanders": [
-        "Niv-Mizzet, Parun - Synergy (Spellslinger)"
+        "Avacyn, Angel of Hope - Synergy (Interaction)",
+        "Padeem, Consul of Innovation - Synergy (Interaction)",
+        "Mangara, the Diplomat - Synergy (Spellslinger)"
       ],
       "popularity_bucket": "Rare",
       "description": "Selects multiple modes on Escalate spells, trading mana/cards for flexible stacked effects. Synergies like Interaction and Spells Matter reinforce the plan."
@@ -8297,11 +9429,10 @@
         "Chainweb Aracnir"
       ],
       "synergy_commanders": [
-        "Emry, Lurker of the Loch - Synergy (Reanimate)",
-        "Six - Synergy (Reanimate)",
-        "Sheoldred, Whispering One - Synergy (Mill)",
-        "Kozilek, Butcher of Truth - Synergy (Mill)",
-        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)"
+        "Six - Synergy (Graveyard Recursion)",
+        "Muldrotha, the Gravetide - Synergy (Graveyard Recursion)",
+        "Emry, Lurker of the Loch - Synergy (Mill)",
+        "Sheoldred, Whispering One - Synergy (Reanimate)"
       ],
       "popularity_bucket": "Rare",
       "description": "Escapes threats from the graveyard by exiling spent resources, generating recursive inevitability. Synergies like Reanimate and Mill reinforce the plan."
@@ -8336,7 +9467,7 @@
         "Resilient Khenra"
       ],
       "synergy_commanders": [
-        "Syr Konrad, the Grim - Synergy (Reanimate)"
+        "Six - Synergy (Graveyard Recursion)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Eternalize leveraging synergies with Clones and Zombie Kindred."
@@ -8371,7 +9502,8 @@
         "Subtlety"
       ],
       "synergy_commanders": [
-        "Idris, Soul of the TARDIS - Synergy (Incarnation Kindred)"
+        "Idris, Soul of the TARDIS - Synergy (Incarnation Kindred)",
+        "Omnath, Locus of Rage - Synergy (Elemental Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Evoke leveraging synergies with Elemental Kindred and Flash."
@@ -8406,8 +9538,9 @@
         "Experiment One"
       ],
       "synergy_commanders": [
-        "Yahenni, Undying Partisan - Synergy (Counters Matter)",
-        "Sram, Senior Edificer - Synergy (Voltron)"
+        "Deadpool, Trading Card - Synergy (Mutant Kindred)",
+        "Kuja, Genome Sorcerer // Trance Kuja, Fate Defied - Synergy (Mutant Kindred)",
+        "Agent Frank Horrigan - Synergy (Mutant Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Sequentially upgrades creatures with Evolve counters, then leverages accumulated stats or counter synergies. Synergies like +1/+1 Counters and Counters Matter reinforce the plan."
@@ -8442,9 +9575,11 @@
         "Rafiq of the Many"
       ],
       "synergy_commanders": [
-        "Etali, Primal Storm - Synergy (Aggro)",
-        "Ragavan, Nimble Pilferer - Synergy (Aggro)",
-        "Toski, Bearer of Secrets - Synergy (Combat Matters)"
+        "Adeline, Resplendent Cathar - Synergy (Knight Kindred)",
+        "Danitha Capashen, Paragon - Synergy (Knight Kindred)",
+        "Boromir, Warden of the Tower - Synergy (Soldier Kindred)",
+        "Anim Pakal, Thousandth Moon - Synergy (Soldier Kindred)",
+        "Etali, Primal Storm - Synergy (Aggro)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Exalted leveraging synergies with Human Kindred and Aggro."
@@ -8514,11 +9649,12 @@
         "Draconautics Engineer"
       ],
       "synergy_commanders": [
-        "Sram, Senior Edificer - Synergy (Vehicles)",
-        "Shorikai, Genesis Engine - Synergy (Vehicles)",
-        "The Indomitable - Synergy (Vehicles)",
-        "Krenko, Tin Street Kingpin - Synergy (+1/+1 Counters)",
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
+        "Toph, Hardheaded Teacher - Synergy (Bending)",
+        "Toph, Earthbending Master - Synergy (Bending)",
+        "The Unagi of Kyoshi Island - Synergy (Bending)",
+        "Cosima, God of the Voyage // The Omenkeel - Synergy (Crew)",
+        "Shorikai, Genesis Engine - Synergy (Crew)",
+        "Sram, Senior Edificer - Synergy (Vehicles)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Exhaust leveraging synergies with +1/+1 Counters and Counters Matter."
@@ -8553,9 +9689,9 @@
         "Chimil, the Inner Sun"
       ],
       "synergy_commanders": [
-        "The Tenth Doctor - Synergy (Suspend)",
+        "Taigam, Master Opportunist - Synergy (Suspend)",
         "Jhoira of the Ghitu - Synergy (Suspend)",
-        "Ranar the Ever-Watchful - Synergy (Foretell)"
+        "Bohn, Beguiling Balladeer - Synergy (Foretell)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Builds around Exile Matters leveraging synergies with Suspend and Impulse."
@@ -8588,6 +9724,14 @@
         "Mizzix of the Izmagnus",
         "Kelsien, the Plague",
         "Daxos the Returned"
+      ],
+      "synergy_commanders": [
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)",
+        "Rishkar, Peema Renegade - Synergy (Counters Matter)",
+        "Syr Konrad, the Grim - Synergy (Human Kindred)",
+        "Azusa, Lost but Seeking - Synergy (Human Kindred)",
+        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds experience counters to scale commander-centric engines into exponential payoffs."
@@ -8660,6 +9804,7 @@
       ],
       "synergy_commanders": [
         "Kellan, Daring Traveler // Journey On - Synergy (Map Token)",
+        "Thrór's Map - Synergy (Map Token)",
         "Selvala, Heart of the Wilds - Synergy (Scout Kindred)"
       ],
       "popularity_bucket": "Niche",
@@ -8731,7 +9876,7 @@
         "Goldbug, Humanity's Ally // Goldbug, Scrappy Scout"
       ],
       "synergy_commanders": [
-        "Prowl, Stoic Strategist // Prowl, Pursuit Vehicle - Synergy (More Than Meets the Eye)"
+        "Prowl, Stoic Strategist // Prowl, Pursuit Vehicle - Synergy (Living metal)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Eye creatures into play with shared payoffs (e.g., Convert and Living metal)."
@@ -8766,6 +9911,7 @@
         "Iron League Steed"
       ],
       "synergy_commanders": [
+        "Urza, Lord High Artificer - Synergy (Artificer Kindred)",
         "Ragavan, Nimble Pilferer - Synergy (Artifact Tokens)"
       ],
       "popularity_bucket": "Rare",
@@ -8785,7 +9931,8 @@
       "example_commanders": [
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
         "Rishkar, Peema Renegade - Synergy (Counters Matter)",
-        "Sram, Senior Edificer - Synergy (Enchantments Matter)"
+        "Sram, Senior Edificer - Synergy (Enchantments Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)"
       ],
       "example_cards": [
         "Tangle Wire",
@@ -8813,7 +9960,8 @@
       "example_commanders": [
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
         "Rishkar, Peema Renegade - Synergy (Counters Matter)",
-        "Sram, Senior Edificer - Synergy (Enchantments Matter)"
+        "Sram, Senior Edificer - Synergy (Enchantments Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)"
       ],
       "example_cards": [
         "Tangle Wire",
@@ -8836,7 +9984,7 @@
         "Rogue Token",
         "Dragon Token",
         "Rogue Kindred",
-        "Flying"
+        "Detective Kindred"
       ],
       "primary_color": "Blue",
       "secondary_color": "Black",
@@ -8858,11 +10006,11 @@
         "Ancient Gold Dragon"
       ],
       "synergy_commanders": [
-        "Lotho, Corrupt Shirriff - Synergy (Rogue Kindred)",
-        "Sakashima of a Thousand Faces - Synergy (Rogue Kindred)",
-        "Niv-Mizzet, Parun - Synergy (Flying)",
-        "Avacyn, Angel of Hope - Synergy (Flying)",
-        "Ragavan, Nimble Pilferer - Synergy (Outlaw Kindred)"
+        "Oona, Queen of the Fae - Synergy (Faerie Token)",
+        "Alela, Artful Provocateur - Synergy (Faerie Token)",
+        "Gisa, the Hellraiser - Synergy (Rogue Token)",
+        "Baron Bertram Graywater - Synergy (Rogue Token)",
+        "Lathliss, Dragon Queen - Synergy (Dragon Token)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Focuses on getting a high number of Faerie creatures into play with shared payoffs (e.g., Rogue Kindred and Outlaw Kindred)."
@@ -8879,6 +10027,30 @@
       ],
       "primary_color": "Blue",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Alela, Cunning Conqueror",
+        "Oona, Queen of the Fae",
+        "Alela, Artful Provocateur",
+        "Feywild Visitor",
+        "Elminster"
+      ],
+      "example_cards": [
+        "Bitterblossom",
+        "Ancient Gold Dragon",
+        "Bitterbloom Bearer",
+        "Mischievous Mystic",
+        "Alela, Cunning Conqueror",
+        "Notorious Throng",
+        "Oona, Queen of the Fae",
+        "Stolen by the Fae"
+      ],
+      "synergy_commanders": [
+        "Gisa, the Hellraiser - Synergy (Rogue Token)",
+        "Baron Bertram Graywater - Synergy (Rogue Token)",
+        "Rankle, Master of Pranks - Synergy (Faerie Kindred)",
+        "Talion, the Kindly Lord - Synergy (Faerie Kindred)",
+        "Lathliss, Dragon Queen - Synergy (Dragon Token)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Rogue Token and Faerie Kindred reinforce the plan."
     },
@@ -8920,6 +10092,13 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Syr Konrad, the Grim - Synergy (Mill)",
+        "Six - Synergy (Mill)",
+        "Emry, Lurker of the Loch - Synergy (Mill)",
+        "Sheoldred, Whispering One - Synergy (Reanimate)",
+        "The Gitrog Monster - Synergy (Reanimate)"
+      ],
       "example_cards": [
         "Matzalantli, the Great Door // The Core",
         "Squirming Emergence",
@@ -8961,7 +10140,7 @@
         "Arcbound Fiend"
       ],
       "synergy_commanders": [
-        "Zopandrel, Hunger Dominus - Synergy (Horror Kindred)",
+        "The Gitrog Monster - Synergy (Horror Kindred)",
         "Neheb, the Eternal - Synergy (Zombie Kindred)",
         "Mikaeus, the Unhallowed - Synergy (Zombie Kindred)",
         "Ashaya, Soul of the Wild - Synergy (Elemental Kindred)"
@@ -8975,6 +10154,14 @@
       "synergies": [],
       "primary_color": "White",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Kangee, Aerie Keeper"
+      ],
+      "example_cards": [
+        "Soulcatchers' Aerie",
+        "Aven Mimeomancer",
+        "Kangee, Aerie Keeper"
+      ],
       "popularity_bucket": "Rare",
       "description": "Accumulates feather counters to unlock scaling payoffs, removal triggers, or delayed value conversions."
     },
@@ -9008,7 +10195,9 @@
         "See the Unwritten"
       ],
       "synergy_commanders": [
-        "Niv-Mizzet, Parun - Synergy (Spellslinger)"
+        "Wildsear, Scouring Maw - Synergy (Wolf Kindred)",
+        "Anara, Wolvid Familiar - Synergy (Wolf Kindred)",
+        "Torgal, A Fine Hound - Synergy (Wolf Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Ferocious leveraging synergies with Big Mana and Spells Matter."
@@ -9056,9 +10245,9 @@
       "synergy_commanders": [
         "Urabrask // The Great Work - Synergy (Lore Counters)",
         "Sheoldred // The True Scriptures - Synergy (Lore Counters)",
-        "Jhoira, Weatherlight Captain - Synergy (Sagas Matter)",
-        "Teshar, Ancestor's Apostle - Synergy (Sagas Matter)",
-        "Etali, Primal Storm - Synergy (Dinosaur Kindred)"
+        "Vorinclex, Monstrous Raider - Synergy (Ore Counters)",
+        "Lae'zel, Vlaakith's Champion - Synergy (Ore Counters)",
+        "Jhoira, Weatherlight Captain - Synergy (Sagas Matter)"
       ],
       "popularity_bucket": "Niche",
       "description": "Builds around Fight leveraging synergies with Lore Counters and Dinosaur Kindred."
@@ -9094,39 +10283,24 @@
       ],
       "synergy_commanders": [
         "Syr Konrad, the Grim - Synergy (Mill)",
+        "Six - Synergy (Mill)",
         "Emry, Lurker of the Loch - Synergy (Mill)",
-        "Sheoldred, Whispering One - Synergy (Mill)",
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
-        "Rishkar, Peema Renegade - Synergy (Counters Matter)",
-        "Six - Synergy (Reanimate)"
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)",
+        "Sheoldred, Whispering One - Synergy (Reanimate)"
       ],
       "popularity_bucket": "Rare",
       "description": "Accumulates finality counters to unlock scaling payoffs, removal triggers, or delayed value conversions."
     },
     {
-      "id": "firebend",
-      "theme": "Firebend",
-      "synergies": [
-        "Firebending",
-        "Bending",
-        "Noble Kindred",
-        "Mana Dork",
-        "Ally Kindred"
-      ],
-      "primary_color": "Red",
-      "secondary_color": "Black",
-      "popularity_bucket": "Niche",
-      "description": "Builds around Firebend leveraging synergies with Firebending and Bending."
-    },
-    {
       "id": "firebending",
       "theme": "Firebending",
       "synergies": [
-        "Firebend",
         "Bending",
+        "Mana Dork",
         "Noble Kindred",
         "Ally Kindred",
-        "Mana Dork"
+        "X Spells"
       ],
       "primary_color": "Red",
       "secondary_color": "Black",
@@ -9148,10 +10322,12 @@
         "Vindictive Warden"
       ],
       "synergy_commanders": [
-        "Aang, Airbending Master - Synergy (Bending)",
-        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Mana Dork)",
-        "Selvala, Heart of the Wilds - Synergy (Mana Dork)",
-        "Ghalta, Primal Hunger - Synergy (X Spells)"
+        "Toph, Hardheaded Teacher - Synergy (Bending)",
+        "Toph, Earthbending Master - Synergy (Bending)",
+        "The Unagi of Kyoshi Island - Synergy (Bending)",
+        "Ayara, First of Locthwain - Synergy (Noble Kindred)",
+        "Loot, Exuberant Explorer - Synergy (Noble Kindred)",
+        "Selvala, Heart of the Wilds - Synergy (Mana Dork)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Firebending leveraging synergies with Bending and Mana Dork."
@@ -9187,8 +10363,8 @@
       ],
       "synergy_commanders": [
         "Ayesha Tanaka - Synergy (Banding)",
-        "Gaddock Teeg - Synergy (Kithkin Kindred)",
-        "Brigid, Hero of Kinsbaile - Synergy (Kithkin Kindred)",
+        "Karlach, Fury of Avernus - Synergy (Barbarian Kindred)",
+        "Godo, Bandit Warlord - Synergy (Barbarian Kindred)",
         "Syr Konrad, the Grim - Synergy (Knight Kindred)"
       ],
       "popularity_bucket": "Uncommon",
@@ -9223,9 +10399,6 @@
         "Eluge, the Shoreless Sea",
         "Tidal Barracuda"
       ],
-      "synergy_commanders": [
-        "Kutzil, Malamet Exemplar - Synergy (Stax)"
-      ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Fish creatures into play with shared payoffs (e.g., Loot and Stax)."
     },
@@ -9241,6 +10414,21 @@
       ],
       "primary_color": "Blue",
       "secondary_color": "White",
+      "example_commanders": [
+        "Beza, the Bounding Spring",
+        "Eluge, the Shoreless Sea - Synergy (Fish Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Into the Flood Maw",
+        "Fountainport",
+        "Parting Gust",
+        "Sazacap's Brew",
+        "Beza, the Bounding Spring",
+        "Reef Worm",
+        "Fisher's Talent",
+        "Longstalk Brawl"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Gift and Fish Kindred reinforce the plan."
     },
@@ -9323,8 +10511,9 @@
         "Hydroelectric Specimen // Hydroelectric Laboratory"
       ],
       "synergy_commanders": [
+        "The Wandering Rescuer - Synergy (Combat Tricks)",
+        "Ambrosia Whiteheart - Synergy (Combat Tricks)",
         "Samut, Voice of Dissent - Synergy (Combat Tricks)",
-        "Naru Meha, Master Wizard - Synergy (Combat Tricks)",
         "Rankle, Master of Pranks - Synergy (Faerie Kindred)"
       ],
       "popularity_bucket": "Common",
@@ -9360,7 +10549,8 @@
         "Momentary Blink"
       ],
       "synergy_commanders": [
-        "Mondrak, Glory Dominus - Synergy (Clones)"
+        "Muldrotha, the Gravetide - Synergy (Graveyard Recursion)",
+        "Uro, Titan of Nature's Wrath - Synergy (Graveyard Recursion)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Replays instants & sorceries from the graveyard (Flashback) for incremental spell velocity. Synergies like Reanimate and Mill reinforce the plan."
@@ -9374,7 +10564,10 @@
       "primary_color": "Blue",
       "example_commanders": [
         "Eluge, the Shoreless Sea",
-        "Xolatoyac, the Smiling Flood"
+        "Xolatoyac, the Smiling Flood",
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)",
+        "Rishkar, Peema Renegade - Synergy (Counters Matter)"
       ],
       "example_cards": [
         "Eluge, the Shoreless Sea",
@@ -9417,9 +10610,11 @@
         "Poised Practitioner"
       ],
       "synergy_commanders": [
+        "Tifa Lockhart - Synergy (Monk Kindred)",
+        "Lyse Hext - Synergy (Monk Kindred)",
         "Lotho, Corrupt Shirriff - Synergy (Spells Matter)",
         "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Spells Matter)",
-        "Niv-Mizzet, Parun - Synergy (Spellslinger)"
+        "Mangara, the Diplomat - Synergy (Spellslinger)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Flurry leveraging synergies with Monk Kindred and Spells Matter."
@@ -9566,8 +10761,8 @@
         "Mirran Bardiche"
       ],
       "synergy_commanders": [
-        "Toralf, God of Fury // Toralf's Hammer - Synergy (Equip)",
-        "The Reality Chip - Synergy (Equipment)"
+        "Barret, Avalanche Leader - Synergy (Rebel Token)",
+        "Longshot, Rebel Bowman - Synergy (Rebel Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around For Mirrodin! leveraging synergies with Rebel Kindred and Equip."
@@ -9601,8 +10796,8 @@
         "Treetop Sentries"
       ],
       "synergy_commanders": [
-        "Syr Ginger, the Meal Ender - Synergy (Food)",
-        "Tatyova, Benthic Druid - Synergy (Lifegain)"
+        "Toski, Bearer of Secrets - Synergy (Squirrel Kindred)",
+        "Chatterfang, Squirrel General - Synergy (Squirrel Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Forage leveraging synergies with Food Token and Food."
@@ -9665,7 +10860,10 @@
         "Pale Recluse"
       ],
       "synergy_commanders": [
-        "Baral, Chief of Compliance - Synergy (Loot)"
+        "Rocksteady, Crash Courser - Synergy (Landcycling)",
+        "Jennika, Bad Apple Big Sister - Synergy (Landcycling)",
+        "Zog, Triceraton Castaway - Synergy (Typecycling)",
+        "Bebop, Warthog Warrior - Synergy (Typecycling)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Forestcycling leveraging synergies with Land Types Matter and Cycling."
@@ -9674,8 +10872,8 @@
       "id": "forestwalk",
       "theme": "Forestwalk",
       "synergies": [
-        "Dryad Kindred",
         "Landwalk",
+        "Dryad Kindred",
         "Cat Kindred",
         "Lands Matter",
         "Warrior Kindred"
@@ -9700,9 +10898,9 @@
         "Lynx"
       ],
       "synergy_commanders": [
-        "Trostani, Selesnya's Voice - Synergy (Dryad Kindred)",
-        "Trostani Discordant - Synergy (Dryad Kindred)",
         "Sheoldred, Whispering One - Synergy (Landwalk)",
+        "Wrexial, the Risen Deep - Synergy (Landwalk)",
+        "Trostani, Selesnya's Voice - Synergy (Dryad Kindred)",
         "Kutzil, Malamet Exemplar - Synergy (Cat Kindred)"
       ],
       "popularity_bucket": "Rare",
@@ -9738,9 +10936,9 @@
         "Doomskar"
       ],
       "synergy_commanders": [
-        "Vito, Thorn of the Dusk Rose - Synergy (Cleric Kindred)",
-        "Elas il-Kor, Sadistic Pilgrim - Synergy (Cleric Kindred)",
-        "Lotho, Corrupt Shirriff - Synergy (Spells Matter)"
+        "Avacyn, Angel of Hope - Synergy (Angel Kindred)",
+        "Aurelia, the Warleader - Synergy (Angel Kindred)",
+        "Vito, Thorn of the Dusk Rose - Synergy (Cleric Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Foretells spells early to smooth curve, conceal information, and discount impactful future turns. Synergies like Exile Matters and Cleric Kindred reinforce the plan."
@@ -9773,6 +10971,7 @@
         "Crater Elemental"
       ],
       "synergy_commanders": [
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)",
         "Syr Konrad, the Grim - Synergy (Human Kindred)",
         "Loran of the Third Path - Synergy (Human Kindred)",
         "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
@@ -9850,10 +11049,12 @@
         "Geometric Nexus"
       ],
       "synergy_commanders": [
-        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)",
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
-        "Yahenni, Undying Partisan - Synergy (Counters Matter)",
-        "Sram, Senior Edificer - Synergy (Voltron)"
+        "Deekah, Fractal Theorist - Synergy (Fractal Token)",
+        "Primo, the Unbounded - Synergy (Fractal Token)",
+        "Berta, Wise Extrapolator - Synergy (Fractal Token)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Fractal creatures into play with shared payoffs (e.g., +1/+1 Counters and Counters Matter)."
@@ -9870,6 +11071,29 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Deekah, Fractal Theorist",
+        "Primo, the Unbounded",
+        "Berta, Wise Extrapolator",
+        "Emil, Vastlands Roamer",
+        "Kianne, Dean of Substance // Imbraham, Dean of Theory"
+      ],
+      "example_cards": [
+        "Deekah, Fractal Theorist",
+        "Fractal Harness",
+        "Oversimplify",
+        "Primo, the Unbounded",
+        "Paradox Zone",
+        "Berta, Wise Extrapolator",
+        "Emil, Vastlands Roamer",
+        "Lattice Library"
+      ],
+      "synergy_commanders": [
+        "Esix, Fractal Bloom - Synergy (Fractal Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Fractal Kindred and Creature Tokens reinforce the plan."
     },
@@ -9904,9 +11128,10 @@
       ],
       "synergy_commanders": [
         "Massacre Girl, Known Killer - Synergy (Assassin Kindred)",
+        "The Lord of Pain - Synergy (Assassin Kindred)",
         "Ghalta, Primal Hunger - Synergy (Cost Reduction)",
         "Emry, Lurker of the Loch - Synergy (Cost Reduction)",
-        "Syr Konrad, the Grim - Synergy (Big Mana)"
+        "Ragavan, Nimble Pilferer - Synergy (Outlaw Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Freerunning leveraging synergies with Assassin Kindred and Cost Reduction."
@@ -9934,6 +11159,11 @@
         "Sophina, Spearsage Deserter",
         "Othelm, Sigardian Outcast",
         "Hargilde, Kindly Runechanter"
+      ],
+      "synergy_commanders": [
+        "Syr Konrad, the Grim - Synergy (Human Kindred)",
+        "Azusa, Lost but Seeking - Synergy (Human Kindred)",
+        "Loran of the Third Path - Synergy (Human Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around the Friends Forever theme and its supporting synergies."
@@ -9971,9 +11201,9 @@
         "Six - Synergy (Reach)",
         "Kodama of the West Tree - Synergy (Reach)",
         "Kodama of the East Tree - Synergy (Reach)",
-        "Loot, Exuberant Explorer - Synergy (Beast Kindred)",
-        "Questing Beast - Synergy (Beast Kindred)",
-        "Emry, Lurker of the Loch - Synergy (Wizard Kindred)"
+        "Tatyova, Benthic Druid - Synergy (Druid Kindred)",
+        "Rishkar, Peema Renegade - Synergy (Druid Kindred)",
+        "Loot, Exuberant Explorer - Synergy (Beast Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Frog creatures into play with shared payoffs (e.g., Reach and Beast Kindred)."
@@ -10020,9 +11250,10 @@
         "Slimefoot, the Stowaway"
       ],
       "synergy_commanders": [
+        "Ellie, Brick Master - Synergy (Fungus Token)",
+        "Abby, Merciless Soldier - Synergy (Fungus Token)",
         "Thelon of Havenwood - Synergy (Spore Counters)",
-        "Nemata, Primeval Warden - Synergy (Saproling Kindred)",
-        "Vorinclex, Monstrous Raider - Synergy (Ore Counters)"
+        "Nemata, Primeval Warden - Synergy (Saproling Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Fungus creatures into play with shared payoffs (e.g., Spore Counters and Saproling Kindred)."
@@ -10038,6 +11269,27 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Black",
+      "example_commanders": [
+        "The Mycotyrant",
+        "Ellie, Brick Master",
+        "Abby, Merciless Soldier",
+        "Slimefoot, the Stowaway - Synergy (Fungus Kindred)",
+        "Slimefoot and Squee - Synergy (Fungus Kindred)"
+      ],
+      "example_cards": [
+        "The Skullspore Nexus",
+        "The Mycotyrant",
+        "Trudge Garden",
+        "Ellie, Brick Master",
+        "Broodrage Mycoid",
+        "Abby, Merciless Soldier",
+        "Synapse Necromage"
+      ],
+      "synergy_commanders": [
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Fungus Kindred and Creature Tokens reinforce the plan."
     },
@@ -10052,6 +11304,26 @@
       ],
       "primary_color": "Red",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Avacyn, Angel of Hope - Synergy (Interaction)",
+        "Boromir, Warden of the Tower - Synergy (Interaction)",
+        "Padeem, Consul of Innovation - Synergy (Interaction)",
+        "Lotho, Corrupt Shirriff - Synergy (Spells Matter)",
+        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Spells Matter)"
+      ],
+      "example_cards": [
+        "Wear // Tear",
+        "Gallifrey Falls // No More",
+        "Double Jump // Flying Kick",
+        "Armed // Dangerous",
+        "Give // Take",
+        "Ready // Willing",
+        "Far // Away",
+        "Beck // Call"
+      ],
+      "synergy_commanders": [
+        "Mangara, the Diplomat - Synergy (Spellslinger)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Fuse leveraging synergies with Removal and Interaction."
     },
@@ -10062,6 +11334,11 @@
         "Counters Matter"
       ],
       "primary_color": "Red",
+      "example_commanders": [
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)",
+        "Rishkar, Peema Renegade - Synergy (Counters Matter)"
+      ],
       "example_cards": [
         "Goblin Bomb",
         "Pumpkin Bombs",
@@ -10102,7 +11379,10 @@
         "Nullstone Gargoyle"
       ],
       "synergy_commanders": [
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)"
+        "The Walls of Ba Sing Se - Synergy (Defender)",
+        "Sokrates, Athenian Teacher - Synergy (Defender)",
+        "The Pride of Hull Clade - Synergy (Defender)",
+        "Toski, Bearer of Secrets - Synergy (Protective Effects)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Gargoyle creatures into play with shared payoffs (e.g., Flying and Blink)."
@@ -10142,7 +11422,7 @@
         "Sai, Master Thopterist - Synergy (Sacrifice to Draw)",
         "Ragavan, Nimble Pilferer - Synergy (Artifact Tokens)",
         "Lotho, Corrupt Shirriff - Synergy (Artifact Tokens)",
-        "Vorinclex // The Grand Evolution - Synergy (Land Types Matter)"
+        "Karametra, God of Harvests - Synergy (Land Types Matter)"
       ],
       "popularity_bucket": "Niche",
       "description": "Builds around Gates Matter leveraging synergies with Sacrifice to Draw and Artifact Tokens."
@@ -10177,7 +11457,8 @@
         "Lashwrithe"
       ],
       "synergy_commanders": [
-        "Toralf, God of Fury // Toralf's Hammer - Synergy (Equip)"
+        "Ekthi, Contaminator Priest - Synergy (Germ Token)",
+        "Brudiclad, Telchor Engineer - Synergy (Phyrexian Token)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Germ creatures into play with shared payoffs (e.g., Living weapon and Equip)."
@@ -10194,6 +11475,22 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Ekthi, Contaminator Priest",
+        "Bitterthorn, Nissa's Animus - Synergy (Germ Kindred)",
+        "Kaldra Compleat - Synergy (Living weapon)",
+        "Brudiclad, Telchor Engineer - Synergy (Phyrexian Token)"
+      ],
+      "example_cards": [
+        "Nettlecyst",
+        "Bitterthorn, Nissa's Animus",
+        "Bonehoard",
+        "Batterskull",
+        "Cranial Ram",
+        "Scytheclaw",
+        "Batterbone",
+        "Lashwrithe"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Germ Kindred and Living weapon reinforce the plan."
     },
@@ -10231,7 +11528,7 @@
         "Polukranos, World Eater - Synergy (Monstrosity)",
         "Hythonia the Cruel - Synergy (Monstrosity)",
         "Kardur, Doomscourge - Synergy (Berserker Kindred)",
-        "Magda, Brazen Outlaw - Synergy (Berserker Kindred)",
+        "Alexios, Deimos of Kosmos - Synergy (Berserker Kindred)",
         "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)"
       ],
       "popularity_bucket": "Uncommon",
@@ -10247,6 +11544,24 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Urza, Lord High Artificer - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)",
+        "Lotho, Corrupt Shirriff - Synergy (Token Creation)"
+      ],
+      "example_cards": [
+        "Giant Opportunity",
+        "Giant's Amulet",
+        "Pact of the Titan",
+        "Quest for the Gravelord",
+        "Feudkiller's Verdict",
+        "Giantbaiting"
+      ],
+      "synergy_commanders": [
+        "Mondrak, Glory Dominus - Synergy (Tokens Matter)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Creature Tokens and Token Creation reinforce the plan."
     },
@@ -10280,9 +11595,9 @@
         "Peerless Recycling"
       ],
       "synergy_commanders": [
+        "Beza, the Bounding Spring - Synergy (Fish Token)",
         "Eluge, the Shoreless Sea - Synergy (Fish Kindred)",
-        "Beza, the Bounding Spring - Synergy (Fish Kindred)",
-        "Morska, Undersea Sleuth - Synergy (Fish Kindred)"
+        "Ray Fillet, Wave Warrior - Synergy (Fish Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Gift leveraging synergies with Unconditional Draw and Cantrips."
@@ -10336,7 +11651,7 @@
         "Braids, Arisen Nightmare - Synergy (Sacrifice Matters)",
         "Sheoldred, the Apocalypse - Synergy (Sacrifice Matters)",
         "Elas il-Kor, Sadistic Pilgrim - Synergy (Aristocrats)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Aristocrats)"
+        "Yawgmoth, Thran Physician - Synergy (Aristocrats)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Glimmer creatures into play with shared payoffs (e.g., Enchantments Matter and Blink)."
@@ -10353,6 +11668,24 @@
       ],
       "primary_color": "White",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Heliod, God of the Sun - Synergy (Enchantment Tokens)",
+        "Go-Shintai of Life's Origin - Synergy (Enchantment Tokens)",
+        "Ellivere of the Wild Court - Synergy (Enchantment Tokens)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Soaring Lightbringer",
+        "Glimmerburst",
+        "Grand Entryway // Elegant Rotunda",
+        "Glimmerlight",
+        "Glimmer Seeker",
+        "Tunnel Surveyor"
+      ],
+      "synergy_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Enchantment Tokens and Creature Tokens reinforce the plan."
     },
@@ -10401,11 +11734,9 @@
         "Jan Jansen, Chaos Crafter"
       ],
       "synergy_commanders": [
+        "Thousand Moons Smithy // Barracks of the Thousand - Synergy (Gnome Token)",
         "Ragavan, Nimble Pilferer - Synergy (Artifact Tokens)",
         "Lotho, Corrupt Shirriff - Synergy (Artifact Tokens)",
-        "Peregrin Took - Synergy (Artifact Tokens)",
-        "Azusa, Lost but Seeking - Synergy (Ramp)",
-        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Ramp)",
         "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
       ],
       "popularity_bucket": "Rare",
@@ -10423,6 +11754,27 @@
       ],
       "primary_color": "White",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Anim Pakal, Thousandth Moon",
+        "Tetzin, Gnome Champion // The Golden-Gear Colossus",
+        "Oswald Fiddlebender - Synergy (Gnome Kindred)",
+        "Jan Jansen, Chaos Crafter - Synergy (Gnome Kindred)",
+        "Ragavan, Nimble Pilferer - Synergy (Artifact Tokens)"
+      ],
+      "example_cards": [
+        "Anim Pakal, Thousandth Moon",
+        "Threefold Thunderhulk",
+        "Thousand Moons Smithy // Barracks of the Thousand",
+        "Illustrious Wanderglyph",
+        "Oltec Matterweaver",
+        "Clay-Fired Bricks // Cosmium Kiln",
+        "Tinker's Tote",
+        "Tetzin, Gnome Champion // The Golden-Gear Colossus"
+      ],
+      "synergy_commanders": [
+        "Lotho, Corrupt Shirriff - Synergy (Artifact Tokens)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Gnome Kindred and Artifact Tokens reinforce the plan."
     },
@@ -10434,7 +11786,7 @@
         "First strike",
         "Rogue Kindred",
         "Theft",
-        "Enchant"
+        "Dragon Kindred"
       ],
       "primary_color": "Red",
       "secondary_color": "Blue",
@@ -10456,11 +11808,12 @@
         "Take the Bait"
       ],
       "synergy_commanders": [
-        "Ragavan, Nimble Pilferer - Synergy (Theft)",
-        "Gonti, Lord of Luxury - Synergy (Theft)",
-        "Lotho, Corrupt Shirriff - Synergy (Rogue Kindred)",
-        "Sakashima of a Thousand Faces - Synergy (Rogue Kindred)",
-        "Katilda, Dawnhart Martyr // Katilda's Rising Dawn - Synergy (Enchant)"
+        "Braids, Arisen Nightmare - Synergy (Politics)",
+        "Loran of the Third Path - Synergy (Politics)",
+        "Adeline, Resplendent Cathar - Synergy (Politics)",
+        "Danitha Capashen, Paragon - Synergy (First strike)",
+        "Gisela, Blade of Goldnight - Synergy (First strike)",
+        "Lotho, Corrupt Shirriff - Synergy (Rogue Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Redirects combat outward by goading opponents’ creatures, destabilizing defenses while you build advantage. Synergies like Enchant and Auras reinforce the plan."
@@ -10496,7 +11849,6 @@
       ],
       "synergy_commanders": [
         "Loot, Exuberant Explorer - Synergy (Beast Kindred)",
-        "Questing Beast - Synergy (Beast Kindred)",
         "Kona, Rescue Beastie - Synergy (Beast Kindred)"
       ],
       "popularity_bucket": "Rare",
@@ -10513,6 +11865,21 @@
       ],
       "primary_color": "Black",
       "secondary_color": "White",
+      "example_commanders": [
+        "Flopsie, Bumi's Buddy - Synergy (Goat Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
+      "example_cards": [
+        "Woe Strider",
+        "Trading Post",
+        "Contraband Livestock",
+        "Clackbridge Troll",
+        "Springjack Pasture",
+        "Springjack Shepherd",
+        "Discordant Piper"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Goat Kindred and Creature Tokens reinforce the plan."
     },
@@ -10546,9 +11913,10 @@
         "Dragonlord's Servant"
       ],
       "synergy_commanders": [
-        "Delina, Wild Mage - Synergy (Shaman Kindred)",
-        "Meren of Clan Nel Toth - Synergy (Shaman Kindred)",
-        "Aurelia, the Warleader - Synergy (Haste)"
+        "General Kreat, the Boltbringer - Synergy (Goblin Token)",
+        "High Perfect Morcant - Synergy (Blight)",
+        "Auntie Ool, Cursewretch - Synergy (Blight)",
+        "Sauron, the Dark Lord - Synergy (Amass)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Focuses on getting a high number of Goblin creatures into play with shared payoffs (e.g., Shaman Kindred and Haste)."
@@ -10565,6 +11933,31 @@
       ],
       "primary_color": "Red",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Krenko, Tin Street Kingpin",
+        "Krenko, Mob Boss",
+        "General Kreat, the Boltbringer",
+        "Pashalik Mons",
+        "Ovika, Enigma Goliath"
+      ],
+      "example_cards": [
+        "Krenko, Tin Street Kingpin",
+        "Krenko, Mob Boss",
+        "Windcrag Siege",
+        "Siege-Gang Commander",
+        "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
+        "Legion Warboss",
+        "Dragon Fodder",
+        "Krenko's Command"
+      ],
+      "synergy_commanders": [
+        "Saruman, the White Hand - Synergy (Army Token)",
+        "Gothmog, Morgul Lieutenant - Synergy (Army Token)",
+        "The Mouth of Sauron - Synergy (Army Token)",
+        "Sauron, the Dark Lord - Synergy (Army Kindred)",
+        "Mauhúr, Uruk-hai Captain - Synergy (Army Kindred)",
+        "Sauron, Lord of the Rings - Synergy (Amass)"
+      ],
       "popularity_bucket": "Uncommon",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Army Token and Army Kindred reinforce the plan."
     },
@@ -10600,9 +11993,9 @@
       "synergy_commanders": [
         "Toski, Bearer of Secrets - Synergy (Indestructible)",
         "Mondrak, Glory Dominus - Synergy (Indestructible)",
-        "Adrix and Nev, Twincasters - Synergy (Ward)",
-        "Miirym, Sentinel Wyrm - Synergy (Ward)",
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Protective Effects)"
+        "Avacyn, Angel of Hope - Synergy (Protective Effects)",
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Protective Effects)",
+        "Deadpool, Trading Card - Synergy (Hero Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of God creatures into play with shared payoffs (e.g., Indestructible and Ward)."
@@ -10640,9 +12033,9 @@
         "Ragavan, Nimble Pilferer - Synergy (Artifact Tokens)",
         "Lotho, Corrupt Shirriff - Synergy (Artifact Tokens)",
         "Peregrin Took - Synergy (Artifact Tokens)",
-        "Mondrak, Glory Dominus - Synergy (Token Creation)",
-        "Adeline, Resplendent Cathar - Synergy (Token Creation)",
-        "Talrand, Sky Summoner - Synergy (Tokens Matter)"
+        "Azusa, Lost but Seeking - Synergy (Ramp)",
+        "Selvala, Heart of the Wilds - Synergy (Ramp)",
+        "Mondrak, Glory Dominus - Synergy (Token Creation)"
       ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Artifact Tokens and Token Creation reinforce the plan."
@@ -10655,7 +12048,7 @@
         "Phyrexian Token",
         "Affinity",
         "Phyrexian Kindred",
-        "Artificer Kindred"
+        "Defender"
       ],
       "primary_color": "Green",
       "secondary_color": "White",
@@ -10677,12 +12070,10 @@
         "Triplicate Titan"
       ],
       "synergy_commanders": [
+        "Ich-Tekik, Salvage Splicer - Synergy (Golem Token)",
         "Tetzin, Gnome Champion // The Golden-Gear Colossus - Synergy (Craft)",
         "The Enigma Jewel // Locus of Enlightenment - Synergy (Craft)",
-        "Throne of the Grim Captain // The Grim Captain - Synergy (Craft)",
-        "Octavia, Living Thesis - Synergy (Graveyard Matters)",
-        "Extus, Oriq Overlord // Awaken the Blood Avatar - Synergy (Graveyard Matters)",
-        "Loran of the Third Path - Synergy (Artificer Kindred)"
+        "Octavia, Living Thesis - Synergy (Graveyard Matters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Golem creatures into play with shared payoffs (e.g., Craft and Graveyard Matters)."
@@ -10699,6 +12090,29 @@
       ],
       "primary_color": "White",
       "secondary_color": "Green",
+      "example_commanders": [
+        "General Ferrous Rokiric",
+        "Malcator, Purity Overseer",
+        "Ich-Tekik, Salvage Splicer",
+        "Brudiclad, Telchor Engineer - Synergy (Phyrexian Token)",
+        "Ovika, Enigma Goliath - Synergy (Phyrexian Token)"
+      ],
+      "example_cards": [
+        "Triplicate Titan",
+        "Phyrexian Triniform",
+        "Hammer of Purphoros",
+        "General Ferrous Rokiric",
+        "Blade Splicer",
+        "Cavalier of Dawn",
+        "Golem Foundry",
+        "Darksteel Splicer"
+      ],
+      "synergy_commanders": [
+        "Vishgraz, the Doomhive - Synergy (Phyrexian Token)",
+        "Alibou, Ancient Witness - Synergy (Golem Kindred)",
+        "Karn, Legacy Reforged - Synergy (Golem Kindred)",
+        "Loran of the Third Path - Synergy (Artificer Kindred)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Phyrexian Token and Golem Kindred reinforce the plan."
     },
@@ -10734,9 +12148,9 @@
         "Sheoldred, the Apocalypse - Synergy (Deathtouch)",
         "Elas il-Kor, Sadistic Pilgrim - Synergy (Deathtouch)",
         "The Gitrog Monster - Synergy (Deathtouch)",
-        "Ulamog, the Infinite Gyre - Synergy (Removal)",
-        "Zacama, Primal Calamity - Synergy (Removal)",
-        "Azusa, Lost but Seeking - Synergy (Toughness Matters)"
+        "Ragavan, Nimble Pilferer - Synergy (Outlaw Kindred)",
+        "Lotho, Corrupt Shirriff - Synergy (Outlaw Kindred)",
+        "Ulamog, the Infinite Gyre - Synergy (Removal)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Gorgon creatures into play with shared payoffs (e.g., Deathtouch and Removal)."
@@ -10771,7 +12185,9 @@
         "Novijen Sages"
       ],
       "synergy_commanders": [
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
+        "Kuja, Genome Sorcerer // Trance Kuja, Fate Defied - Synergy (Mutant Kindred)",
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)",
+        "Selvala, Heart of the Wilds - Synergy (Blink)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Graft leveraging synergies with Mutant Kindred and +1/+1 Counters."
@@ -10804,6 +12220,13 @@
       "synergies": [],
       "primary_color": "Black",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Sek'Kuar, Deathkeeper"
+      ],
+      "example_cards": [
+        "Sek'Kuar, Deathkeeper",
+        "Balduvian Dead"
+      ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Graveborn creatures into play with shared payoffs."
     },
@@ -10813,6 +12236,13 @@
       "synergies": [],
       "primary_color": "Black",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Sek'Kuar, Deathkeeper"
+      ],
+      "example_cards": [
+        "Sek'Kuar, Deathkeeper",
+        "Balduvian Dead"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines."
     },
@@ -10828,8 +12258,31 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Valgavoth, Terror Eater",
+        "The Scarab God",
+        "Urabrask // The Great Work",
+        "Lord Skitter, Sewer King",
+        "Tinybones, Bauble Burglar"
+      ],
+      "example_cards": [
+        "Bojuka Bog",
+        "Farewell",
+        "Force of Negation",
+        "Scavenger Grounds",
+        "Rakdos Charm",
+        "Dauthi Voidwalker",
+        "Living Death",
+        "Deathrite Shaman"
+      ],
+      "synergy_commanders": [
+        "Katilda, Dawnhart Martyr // Katilda's Rising Dawn - Synergy (Disturb)",
+        "Dorothea, Vengeful Victim // Dorothea's Retribution - Synergy (Disturb)",
+        "Dennick, Pious Apprentice // Dennick, Pious Apparition - Synergy (Disturb)",
+        "Idris, Soul of the TARDIS - Synergy (Imprint)"
+      ],
       "popularity_bucket": "Common",
-      "description": "Loads high-impact cards into the graveyard early and reanimates them for explosive tempo or combo loops. Synergies like Processor Kindred and Imprint reinforce the plan."
+      "description": "Loads high-impact cards into the graveyard early and reanimates them for explosive tempo or combo loops. Synergies like Disturb and Processor Kindred reinforce the plan."
     },
     {
       "id": "graveyard-matters",
@@ -10861,8 +12314,9 @@
         "Eye of Ojer Taq // Apex Observatory"
       ],
       "synergy_commanders": [
-        "Sheoldred, Whispering One - Synergy (Mill)",
-        "Glarb, Calamity's Augur - Synergy (Surveil)"
+        "Six - Synergy (Mill)",
+        "Tri-Sentinel, Act of Vengeance - Synergy (Unearth)",
+        "Fandaniel, Telophoroi Ascian - Synergy (Surveil)"
       ],
       "popularity_bucket": "Rare",
       "description": "Loads high-impact cards into the graveyard early and reanimates them for explosive tempo or combo loops. Synergies like Reanimate and Mill reinforce the plan."
@@ -10879,6 +12333,26 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Six",
+        "Muldrotha, the Gravetide",
+        "Uro, Titan of Nature's Wrath",
+        "Chainer, Nightmare Adept",
+        "Honest Rutstein"
+      ],
+      "example_cards": [
+        "Faithless Looting",
+        "Eternal Witness",
+        "Buried Ruin",
+        "Bala Ged Recovery // Bala Ged Sanctuary",
+        "Sevinne's Reclamation",
+        "Underworld Breach",
+        "Fanatic of Rhonas",
+        "Pinnacle Monk // Mystic Peak"
+      ],
+      "synergy_commanders": [
+        "Tri-Sentinel, Act of Vengeance - Synergy (Unearth)"
+      ],
       "popularity_bucket": "Very Common",
       "description": "Loads high-impact cards into the graveyard early and reanimates them for explosive tempo or combo loops. Synergies like Flashback and Unearth reinforce the plan."
     },
@@ -10886,11 +12360,11 @@
       "id": "gremlin-kindred",
       "theme": "Gremlin Kindred",
       "synergies": [
-        "Little Fellas",
-        "Counters Matter",
+        "Token Creation",
+        "Tokens Matter",
         "Artifacts Matter",
-        "Aggro",
-        "Combat Matters"
+        "Little Fellas",
+        "Counters Matter"
       ],
       "primary_color": "Red",
       "secondary_color": "Black",
@@ -10911,8 +12385,9 @@
         "Phyrexian Gremlins"
       ],
       "synergy_commanders": [
-        "Toski, Bearer of Secrets - Synergy (Little Fellas)",
-        "Etali, Primal Storm - Synergy (Aggro)"
+        "Mondrak, Glory Dominus - Synergy (Token Creation)",
+        "Adeline, Resplendent Cathar - Synergy (Tokens Matter)",
+        "Talrand, Sky Summoner - Synergy (Tokens Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Gremlin creatures into play with shared payoffs."
@@ -10927,6 +12402,28 @@
       ],
       "primary_color": "Red",
       "secondary_color": "White",
+      "example_commanders": [
+        "Gimbal, Gremlin Prodigy",
+        "The Unluckiest Planeswalker",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Urza, Lord High Artificer - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Gremlin Tamer",
+        "Scurry of Gremlins",
+        "Release the Gremlins",
+        "Midnight Mayhem",
+        "Gimbal, Gremlin Prodigy",
+        "Razorkin Hordecaller",
+        "Gremlin Infestation",
+        "The Unluckiest Planeswalker"
+      ],
+      "synergy_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)",
+        "Lotho, Corrupt Shirriff - Synergy (Token Creation)",
+        "Mondrak, Glory Dominus - Synergy (Tokens Matter)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Creature Tokens and Token Creation reinforce the plan."
     },
@@ -10960,9 +12457,10 @@
         "Griffin Sentinel"
       ],
       "synergy_commanders": [
+        "Aurelia, the Warleader - Synergy (Flying)",
         "Loran of the Third Path - Synergy (Vigilance)",
         "Adeline, Resplendent Cathar - Synergy (Vigilance)",
-        "Azusa, Lost but Seeking - Synergy (Toughness Matters)"
+        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Griffin creatures into play with shared payoffs (e.g., Flying and Vigilance)."
@@ -10985,6 +12483,13 @@
         "Counters Matter"
       ],
       "primary_color": "Green",
+      "example_commanders": [
+        "Sram, Senior Edificer - Synergy (Enchantments Matter)",
+        "Purphoros, God of the Forge - Synergy (Enchantments Matter)",
+        "Danitha Capashen, Paragon - Synergy (Enchantments Matter)",
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)"
+      ],
       "example_cards": [
         "Simic Ascendancy",
         "Paradox Zone",
@@ -11024,10 +12529,10 @@
         "Dissatisfied Customer"
       ],
       "synergy_commanders": [
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Blink)",
-        "Elesh Norn, Mother of Machines - Synergy (Enter the Battlefield)",
+        "Veyran, Voice of Duality - Synergy (Blink)",
+        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)",
         "Kodama of the East Tree - Synergy (Enter the Battlefield)",
-        "Nezahal, Primal Tide - Synergy (Leave the Battlefield)"
+        "Elesh Norn, Mother of Machines - Synergy (Leave the Battlefield)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Guest creatures into play with shared payoffs (e.g., Blink and Enter the Battlefield)."
@@ -11040,6 +12545,11 @@
       ],
       "primary_color": "Blue",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)",
+        "Azusa, Lost but Seeking - Synergy (Little Fellas)",
+        "Loran of the Third Path - Synergy (Little Fellas)"
+      ],
       "example_cards": [
         "Fate Unraveler",
         "Sea Hag // Aquatic Ingress",
@@ -11083,8 +12593,8 @@
         "Samwise Gamgee"
       ],
       "synergy_commanders": [
-        "Ms. Bumbleflower - Synergy (Citizen Kindred)",
-        "Farmer Cotton - Synergy (Food Token)"
+        "Camellia, the Seedmiser - Synergy (Food Token)",
+        "The Cabbage Merchant - Synergy (Citizen Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Halfling creatures into play with shared payoffs (e.g., Peasant Kindred and Citizen Kindred)."
@@ -11095,6 +12605,16 @@
       "synergies": [],
       "primary_color": "White",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Farmer Cotton",
+        "Saradoc, Master of Buckland"
+      ],
+      "example_cards": [
+        "Farmer Cotton",
+        "Of Herbs and Stewed Rabbit",
+        "Field-Tested Frying Pan",
+        "Saradoc, Master of Buckland"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines."
     },
@@ -11147,7 +12667,9 @@
         "Ureni's Rebuff"
       ],
       "synergy_commanders": [
-        "Niv-Mizzet, Parun - Synergy (Spellslinger)"
+        "Six - Synergy (Graveyard Recursion)",
+        "Muldrotha, the Gravetide - Synergy (Graveyard Recursion)",
+        "Uro, Titan of Nature's Wrath - Synergy (Graveyard Recursion)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Harmonize leveraging synergies with Mill and Spells Matter."
@@ -11182,7 +12704,10 @@
         "Blood-Toll Harpy"
       ],
       "synergy_commanders": [
-        "Azusa, Lost but Seeking - Synergy (Little Fellas)"
+        "Aurelia, the Warleader - Synergy (Flying)",
+        "Selvala, Heart of the Wilds - Synergy (Blink)",
+        "Sheoldred, Whispering One - Synergy (Blink)",
+        "Veyran, Voice of Duality - Synergy (Enter the Battlefield)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Harpy creatures into play with shared payoffs (e.g., Flying and Little Fellas)."
@@ -11217,11 +12742,11 @@
         "End-Raze Forerunners"
       ],
       "synergy_commanders": [
-        "Obosh, the Preypiercer - Synergy (Hellion Kindred)",
-        "Ulasht, the Hate Seed - Synergy (Hellion Kindred)",
-        "Thromok the Insatiable - Synergy (Hellion Kindred)",
         "Otharri, Suns' Glory - Synergy (Phoenix Kindred)",
-        "Joshua, Phoenix's Dominant // Phoenix, Warden of Fire - Synergy (Phoenix Kindred)"
+        "Joshua, Phoenix's Dominant // Phoenix, Warden of Fire - Synergy (Phoenix Kindred)",
+        "Syrix, Carrier of the Flame - Synergy (Phoenix Kindred)",
+        "Obosh, the Preypiercer - Synergy (Hellion Kindred)",
+        "Ulasht, the Hate Seed - Synergy (Hellion Kindred)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Builds around Haste leveraging synergies with Goblin Kindred and Trample."
@@ -11270,6 +12795,7 @@
         "Absolver Thrull"
       ],
       "synergy_commanders": [
+        "Yawgmoth, Thran Physician - Synergy (Aristocrats)",
         "Selvala, Heart of the Wilds - Synergy (Blink)"
       ],
       "popularity_bucket": "Rare",
@@ -11287,6 +12813,28 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Wolverine, Best There Is",
+        "Wolverine, Fierce Fighter",
+        "Ezuri, Renegade Leader - Synergy (Regenerate)",
+        "Skithiryx, the Blight Dragon - Synergy (Regenerate)",
+        "Ink-Eyes, Servant of Oni - Synergy (Regenerate)"
+      ],
+      "example_cards": [
+        "Swarmyard",
+        "Asceticism",
+        "Accursed Duneyard",
+        "Mortivore",
+        "Ring of Xathrid",
+        "Wolverine, Best There Is",
+        "Experiment One",
+        "Sedge Sliver"
+      ],
+      "synergy_commanders": [
+        "Tinybones, the Pickpocket - Synergy (Skeleton Kindred)",
+        "Tinybones, Bauble Burglar - Synergy (Skeleton Kindred)",
+        "Azusa, Lost but Seeking - Synergy (Lands Matter)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Heal leveraging synergies with Regenerate and Skeleton Kindred."
     },
@@ -11368,9 +12916,10 @@
       "synergy_commanders": [
         "Aurelia, the Warleader - Synergy (Haste)",
         "Yahenni, Undying Partisan - Synergy (Haste)",
-        "Kiki-Jiki, Mirror Breaker - Synergy (Haste)",
+        "Captain Lannery Storm - Synergy (Haste)",
         "Ghalta, Primal Hunger - Synergy (Trample)",
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Trample)"
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Trample)",
+        "Syr Konrad, the Grim - Synergy (Big Mana)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Hellion creatures into play with shared payoffs (e.g., Blink and Enter the Battlefield)."
@@ -11405,10 +12954,9 @@
         "Iron Man, Titan of Innovation"
       ],
       "synergy_commanders": [
-        "Spider-Man, Brooklyn Visionary - Synergy (Web-slinging)",
-        "Peter Parker // Amazing Spider-Man - Synergy (Web-slinging)",
-        "Spider-Man India - Synergy (Web-slinging)",
-        "Arasta of the Endless Web - Synergy (Spider Kindred)"
+        "Tellah, Great Sage - Synergy (Hero Token)",
+        "Iron Man, Tony Stark - Synergy (Hero Token)",
+        "Spider-Man, Brooklyn Visionary - Synergy (Web-slinging)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Hero creatures into play with shared payoffs (e.g., Web-slinging and Job select)."
@@ -11425,6 +12973,27 @@
       ],
       "primary_color": "White",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "G'raha Tia, Scion Reborn",
+        "Tellah, Great Sage",
+        "Iron Man, Tony Stark",
+        "Shuri, Vibranium Technologist",
+        "Deadpool, Trading Card - Synergy (Hero Kindred)"
+      ],
+      "example_cards": [
+        "Black Mage's Rod",
+        "Zanarkand, Ancient Metropolis // Lasting Fayth",
+        "Champions from Beyond",
+        "Dancer's Chakrams",
+        "Machinist's Arsenal",
+        "Astrologian's Planisphere",
+        "G'raha Tia, Scion Reborn",
+        "Samurai's Katana"
+      ],
+      "synergy_commanders": [
+        "Gwenom, Remorseless - Synergy (Hero Kindred)",
+        "Halvar, God of Battle // Sword of the Realms - Synergy (Equip)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Job select and Hero Kindred reinforce the plan."
     },
@@ -11460,9 +13029,9 @@
       "synergy_commanders": [
         "Boromir, Warden of the Tower - Synergy (Soldier Kindred)",
         "Anim Pakal, Thousandth Moon - Synergy (Soldier Kindred)",
-        "Thalia, Heretic Cathar - Synergy (Soldier Kindred)",
+        "Sephiroth, Fabled SOLDIER // Sephiroth, One-Winged Angel - Synergy (Soldier Kindred)",
         "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)",
-        "Chatterfang, Squirrel General - Synergy (Warrior Kindred)",
+        "Moraug, Fury of Akoum - Synergy (Warrior Kindred)",
         "Syr Konrad, the Grim - Synergy (Human Kindred)"
       ],
       "popularity_bucket": "Rare",
@@ -11542,7 +13111,8 @@
         "Skrelv, Defector Mite - Synergy (Hexproof)",
         "Shalai, Voice of Plenty - Synergy (Hexproof)",
         "Toski, Bearer of Secrets - Synergy (Protective Effects)",
-        "Mondrak, Glory Dominus - Synergy (Protective Effects)"
+        "Mondrak, Glory Dominus - Synergy (Protective Effects)",
+        "Niv-Mizzet, Parun - Synergy (Flying)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Hexproof from leveraging synergies with Hexproof and Protective Effects."
@@ -11576,6 +13146,9 @@
         "Watcher for Tomorrow",
         "Clive's Hideaway"
       ],
+      "synergy_commanders": [
+        "Sram, Senior Edificer - Synergy (Enchantments Matter)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Hideaway leveraging synergies with Topdeck."
     },
@@ -11589,7 +13162,10 @@
       "secondary_color": "Black",
       "example_commanders": [
         "Keruga, the Macrosage",
-        "Phelddagrif"
+        "Phelddagrif",
+        "Braids, Arisen Nightmare - Synergy (Card Draw)",
+        "Loran of the Third Path - Synergy (Card Draw)",
+        "Toski, Bearer of Secrets - Synergy (Card Draw)"
       ],
       "example_cards": [
         "Keruga, the Macrosage",
@@ -11601,6 +13177,10 @@
         "Pygmy Hippo",
         "Bull Hippo"
       ],
+      "synergy_commanders": [
+        "Syr Konrad, the Grim - Synergy (Big Mana)",
+        "Etali, Primal Storm - Synergy (Big Mana)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Hippo creatures into play with shared payoffs."
     },
@@ -11610,6 +13190,14 @@
       "synergies": [],
       "primary_color": "Green",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Phelddagrif"
+      ],
+      "example_cards": [
+        "Phelddagrif",
+        "Mouth // Feed",
+        "Questing Phelddagrif"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines."
     },
@@ -11638,6 +13226,9 @@
         "Razor Hippogriff",
         "Soul-Guide Gryff",
         "Galedrifter // Waildrifter"
+      ],
+      "synergy_commanders": [
+        "Aurelia, the Warleader - Synergy (Flying)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Hippogriff creatures into play with shared payoffs (e.g., Flying and Little Fellas)."
@@ -11674,7 +13265,7 @@
       "synergy_commanders": [
         "Jaheira, Friend of the Forest - Synergy (Backgrounds Matter)",
         "Karlach, Fury of Avernus - Synergy (Backgrounds Matter)",
-        "Lae'zel, Vlaakith's Champion - Synergy (Choose a background)"
+        "Kodama of the East Tree - Synergy (Partner)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Casts a dense mix of artifacts, legendaries, and sagas to trigger Historic-matter payoffs repeatedly."
@@ -11706,7 +13297,8 @@
       "example_commanders": [
         "Ragavan, Nimble Pilferer - Synergy (Little Fellas)",
         "Azusa, Lost but Seeking - Synergy (Little Fellas)",
-        "Toski, Bearer of Secrets - Synergy (Little Fellas)"
+        "Toski, Bearer of Secrets - Synergy (Little Fellas)",
+        "Loran of the Third Path - Synergy (Little Fellas)"
       ],
       "example_cards": [
         "Deepmuck Desperado",
@@ -11751,12 +13343,12 @@
         "Zndrsplt, Eye of Wisdom"
       ],
       "synergy_commanders": [
-        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)",
-        "Azusa, Lost but Seeking - Synergy (Little Fellas)",
-        "Toski, Bearer of Secrets - Synergy (Little Fellas)",
-        "Sheoldred, the Apocalypse - Synergy (Toughness Matters)",
-        "Vito, Thorn of the Dusk Rose - Synergy (Toughness Matters)",
-        "Braids, Arisen Nightmare - Synergy (Card Draw)"
+        "Braids, Arisen Nightmare - Synergy (Draw Triggers)",
+        "Loran of the Third Path - Synergy (Draw Triggers)",
+        "Selvala, Heart of the Wilds - Synergy (Draw Triggers)",
+        "Sheoldred, the Apocalypse - Synergy (Wheels)",
+        "Niv-Mizzet, Parun - Synergy (Wheels)",
+        "Azusa, Lost but Seeking - Synergy (Toughness Matters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Homunculus creatures into play with shared payoffs (e.g., Little Fellas and Toughness Matters)."
@@ -11791,8 +13383,8 @@
         "Zopandrel, Hunger Dominus"
       ],
       "synergy_commanders": [
-        "Iraxxa, Empress of Mars - Synergy (Alien Kindred)",
-        "Davros, Dalek Creator - Synergy (Alien Kindred)",
+        "Zellix, Sanity Flayer - Synergy (Horror Token)",
+        "Nissa, Ascended Animist - Synergy (Horror Token)",
         "Wort, Boggart Auntie - Synergy (Fear)"
       ],
       "popularity_bucket": "Common",
@@ -11810,6 +13402,22 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Zellix, Sanity Flayer",
+        "Mondrak, Glory Dominus - Synergy (Horror Kindred)",
+        "Solphim, Mayhem Dominus - Synergy (Horror Kindred)",
+        "Kozilek, Butcher of Truth - Synergy (Eldrazi Kindred)"
+      ],
+      "example_cards": [
+        "Urabrask's Forge",
+        "Zellix, Sanity Flayer",
+        "Nissa, Ascended Animist",
+        "Phyrexian Rebirth",
+        "Defiled Crypt // Cadaver Lab",
+        "Wharf Infiltrator",
+        "Profane Transfusion",
+        "Pink Horror"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Eldrazi Token and Horror Kindred reinforce the plan."
     },
@@ -11846,8 +13454,8 @@
         "The Gitrog, Ravenous Ride - Synergy (Saddle)",
         "Fortune, Loyal Steed - Synergy (Saddle)",
         "Kolodin, Triumph Caster - Synergy (Mount Kindred)",
-        "Miriam, Herd Whisperer - Synergy (Mount Kindred)",
-        "Selvala, Heart of the Wilds - Synergy (Blink)"
+        "Caradora, Heart of Alacria - Synergy (Mount Kindred)",
+        "Braids, Arisen Nightmare - Synergy (Nightmare Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Horse creatures into play with shared payoffs (e.g., Blink and Enter the Battlefield)."
@@ -11884,7 +13492,7 @@
       "synergy_commanders": [
         "Boromir, Warden of the Tower - Synergy (Soldier Kindred)",
         "Anim Pakal, Thousandth Moon - Synergy (Soldier Kindred)",
-        "Thalia, Heretic Cathar - Synergy (Soldier Kindred)",
+        "Sephiroth, Fabled SOLDIER // Sephiroth, One-Winged Angel - Synergy (Soldier Kindred)",
         "Syr Konrad, the Grim - Synergy (Human Kindred)",
         "Azusa, Lost but Seeking - Synergy (Human Kindred)",
         "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)"
@@ -11935,11 +13543,11 @@
         "Archmage Emeritus"
       ],
       "synergy_commanders": [
+        "Aragorn, the Uniter - Synergy (Human Token)",
+        "Maja, Bretagard Protector - Synergy (Human Token)",
         "Lu Xun, Scholar General - Synergy (Horsemanship)",
         "Xiahou Dun, the One-Eyed - Synergy (Horsemanship)",
-        "Lu Bu, Master-at-Arms - Synergy (Horsemanship)",
-        "Torens, Fist of the Angels - Synergy (Training)",
-        "Jenny Flint - Synergy (Training)"
+        "Torens, Fist of the Angels - Synergy (Training)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Focuses on getting a high number of Human creatures into play with shared payoffs (e.g., Horsemanship and Training)."
@@ -11956,6 +13564,31 @@
       ],
       "primary_color": "White",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Adeline, Resplendent Cathar",
+        "Aragorn, the Uniter",
+        "Maja, Bretagard Protector",
+        "Prince Imrahil the Fair",
+        "Torens, Fist of the Angels"
+      ],
+      "example_cards": [
+        "Stroke of Midnight",
+        "Bastion of Remembrance",
+        "Adeline, Resplendent Cathar",
+        "Castle Ardenvale",
+        "Westvale Abbey // Ormendahl, Profane Prince",
+        "Call the Coppercoats",
+        "Horn of Gondor",
+        "Forth Eorlingas!"
+      ],
+      "synergy_commanders": [
+        "Myrel, Shield of Argive - Synergy (Soldier Token)",
+        "Caesar, Legion's Emperor - Synergy (Soldier Token)",
+        "Abdel Adrian, Gorion's Ward - Synergy (Soldier Token)",
+        "The Council of Four - Synergy (Knight Token)",
+        "Dion, Bahamut's Dominant // Bahamut, Warden of Light - Synergy (Knight Token)",
+        "Urabrask // The Great Work - Synergy (Lore Counters)"
+      ],
       "popularity_bucket": "Uncommon",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Soldier Token and Knight Token reinforce the plan."
     },
@@ -11989,12 +13622,12 @@
         "Ulvenwald Hydra"
       ],
       "synergy_commanders": [
+        "Bristly Bill, Spine Sower - Synergy (Plant Kindred)",
+        "The Necrobloom - Synergy (Plant Kindred)",
+        "Phylath, World Sculptor - Synergy (Plant Kindred)",
         "Ghalta, Primal Hunger - Synergy (X Spells)",
         "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (X Spells)",
-        "Emry, Lurker of the Loch - Synergy (X Spells)",
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Trample)",
-        "Ghalta, Stampede Tyrant - Synergy (Trample)",
-        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)"
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Hydra creatures into play with shared payoffs (e.g., X Spells and Trample)."
@@ -12005,6 +13638,17 @@
       "synergies": [],
       "primary_color": "Green",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Zaxara, the Exemplary",
+        "Grakmaw, Skyclave Ravager",
+        "Polukranos Reborn // Polukranos, Engine of Ruin"
+      ],
+      "example_cards": [
+        "Hydra Broodmaster",
+        "Zaxara, the Exemplary",
+        "Grakmaw, Skyclave Ravager",
+        "Polukranos Reborn // Polukranos, Engine of Ruin"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines."
     },
@@ -12037,7 +13681,8 @@
       "example_commanders": [
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
         "Rishkar, Peema Renegade - Synergy (Counters Matter)",
-        "Krenko, Tin Street Kingpin - Synergy (Counters Matter)"
+        "Krenko, Tin Street Kingpin - Synergy (Counters Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)"
       ],
       "example_cards": [
         "Dark Depths",
@@ -12080,10 +13725,10 @@
         "Hover Barrier"
       ],
       "synergy_commanders": [
+        "Minn, Wily Illusionist - Synergy (Illusion Token)",
+        "Mysterio, Master of Illusion - Synergy (Illusion Token)",
         "Akroma, Angel of Fury - Synergy (Morph)",
-        "Pramikon, Sky Rampart - Synergy (Wall Kindred)",
-        "Rammas Echor, Ancient Shield - Synergy (Wall Kindred)",
-        "The Pride of Hull Clade - Synergy (Defender)"
+        "The Walls of Ba Sing Se - Synergy (Wall Kindred)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Focuses on getting a high number of Illusion creatures into play with shared payoffs (e.g., Morph and Wall Kindred)."
@@ -12100,6 +13745,28 @@
       ],
       "primary_color": "Blue",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Minn, Wily Illusionist",
+        "Meloku the Clouded Mirror",
+        "Mysterio, Master of Illusion",
+        "Preston, the Vanisher - Synergy (Illusion Kindred)",
+        "Toothy, Imaginary Friend - Synergy (Illusion Kindred)"
+      ],
+      "example_cards": [
+        "Skyclave Apparition",
+        "Murmuring Mystic",
+        "Minn, Wily Illusionist",
+        "Manaform Hellkite",
+        "Meloku the Clouded Mirror",
+        "Mordenkainen",
+        "Moonblade Shinobi",
+        "Mysterio, Master of Illusion"
+      ],
+      "synergy_commanders": [
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Illusion Kindred and Creature Tokens reinforce the plan."
     },
@@ -12167,6 +13834,9 @@
         "Overlord of the Mistmoors"
       ],
       "synergy_commanders": [
+        "Taigam, Master Opportunist - Synergy (Time Counters)",
+        "Jhoira of the Ghitu - Synergy (Time Counters)",
+        "Sephiroth, Fabled SOLDIER // Sephiroth, One-Winged Angel - Synergy (Avatar Kindred)",
         "Mondrak, Glory Dominus - Synergy (Horror Kindred)"
       ],
       "popularity_bucket": "Rare",
@@ -12185,7 +13855,11 @@
       "primary_color": "Blue",
       "secondary_color": "White",
       "example_commanders": [
-        "Idris, Soul of the TARDIS"
+        "Idris, Soul of the TARDIS",
+        "Etali, Primal Storm - Synergy (Exile Matters)",
+        "Ragavan, Nimble Pilferer - Synergy (Exile Matters)",
+        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Exile Matters)",
+        "Valgavoth, Terror Eater - Synergy (Graveyard Hate)"
       ],
       "example_cards": [
         "Chrome Mox",
@@ -12196,6 +13870,10 @@
         "Semblance Anvil",
         "Ugin's Labyrinth",
         "River Song's Diary"
+      ],
+      "synergy_commanders": [
+        "The Scarab God - Synergy (Graveyard Hate)",
+        "Mondrak, Glory Dominus - Synergy (Clones)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around the Imprint theme and its supporting synergies."
@@ -12230,7 +13908,8 @@
         "Herald of Anguish"
       ],
       "synergy_commanders": [
-        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Spells Matter)"
+        "Urza, Lord High Artificer - Synergy (Artificer Kindred)",
+        "Sai, Master Thopterist - Synergy (Artificer Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Taps artifacts as pseudo-mana (Improvise) to deploy oversized non-artifact spells ahead of curve. Synergies like Artifacts Matter and Big Mana reinforce the plan."
@@ -12243,7 +13922,7 @@
         "Junk Token",
         "Exile Matters",
         "Monk Kindred",
-        "Noble Kindred"
+        "Artificer Kindred"
       ],
       "primary_color": "Red",
       "secondary_color": "Blue",
@@ -12303,6 +13982,9 @@
         "Filth",
         "Subtlety"
       ],
+      "synergy_commanders": [
+        "Sliver Gravemother - Synergy (Encore)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Incarnation creatures into play with shared payoffs (e.g., Elemental Kindred and Reanimate)."
     },
@@ -12318,6 +14000,27 @@
       ],
       "primary_color": "Blue",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Berta, Wise Extrapolator",
+        "Emry, Lurker of the Loch - Synergy (Wizard Kindred)",
+        "Niv-Mizzet, Parun - Synergy (Wizard Kindred)",
+        "Talrand, Sky Summoner - Synergy (Wizard Kindred)",
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)"
+      ],
+      "example_cards": [
+        "Pensive Professor",
+        "Topiary Lecturer",
+        "Berta, Wise Extrapolator",
+        "Ambitious Augmenter",
+        "Fractal Tender",
+        "Cuboid Colony",
+        "Textbook Tabulator",
+        "Tester of the Tangential"
+      ],
+      "synergy_commanders": [
+        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)",
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Increment leveraging synergies with Wizard Kindred and +1/+1 Counters."
     },
@@ -12351,6 +14054,7 @@
         "Essence of Orthodoxy"
       ],
       "synergy_commanders": [
+        "Veyran, Voice of Duality - Synergy (Transform)",
         "Mondrak, Glory Dominus - Synergy (Phyrexian Kindred)"
       ],
       "popularity_bucket": "Rare",
@@ -12386,6 +14090,7 @@
         "Essence of Orthodoxy"
       ],
       "synergy_commanders": [
+        "Veyran, Voice of Duality - Synergy (Transform)",
         "Mondrak, Glory Dominus - Synergy (Phyrexian Kindred)"
       ],
       "popularity_bucket": "Rare",
@@ -12491,6 +14196,27 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Moseo, Vein's New Dean",
+        "Lotho, Corrupt Shirriff - Synergy (Spells Matter)",
+        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Spells Matter)",
+        "Mangara, the Diplomat - Synergy (Spells Matter)",
+        "Niv-Mizzet, Parun - Synergy (Spellslinger)"
+      ],
+      "example_cards": [
+        "Moseo, Vein's New Dean",
+        "Withering Curse",
+        "Tragedy Feaster",
+        "Foolish Fate",
+        "Follow the Lumarets",
+        "Efflorescence",
+        "Thornfist Striker",
+        "Lumaret's Favor"
+      ],
+      "synergy_commanders": [
+        "Talrand, Sky Summoner - Synergy (Spellslinger)",
+        "Etali, Primal Storm - Synergy (Aggro)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Infusion leveraging synergies with Spells Matter and Spellslinger."
     },
@@ -12539,7 +14265,9 @@
       "example_commanders": [
         "Fain, the Broker",
         "Shadrix Silverquill",
-        "Felisa, Fang of Silverquill"
+        "Felisa, Fang of Silverquill",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)"
       ],
       "example_cards": [
         "Inkshield",
@@ -12550,6 +14278,9 @@
         "Blot Out the Sky",
         "Dramatic Finale",
         "Mascot Exhibition"
+      ],
+      "synergy_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Inkling creatures into play with shared payoffs."
@@ -12566,6 +14297,26 @@
       ],
       "primary_color": "White",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Shadrix Silverquill",
+        "Fain, the Broker",
+        "Felisa, Fang of Silverquill",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Inkshield",
+        "Shadrix Silverquill",
+        "Fain, the Broker",
+        "Felisa, Fang of Silverquill",
+        "Combat Calligrapher",
+        "Blot Out the Sky",
+        "Emeritus of Truce // Swords to Plowshares",
+        "Informed Inkwright"
+      ],
+      "synergy_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Inkling Kindred and Creature Tokens reinforce the plan."
     },
@@ -12575,6 +14326,14 @@
       "synergies": [],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Inquisitor Greyfax",
+        "Inquisitor Eisenhorn"
+      ],
+      "example_cards": [
+        "Inquisitor Greyfax",
+        "Inquisitor Eisenhorn"
+      ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Inquisitor creatures into play with shared payoffs."
     },
@@ -12585,8 +14344,8 @@
         "Insect Token",
         "Scientist Kindred",
         "Poison Counters",
-        "Landfall",
-        "Shroud"
+        "Shroud",
+        "Landfall"
       ],
       "primary_color": "Green",
       "secondary_color": "Black",
@@ -12608,11 +14367,9 @@
         "The Locust God"
       ],
       "synergy_commanders": [
-        "Tatyova, Benthic Druid - Synergy (Landfall)",
-        "Aesi, Tyrant of Gyre Strait - Synergy (Landfall)",
-        "Bristly Bill, Spine Sower - Synergy (Landfall)",
-        "Shay Cormac - Synergy (Shroud)",
-        "Eladamri, Lord of Leaves - Synergy (Shroud)",
+        "Grist, Voracious Larva // Grist, the Plague Swarm - Synergy (Insect Token)",
+        "Norman Osborn // Green Goblin - Synergy (Scientist Kindred)",
+        "Professor Hojo - Synergy (Scientist Kindred)",
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Poison Counters)"
       ],
       "popularity_bucket": "Uncommon",
@@ -12630,6 +14387,30 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Black",
+      "example_commanders": [
+        "The Locust God",
+        "Grist, Voracious Larva // Grist, the Plague Swarm",
+        "Old Rutstein",
+        "Izoni, Thousand-Eyed",
+        "Fumulus, the Infestation"
+      ],
+      "example_cards": [
+        "Scute Swarm",
+        "Springheart Nantuko",
+        "Hornet Queen",
+        "The Locust God",
+        "Grist, the Hunger Tide",
+        "Crawling Sensation",
+        "Nest of Scarabs",
+        "Canoptek Scarab Swarm"
+      ],
+      "synergy_commanders": [
+        "Mazirek, Kraul Death Priest - Synergy (Insect Kindred)",
+        "The Wise Mothman - Synergy (Insect Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Insect Kindred and Creature Tokens reinforce the plan."
     },
@@ -12664,8 +14445,8 @@
       ],
       "synergy_commanders": [
         "Heliod, God of the Sun - Synergy (Enchantment Tokens)",
-        "Ellivere of the Wild Court - Synergy (Enchantment Tokens)",
         "Go-Shintai of Life's Origin - Synergy (Enchantment Tokens)",
+        "Ellivere of the Wild Court - Synergy (Enchantment Tokens)",
         "Talrand, Sky Summoner - Synergy (Creature Tokens)"
       ],
       "popularity_bucket": "Rare",
@@ -12702,10 +14483,11 @@
       ],
       "synergy_commanders": [
         "Ulamog, the Infinite Gyre - Synergy (Removal)",
-        "Zacama, Primal Calamity - Synergy (Removal)",
+        "Glissa Sunslayer - Synergy (Removal)",
         "The Scarab God - Synergy (Removal)",
-        "Samut, Voice of Dissent - Synergy (Combat Tricks)",
-        "Naru Meha, Master Wizard - Synergy (Combat Tricks)"
+        "The Wandering Rescuer - Synergy (Combat Tricks)",
+        "Ambrosia Whiteheart - Synergy (Combat Tricks)",
+        "Emrakul, the World Anew - Synergy (Board Wipes)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Builds around Interaction leveraging synergies with Removal and Combat Tricks."
@@ -12740,9 +14522,9 @@
         "Flesh Carver"
       ],
       "synergy_commanders": [
-        "Syr Konrad, the Grim - Synergy (Reanimate)",
-        "Emry, Lurker of the Loch - Synergy (Reanimate)",
-        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
+        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)",
+        "Azusa, Lost but Seeking - Synergy (Little Fellas)",
+        "Syr Konrad, the Grim - Synergy (Human Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Intimidate leveraging synergies with Zombie Kindred and Reanimate."
@@ -12798,7 +14580,8 @@
         "Monstrosity of the Lake",
         "The Balrog of Moria - Synergy (Cycling)",
         "Yidaro, Wandering Monster - Synergy (Cycling)",
-        "Baral, Chief of Compliance - Synergy (Loot)"
+        "Baral, Chief of Compliance - Synergy (Loot)",
+        "Rocksteady, Crash Courser - Synergy (Landcycling)"
       ],
       "example_cards": [
         "Lórien Revealed",
@@ -12809,6 +14592,11 @@
         "Jhessian Zombies",
         "Ice Flan",
         "Sanctum Plowbeast"
+      ],
+      "synergy_commanders": [
+        "Jennika, Bad Apple Big Sister - Synergy (Landcycling)",
+        "Zog, Triceraton Castaway - Synergy (Typecycling)",
+        "Bebop, Warthog Warrior - Synergy (Typecycling)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Islandcycling leveraging synergies with Landcycling and Cycling."
@@ -12881,7 +14669,8 @@
         "Dread Wanderer"
       ],
       "synergy_commanders": [
-        "Themberchaud - Synergy (Exert)"
+        "Themberchaud - Synergy (Exert)",
+        "Basri, Tomorrow's Champion - Synergy (Exert)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Jackal creatures into play with shared payoffs (e.g., Zombie Kindred and Warrior Kindred)."
@@ -12918,9 +14707,9 @@
       "synergy_commanders": [
         "Niv-Mizzet, Parun - Synergy (Flying)",
         "Avacyn, Angel of Hope - Synergy (Flying)",
-        "Old Gnawbone - Synergy (Flying)",
+        "Aurelia, the Warleader - Synergy (Flying)",
         "Azusa, Lost but Seeking - Synergy (Toughness Matters)",
-        "Sheoldred, the Apocalypse - Synergy (Toughness Matters)",
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)",
         "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
       ],
       "popularity_bucket": "Rare",
@@ -12956,8 +14745,9 @@
         "Dragoon's Lance"
       ],
       "synergy_commanders": [
-        "Toralf, God of Fury // Toralf's Hammer - Synergy (Equip)",
-        "The Reality Chip - Synergy (Equipment)"
+        "Tellah, Great Sage - Synergy (Hero Token)",
+        "Iron Man, Tony Stark - Synergy (Hero Token)",
+        "Gwenom, Remorseless - Synergy (Hero Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Job select leveraging synergies with Hero Kindred and Equip."
@@ -12989,7 +14779,11 @@
       ],
       "primary_color": "Blue",
       "example_commanders": [
-        "Graaz, Unstoppable Juggernaut"
+        "Graaz, Unstoppable Juggernaut",
+        "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)",
+        "Loran of the Third Path - Synergy (Artifacts Matter)",
+        "Lotho, Corrupt Shirriff - Synergy (Artifacts Matter)",
+        "Etali, Primal Storm - Synergy (Aggro)"
       ],
       "example_cards": [
         "Terisian Mindbreaker",
@@ -13000,6 +14794,10 @@
         "Extruder",
         "Phyrexian Juggernaut",
         "Gruul War Plow"
+      ],
+      "synergy_commanders": [
+        "Toski, Bearer of Secrets - Synergy (Aggro)",
+        "Kutzil, Malamet Exemplar - Synergy (Combat Matters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Juggernaut creatures into play with shared payoffs."
@@ -13034,7 +14832,8 @@
         "Kain, Traitorous Dragoon"
       ],
       "synergy_commanders": [
-        "Braids, Arisen Nightmare - Synergy (Card Draw)"
+        "Six - Synergy (Graveyard Recursion)",
+        "Muldrotha, the Gravetide - Synergy (Graveyard Recursion)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Jump leveraging synergies with Jump-start and Mill."
@@ -13069,7 +14868,8 @@
         "Sonic Assault"
       ],
       "synergy_commanders": [
-        "Lotho, Corrupt Shirriff - Synergy (Spells Matter)"
+        "Six - Synergy (Graveyard Recursion)",
+        "Muldrotha, the Gravetide - Synergy (Graveyard Recursion)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Jump-start leveraging synergies with Jump and Mill."
@@ -13143,7 +14943,7 @@
       "synergy_commanders": [
         "Etali, Primal Storm - Synergy (Impulse)",
         "Ragavan, Nimble Pilferer - Synergy (Impulse)",
-        "Lotho, Corrupt Shirriff - Synergy (Artifact Tokens)"
+        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Exile Matters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Junk Token and Impulse reinforce the plan."
@@ -13181,7 +14981,9 @@
         "Slinn Voda, the Rising Deep - Synergy (Kicker)",
         "Tourach, Dread Cantor - Synergy (Kicker)",
         "Josu Vess, Lich Knight - Synergy (Kicker)",
-        "Boromir, Warden of the Tower - Synergy (Soldier Kindred)"
+        "Boromir, Warden of the Tower - Synergy (Soldier Kindred)",
+        "Anim Pakal, Thousandth Moon - Synergy (Soldier Kindred)",
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Kavu creatures into play with shared payoffs (e.g., +1/+1 Counters and Counters Matter)."
@@ -13192,6 +14994,13 @@
       "synergies": [],
       "primary_color": "Green",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Jared Carthalion"
+      ],
+      "example_cards": [
+        "Jared Carthalion",
+        "Penumbra Kavu"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines."
     },
@@ -13224,6 +15033,7 @@
         "Budoka Pupil // Ichiga, Who Topples Oaks"
       ],
       "synergy_commanders": [
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)",
         "Syr Konrad, the Grim - Synergy (Human Kindred)"
       ],
       "popularity_bucket": "Rare",
@@ -13261,10 +15071,7 @@
       "synergy_commanders": [
         "Tannuk, Memorial Ensign - Synergy (Kavu Kindred)",
         "Tannuk, Steadfast Second - Synergy (Kavu Kindred)",
-        "Jared Carthalion - Synergy (Kavu Kindred)",
-        "Tatyova, Benthic Druid - Synergy (Merfolk Kindred)",
-        "Emry, Lurker of the Loch - Synergy (Merfolk Kindred)",
-        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)"
+        "Myrel, Shield of Argive - Synergy (Soldier Token)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Kicker / Multikicker spells scale flexibly—paying extra mana for amplified late-game impact. Synergies like Merfolk Kindred and Combat Tricks reinforce the plan."
@@ -13298,6 +15105,7 @@
       ],
       "synergy_commanders": [
         "Meren of Clan Nel Toth - Synergy (Shaman Kindred)",
+        "Ashling, Flame Dancer - Synergy (Shaman Kindred)",
         "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
       ],
       "popularity_bucket": "Rare",
@@ -13373,10 +15181,11 @@
         "Order of Whiteclay"
       ],
       "synergy_commanders": [
-        "Boromir, Warden of the Tower - Synergy (Soldier Kindred)",
-        "Anim Pakal, Thousandth Moon - Synergy (Soldier Kindred)",
-        "Thalia, Heretic Cathar - Synergy (Soldier Kindred)",
-        "Vito, Thorn of the Dusk Rose - Synergy (Cleric Kindred)"
+        "Brigid, Clachan's Heart // Brigid, Doun's Mind - Synergy (Kithkin Token)",
+        "Ajani, Outland Chaperone - Synergy (Kithkin Token)",
+        "Myrel, Shield of Argive - Synergy (Soldier Token)",
+        "Caesar, Legion's Emperor - Synergy (Soldier Token)",
+        "Boromir, Warden of the Tower - Synergy (Soldier Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Kithkin creatures into play with shared payoffs (e.g., First strike and Soldier Kindred)."
@@ -13393,6 +15202,26 @@
       ],
       "primary_color": "White",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Brigid, Clachan's Heart // Brigid, Doun's Mind",
+        "Gaddock Teeg - Synergy (Kithkin Kindred)",
+        "Brigid, Hero of Kinsbaile - Synergy (Kithkin Kindred)",
+        "Myrel, Shield of Argive - Synergy (Soldier Token)",
+        "Caesar, Legion's Emperor - Synergy (Soldier Token)"
+      ],
+      "example_cards": [
+        "Brigid, Clachan's Heart // Brigid, Doun's Mind",
+        "Kinbinding",
+        "Ajani, Outland Chaperone",
+        "Patrol Signaler",
+        "Clachan Festival",
+        "Brigid's Command",
+        "Catharsis",
+        "Militia's Pride"
+      ],
+      "synergy_commanders": [
+        "Boromir, Warden of the Tower - Synergy (Soldier Kindred)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Kithkin Kindred and Soldier Token reinforce the plan."
     },
@@ -13426,10 +15255,11 @@
         "Moonshaker Cavalry"
       ],
       "synergy_commanders": [
+        "The Council of Four - Synergy (Knight Token)",
+        "Dion, Bahamut's Dominant // Bahamut, Warden of Light - Synergy (Knight Token)",
+        "Éowyn, Shieldmaiden - Synergy (Knight Token)",
         "Sidar Kondo of Jamuraa - Synergy (Flanking)",
-        "Sidar Jabari - Synergy (Flanking)",
-        "Telim'Tor - Synergy (Flanking)",
-        "Yawgmoth, Thran Physician - Synergy (Protection)"
+        "Sidar Jabari - Synergy (Flanking)"
       ],
       "popularity_bucket": "Common",
       "description": "Focuses on getting a high number of Knight creatures into play with shared payoffs (e.g., Flanking and First strike)."
@@ -13445,7 +15275,32 @@
         "Tokens Matter"
       ],
       "primary_color": "White",
-      "secondary_color": "Black",
+      "secondary_color": "Red",
+      "example_commanders": [
+        "The Council of Four",
+        "Dion, Bahamut's Dominant // Bahamut, Warden of Light",
+        "Éowyn, Shieldmaiden",
+        "Bladewing, Deathless Tyrant",
+        "Josu Vess, Lich Knight"
+      ],
+      "example_cards": [
+        "The Council of Four",
+        "Summon: Knights of Round",
+        "Virtue of Loyalty // Ardenvale Fealty",
+        "Chivalric Alliance",
+        "Forth Eorlingas!",
+        "Court of Embereth",
+        "Dion, Bahamut's Dominant // Bahamut, Warden of Light",
+        "Éowyn, Shieldmaiden"
+      ],
+      "synergy_commanders": [
+        "Syr Konrad, the Grim - Synergy (Knight Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Knight Kindred)",
+        "Danitha Capashen, Paragon - Synergy (Knight Kindred)",
+        "Aragorn, the Uniter - Synergy (Human Token)",
+        "Maja, Bretagard Protector - Synergy (Human Token)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Knight Kindred and Human Token reinforce the plan."
     },
@@ -13476,10 +15331,10 @@
       ],
       "synergy_commanders": [
         "Azusa, Lost but Seeking - Synergy (Toughness Matters)",
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)",
         "Sheoldred, the Apocalypse - Synergy (Toughness Matters)",
-        "Vito, Thorn of the Dusk Rose - Synergy (Toughness Matters)",
         "Ragavan, Nimble Pilferer - Synergy (Little Fellas)",
-        "Toski, Bearer of Secrets - Synergy (Little Fellas)",
+        "Loran of the Third Path - Synergy (Little Fellas)",
         "Etali, Primal Storm - Synergy (Aggro)"
       ],
       "popularity_bucket": "Rare",
@@ -13491,6 +15346,17 @@
       "synergies": [],
       "primary_color": "Red",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Prossh, Skyraider of Kher",
+        "Rosnakht, Heir of Rohgahh",
+        "Rohgahh, Kher Keep Overlord"
+      ],
+      "example_cards": [
+        "Kher Keep",
+        "Prossh, Skyraider of Kher",
+        "Rosnakht, Heir of Rohgahh",
+        "Rohgahh, Kher Keep Overlord"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines."
     },
@@ -13524,11 +15390,11 @@
         "Akiri, Fearless Voyager"
       ],
       "synergy_commanders": [
+        "Nahiri, the Lithomancer - Synergy (Kor Token)",
+        "Oath of Gideon - Synergy (Kor Token)",
+        "Nahiri, Heir of the Ancients - Synergy (Kor Token)",
         "Drana, Liberator of Malakir - Synergy (Ally Kindred)",
         "Mina and Denn, Wildborn - Synergy (Ally Kindred)",
-        "Zada, Hedron Grinder - Synergy (Ally Kindred)",
-        "Selvala, Heart of the Wilds - Synergy (Scout Kindred)",
-        "Delney, Streetwise Lookout - Synergy (Scout Kindred)",
         "Vito, Thorn of the Dusk Rose - Synergy (Cleric Kindred)"
       ],
       "popularity_bucket": "Niche",
@@ -13545,6 +15411,27 @@
       ],
       "primary_color": "White",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Nahiri, the Lithomancer",
+        "Elas il-Kor, Sadistic Pilgrim - Synergy (Kor Kindred)",
+        "Ardenn, Intrepid Archaeologist - Synergy (Kor Kindred)",
+        "Akiri, Fearless Voyager - Synergy (Kor Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Retreat to Emeria",
+        "Oath of Gideon",
+        "Nahiri, the Lithomancer",
+        "Squad Commander",
+        "Captain's Claws",
+        "Nahiri, Heir of the Ancients",
+        "Nomads' Assembly",
+        "Conqueror's Pledge"
+      ],
+      "synergy_commanders": [
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Kor Kindred and Creature Tokens reinforce the plan."
     },
@@ -13578,12 +15465,10 @@
         "Kiora Bests the Sea God"
       ],
       "synergy_commanders": [
-        "Braids, Arisen Nightmare - Synergy (Draw Triggers)",
-        "Loran of the Third Path - Synergy (Draw Triggers)",
-        "Sheoldred, the Apocalypse - Synergy (Draw Triggers)",
-        "Selvala, Heart of the Wilds - Synergy (Wheels)",
-        "Niv-Mizzet, Parun - Synergy (Wheels)",
-        "Toski, Bearer of Secrets - Synergy (Protective Effects)"
+        "Kiora, the Crashing Wave - Synergy (Kraken Token)",
+        "Charix, the Raging Isle - Synergy (Leviathan Kindred)",
+        "Slinn Voda, the Rising Deep - Synergy (Leviathan Kindred)",
+        "Aesi, Tyrant of Gyre Strait - Synergy (Serpent Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Kraken creatures into play with shared payoffs (e.g., Draw Triggers and Wheels)."
@@ -13599,6 +15484,24 @@
       ],
       "primary_color": "Blue",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Arixmethes, Slumbering Isle - Synergy (Kraken Kindred)",
+        "Gyruda, Doom of Depths - Synergy (Kraken Kindred)",
+        "Tromokratis - Synergy (Kraken Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Ominous Seas",
+        "Spawning Kraken",
+        "Kiora Bests the Sea God",
+        "Reef Worm",
+        "Invasion of Segovia // Caetus, Sea Tyrant of Segovia",
+        "Kiora, the Crashing Wave"
+      ],
+      "synergy_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Kraken Kindred and Creature Tokens reinforce the plan."
     },
@@ -13611,6 +15514,20 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Karametra, God of Harvests - Synergy (Land Types Matter)",
+        "Vorinclex // The Grand Evolution - Synergy (Land Types Matter)",
+        "Titania, Nature's Force - Synergy (Land Types Matter)",
+        "Azusa, Lost but Seeking - Synergy (Lands Matter)",
+        "Tatyova, Benthic Druid - Synergy (Lands Matter)"
+      ],
+      "example_cards": [
+        "Crosis's Catacombs",
+        "Rith's Grove",
+        "Dromar's Cavern",
+        "Treva's Ruins",
+        "Darigaaz's Caldera"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Lairs Matter leveraging synergies with Land Types Matter and Lands Matter."
     },
@@ -13668,6 +15585,11 @@
         "Bloodstained Mire",
         "Windswept Heath"
       ],
+      "synergy_commanders": [
+        "Zog, Triceraton Castaway - Synergy (Mountaincycling)",
+        "Jennika, Bad Apple Big Sister - Synergy (Plainscycling)",
+        "Rocksteady, Crash Courser - Synergy (Forestcycling)"
+      ],
       "popularity_bucket": "Uncommon",
       "description": "Builds around Land Types Matter leveraging synergies with Plainscycling and Forestcycling."
     },
@@ -13685,7 +15607,9 @@
       "secondary_color": "Green",
       "example_commanders": [
         "Monstrosity of the Lake",
-        "The Balrog of Moria - Synergy (Cycling)"
+        "The Balrog of Moria - Synergy (Cycling)",
+        "Zog, Triceraton Castaway - Synergy (Mountaincycling)",
+        "Jennika, Bad Apple Big Sister - Synergy (Plainscycling)"
       ],
       "example_cards": [
         "Ash Barrens",
@@ -13707,8 +15631,8 @@
         "Lands Matter",
         "Ramp",
         "Token Creation",
-        "Earthbend",
-        "Bending"
+        "Earthbending",
+        "Earthbend"
       ],
       "primary_color": "Green",
       "secondary_color": "White",
@@ -13731,8 +15655,8 @@
       ],
       "synergy_commanders": [
         "Azusa, Lost but Seeking - Synergy (Lands Matter)",
-        "Sheoldred, Whispering One - Synergy (Lands Matter)",
-        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Ramp)",
+        "Six - Synergy (Lands Matter)",
+        "Lotho, Corrupt Shirriff - Synergy (Ramp)",
         "Selvala, Heart of the Wilds - Synergy (Ramp)",
         "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
       ],
@@ -13789,6 +15713,22 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Flagstones of Trokair - Synergy (Alt Fetchland)",
+        "The Balrog of Moria - Synergy (Cycling)",
+        "Monstrosity of the Lake - Synergy (Cycling)",
+        "Baral, Chief of Compliance - Synergy (Loot)"
+      ],
+      "example_cards": [
+        "Bountiful Landscape",
+        "Foreboding Landscape",
+        "Twisted Landscape",
+        "Seething Landscape",
+        "Shattered Landscape",
+        "Tranquil Landscape",
+        "Perilous Landscape",
+        "Deceptive Landscape"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Landscape Land leveraging synergies with Alt Fetchland and Cycling."
     },
@@ -13823,7 +15763,7 @@
       ],
       "synergy_commanders": [
         "Sol'kanar the Swamp King - Synergy (Swampwalk)",
-        "Adrestia - Synergy (Islandwalk)"
+        "Sygg, River Guide - Synergy (Islandwalk)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Builds around Landwalk leveraging synergies with Swampwalk and Islandwalk."
@@ -13893,7 +15833,7 @@
         "Mithril Coat"
       ],
       "synergy_commanders": [
-        "Sidisi, Undead Vizier - Synergy (Exploit)"
+        "Veyran, Voice of Duality - Synergy (Blink)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Builds around Leave the Battlefield leveraging synergies with Blink and Enter the Battlefield."
@@ -13929,7 +15869,7 @@
       ],
       "synergy_commanders": [
         "Danitha Capashen, Paragon - Synergy (X Spells)",
-        "Tatyova, Benthic Druid - Synergy (Lifegain)"
+        "Sheoldred, the Apocalypse - Synergy (Lifegain)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Leech creatures into play with shared payoffs (e.g., Cost Reduction and X Spells)."
@@ -13966,7 +15906,7 @@
       "synergy_commanders": [
         "Jaheira, Friend of the Forest - Synergy (Backgrounds Matter)",
         "Karlach, Fury of Avernus - Synergy (Backgrounds Matter)",
-        "Lae'zel, Vlaakith's Champion - Synergy (Choose a background)"
+        "Kodama of the East Tree - Synergy (Partner)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Builds around Legends Matter leveraging synergies with Historics Matter and Backgrounds Matter."
@@ -13986,7 +15926,8 @@
       "example_commanders": [
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
         "Rishkar, Peema Renegade - Synergy (Counters Matter)",
-        "Emry, Lurker of the Loch - Synergy (Wizard Kindred)"
+        "Emry, Lurker of the Loch - Synergy (Wizard Kindred)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)"
       ],
       "example_cards": [
         "Joraga Treespeaker",
@@ -14017,7 +15958,8 @@
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
         "Rishkar, Peema Renegade - Synergy (Counters Matter)",
         "Syr Konrad, the Grim - Synergy (Human Kindred)",
-        "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)"
+        "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)"
       ],
       "example_cards": [
         "Joraga Treespeaker",
@@ -14062,12 +16004,12 @@
         "Aethersquall Ancient"
       ],
       "synergy_commanders": [
-        "Ghalta, Primal Hunger - Synergy (Trample)",
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Trample)",
-        "Ghalta, Stampede Tyrant - Synergy (Trample)",
-        "Syr Konrad, the Grim - Synergy (Big Mana)",
-        "Etali, Primal Storm - Synergy (Big Mana)",
-        "Selvala, Heart of the Wilds - Synergy (Blink)"
+        "Arixmethes, Slumbering Isle - Synergy (Kraken Kindred)",
+        "Gyruda, Doom of Depths - Synergy (Kraken Kindred)",
+        "Tromokratis - Synergy (Kraken Kindred)",
+        "Kiora, the Rising Tide - Synergy (Octopus Kindred)",
+        "Queza, Augur of Agonies - Synergy (Octopus Kindred)",
+        "Aesi, Tyrant of Gyre Strait - Synergy (Serpent Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Leviathan creatures into play with shared payoffs (e.g., Trample and Big Mana)."
@@ -14102,7 +16044,11 @@
         "Tarmogoyf"
       ],
       "synergy_commanders": [
-        "Sheoldred, the Apocalypse - Synergy (Combat Matters)"
+        "Syr Konrad, the Grim - Synergy (Mill)",
+        "Six - Synergy (Mill)",
+        "Emry, Lurker of the Loch - Synergy (Mill)",
+        "Sheoldred, Whispering One - Synergy (Reanimate)",
+        "The Gitrog Monster - Synergy (Reanimate)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Lhurgoyf creatures into play with shared payoffs."
@@ -14137,7 +16083,7 @@
         "Stinging Licid"
       ],
       "synergy_commanders": [
-        "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)"
+        "Purphoros, God of the Forge - Synergy (Enchantments Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Licid creatures into play with shared payoffs (e.g., Equipment Matters and Auras)."
@@ -14173,7 +16119,7 @@
       "synergy_commanders": [
         "Niv-Mizzet, Parun - Synergy (Flying)",
         "Avacyn, Angel of Hope - Synergy (Flying)",
-        "Old Gnawbone - Synergy (Flying)"
+        "Aurelia, the Warleader - Synergy (Flying)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Lieutenant leveraging synergies with Aggro and Combat Matters."
@@ -14242,8 +16188,10 @@
         "Unfulfilled Desires"
       ],
       "synergy_commanders": [
-        "Sram, Senior Edificer - Synergy (Enchantments Matter)",
-        "Purphoros, God of the Forge - Synergy (Enchantments Matter)"
+        "Sythis, Harvest's Hand - Synergy (Cantrips)",
+        "Tataru Taru - Synergy (Cantrips)",
+        "Wan Shi Tong, Librarian - Synergy (Cantrips)",
+        "Sram, Senior Edificer - Synergy (Enchantments Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Life to Draw leveraging synergies with Card Draw and Enchantments Matter."
@@ -14289,8 +16237,8 @@
       "synergies": [
         "Vampire Kindred",
         "Food Token",
-        "Food",
         "Lifelink",
+        "Food",
         "Lifegain"
       ],
       "primary_color": "White",
@@ -14315,9 +16263,9 @@
       "synergy_commanders": [
         "Yahenni, Undying Partisan - Synergy (Vampire Kindred)",
         "Elenda, the Dusk Rose - Synergy (Vampire Kindred)",
-        "Mangara, the Diplomat - Synergy (Lifelink)",
-        "Danitha Capashen, Paragon - Synergy (Lifelink)",
-        "Tatyova, Benthic Druid - Synergy (Lifegain)"
+        "Peregrin Took - Synergy (Food Token)",
+        "Rosie Cotton of South Lane - Synergy (Food Token)",
+        "Mangara, the Diplomat - Synergy (Lifelink)"
       ],
       "popularity_bucket": "Niche",
       "description": "Turns repeat lifegain triggers into card draw, scaling bodies, or drain-based win pressure. Synergies like Vampire Kindred and Lifelink reinforce the plan."
@@ -14352,9 +16300,10 @@
         "Whip of Erebos"
       ],
       "synergy_commanders": [
-        "Dina, Soul Steeper - Synergy (Lifegain Triggers)",
-        "Yahenni, Undying Partisan - Synergy (Vampire Kindred)",
-        "Tatyova, Benthic Druid - Synergy (Lifegain)"
+        "Ghalta and Mavren - Synergy (Vampire Token)",
+        "Edgar Markov - Synergy (Vampire Token)",
+        "Jolrael, Mwonvuli Recluse - Synergy (Cat Token)",
+        "Brimaz, King of Oreskos - Synergy (Cat Token)"
       ],
       "popularity_bucket": "Common",
       "description": "Builds around Lifelink leveraging synergies with Lifegain Triggers and Vampire Kindred."
@@ -14389,7 +16338,9 @@
         "Starlit Soothsayer"
       ],
       "synergy_commanders": [
-        "Tatyova, Benthic Druid - Synergy (Life Matters)"
+        "Mister Negative - Synergy (Lifeloss Triggers)",
+        "Momo, Friendly Flier - Synergy (Bat Kindred)",
+        "Sheoldred, the Apocalypse - Synergy (Life Matters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Channels symmetrical life loss into card flow, recursion, and inevitability drains. Synergies like Lifeloss Triggers and Bat Kindred reinforce the plan."
@@ -14424,7 +16375,9 @@
         "Starlit Soothsayer"
       ],
       "synergy_commanders": [
-        "Tatyova, Benthic Druid - Synergy (Life Matters)"
+        "Mister Negative - Synergy (Lifeloss)",
+        "Momo, Friendly Flier - Synergy (Bat Kindred)",
+        "Sheoldred, the Apocalypse - Synergy (Life Matters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Channels symmetrical life loss into card flow, recursion, and inevitability drains. Synergies like Lifeloss and Bat Kindred reinforce the plan."
@@ -14459,7 +16412,7 @@
         "Blood Artist"
       ],
       "synergy_commanders": [
-        "Ayesha Tanaka - Synergy (Banding)"
+        "Torens, Fist of the Angels - Synergy (Training)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Builds around Little Fellas leveraging synergies with Nomad Kindred and Banding."
@@ -14528,6 +16481,10 @@
         "Batterbone",
         "Cranial Ram"
       ],
+      "synergy_commanders": [
+        "Ekthi, Contaminator Priest - Synergy (Germ Kindred)",
+        "Brudiclad, Telchor Engineer - Synergy (Phyrexian Token)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Living weapon leveraging synergies with Germ Kindred and Equip."
     },
@@ -14561,15 +16518,30 @@
         "Alpha Deathclaw"
       ],
       "synergy_commanders": [
-        "Junji, the Midnight Sky - Synergy (Menace)",
-        "Kozilek, the Great Distortion - Synergy (Menace)",
-        "Massacre Girl - Synergy (Menace)",
-        "Kiki-Jiki, Mirror Breaker - Synergy (Shaman Kindred)",
-        "Delina, Wild Mage - Synergy (Shaman Kindred)",
-        "Ragavan, Nimble Pilferer - Synergy (Outlaw Kindred)"
+        "Cloud, Midgar Mercenary - Synergy (Mercenary Kindred)",
+        "Kellogg, Dangerous Mind - Synergy (Mercenary Kindred)",
+        "Deadpool, Trading Card - Synergy (Mercenary Kindred)",
+        "Saryth, the Viper's Fang - Synergy (Warlock Kindred)",
+        "Honest Rutstein - Synergy (Warlock Kindred)",
+        "Junji, the Midnight Sky - Synergy (Menace)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Lizard creatures into play with shared payoffs (e.g., Trample and Outlaw Kindred)."
+    },
+    {
+      "id": "lizard-token",
+      "theme": "Lizard Token",
+      "synergies": [],
+      "primary_color": "Blue",
+      "secondary_color": "Green",
+      "example_cards": [
+        "Rapid Hybridization",
+        "Incubation // Incongruity",
+        "Subterranean Tremors",
+        "Predatory Advantage"
+      ],
+      "popularity_bucket": "Rare",
+      "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines."
     },
     {
       "id": "loot",
@@ -14602,10 +16574,10 @@
       ],
       "synergy_commanders": [
         "Braids, Arisen Nightmare - Synergy (Card Draw)",
-        "Toski, Bearer of Secrets - Synergy (Card Draw)",
         "Loran of the Third Path - Synergy (Card Draw)",
+        "Toski, Bearer of Secrets - Synergy (Card Draw)",
         "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Discard Matters)",
-        "Solphim, Mayhem Dominus - Synergy (Discard Matters)",
+        "Yawgmoth, Thran Physician - Synergy (Discard Matters)",
         "Syr Konrad, the Grim - Synergy (Reanimate)"
       ],
       "popularity_bucket": "Common",
@@ -14641,9 +16613,9 @@
         "One Ring to Rule Them All"
       ],
       "synergy_commanders": [
-        "Jhoira, Weatherlight Captain - Synergy (Sagas Matter)",
-        "Urabrask // The Great Work - Synergy (Sagas Matter)",
-        "Vorinclex, Monstrous Raider - Synergy (Ore Counters)"
+        "Vorinclex, Monstrous Raider - Synergy (Ore Counters)",
+        "Lae'zel, Vlaakith's Champion - Synergy (Ore Counters)",
+        "Jhoira, Weatherlight Captain - Synergy (Sagas Matter)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Accumulates lore counters to unlock scaling payoffs, removal triggers, or delayed value conversions."
@@ -14678,12 +16650,12 @@
         "Ral, Crackling Wit"
       ],
       "synergy_commanders": [
+        "Vraska, Betrayal's Sting - Synergy (Compleated)",
+        "Nissa, Ascended Animist - Synergy (Compleated)",
+        "Jace, the Perfected Mind - Synergy (Compleated)",
         "Adeline, Resplendent Cathar - Synergy (Planeswalkers)",
         "Yawgmoth, Thran Physician - Synergy (Planeswalkers)",
-        "Vorinclex, Monstrous Raider - Synergy (Planeswalkers)",
-        "Lae'zel, Vlaakith's Champion - Synergy (Superfriends)",
-        "Tekuthal, Inquiry Dominus - Synergy (Superfriends)",
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
+        "Vorinclex, Monstrous Raider - Synergy (Superfriends)"
       ],
       "popularity_bucket": "Rare",
       "description": "Protects and reuses planeswalkers—amplifying loyalty via proliferate and recursion for inevitability. Synergies like Planeswalkers and Superfriends reinforce the plan."
@@ -14756,9 +16728,9 @@
       "synergy_commanders": [
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Transform)",
         "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Transform)",
-        "Emry, Lurker of the Loch - Synergy (Wizard Kindred)",
-        "Niv-Mizzet, Parun - Synergy (Wizard Kindred)",
-        "Syr Konrad, the Grim - Synergy (Human Kindred)"
+        "Kiki-Jiki, Mirror Breaker - Synergy (Shaman Kindred)",
+        "Meren of Clan Nel Toth - Synergy (Shaman Kindred)",
+        "Emry, Lurker of the Loch - Synergy (Wizard Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Chains cheap instants & sorceries for velocity—converting triggers into scalable damage or card advantage before a finisher. Synergies like Transform and Wizard Kindred reinforce the plan."
@@ -14767,11 +16739,11 @@
       "id": "mana-dork",
       "theme": "Mana Dork",
       "synergies": [
-        "Firebend",
         "Firebending",
         "Scion Token",
         "Scion Kindred",
-        "Spawn Token"
+        "Spawn Token",
+        "Eldrazi Token"
       ],
       "primary_color": "Green",
       "secondary_color": "Blue",
@@ -14793,11 +16765,10 @@
         "Avacyn's Pilgrim"
       ],
       "synergy_commanders": [
-        "Fire Lord Zuko - Synergy (Firebending)",
+        "Fire Lord Azula - Synergy (Firebending)",
+        "Ozai, the Phoenix King - Synergy (Firebending)",
         "Zuko, Exiled Prince - Synergy (Firebending)",
-        "Avatar Aang // Aang, Master of Elements - Synergy (Firebending)",
-        "Kiora, the Rising Tide - Synergy (Scion Kindred)",
-        "Magnus the Red - Synergy (Spawn Kindred)"
+        "Kiora, the Rising Tide - Synergy (Scion Kindred)"
       ],
       "popularity_bucket": "Common",
       "description": "Builds around Mana Dork leveraging synergies with Scion Kindred and Spawn Kindred."
@@ -14832,11 +16803,12 @@
         "Talisman of Dominance"
       ],
       "synergy_commanders": [
+        "Azusa, Lost but Seeking - Synergy (Ramp)",
+        "Lotho, Corrupt Shirriff - Synergy (Ramp)",
+        "Selvala, Heart of the Wilds - Synergy (Ramp)",
         "Brudiclad, Telchor Engineer - Synergy (Myr Kindred)",
         "Urtet, Remnant of Memnarch - Synergy (Myr Kindred)",
-        "Hearthhull, the Worldseed - Synergy (Charge Counters)",
-        "Dawnsire, Sunstar Dreadnought - Synergy (Charge Counters)",
-        "Azusa, Lost but Seeking - Synergy (Ramp)"
+        "Immard, the Stormcleaver - Synergy (Charge Counters)"
       ],
       "popularity_bucket": "Niche",
       "description": "Builds around Mana Rock leveraging synergies with Charge Counters and Ramp."
@@ -14906,7 +16878,7 @@
         "Valgavoth's Onslaught"
       ],
       "synergy_commanders": [
-        "Syr Konrad, the Grim - Synergy (Reanimate)"
+        "Syr Konrad, the Grim - Synergy (Mill)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Manifest dread leveraging synergies with Manifest and Topdeck."
@@ -14939,7 +16911,8 @@
         "Sawback Manticore"
       ],
       "synergy_commanders": [
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)"
+        "Niv-Mizzet, Parun - Synergy (Flying)",
+        "Avacyn, Angel of Hope - Synergy (Flying)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Manticore creatures into play with shared payoffs."
@@ -15009,9 +16982,9 @@
         "Perilous Snare"
       ],
       "synergy_commanders": [
-        "Sram, Senior Edificer - Synergy (Vehicles)",
-        "Shorikai, Genesis Engine - Synergy (Vehicles)",
-        "Selvala, Heart of the Wilds - Synergy (Scout Kindred)"
+        "Selvala, Heart of the Wilds - Synergy (Scout Kindred)",
+        "Delney, Streetwise Lookout - Synergy (Scout Kindred)",
+        "Kutzil, Malamet Exemplar - Synergy (Cat Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Max speed leveraging synergies with Start your engines! and Conditional Draw."
@@ -15046,11 +17019,12 @@
         "Swarm, Being of Bees"
       ],
       "synergy_commanders": [
+        "Six - Synergy (Graveyard Recursion)",
+        "Muldrotha, the Gravetide - Synergy (Graveyard Recursion)",
+        "Uro, Titan of Nature's Wrath - Synergy (Graveyard Recursion)",
         "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Discard Matters)",
-        "Solphim, Mayhem Dominus - Synergy (Discard Matters)",
         "Yawgmoth, Thran Physician - Synergy (Discard Matters)",
-        "Syr Konrad, the Grim - Synergy (Mill)",
-        "Emry, Lurker of the Loch - Synergy (Mill)"
+        "Syr Konrad, the Grim - Synergy (Mill)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around the Mayhem theme and its supporting synergies."
@@ -15087,8 +17061,7 @@
       "synergy_commanders": [
         "Niv-Mizzet, Parun - Synergy (Dragon Kindred)",
         "Old Gnawbone - Synergy (Dragon Kindred)",
-        "Drakuseth, Maw of Flames - Synergy (Dragon Kindred)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Midrange)"
+        "Lathliss, Dragon Queen - Synergy (Dragon Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Megamorph leveraging synergies with +1/+1 Counters and Counters Matter."
@@ -15148,9 +17121,9 @@
       ],
       "synergy_commanders": [
         "Adeline, Resplendent Cathar - Synergy (Politics)",
-        "Etali, Primal Storm - Synergy (Aggro)",
-        "Ragavan, Nimble Pilferer - Synergy (Aggro)",
-        "Toski, Bearer of Secrets - Synergy (Combat Matters)"
+        "Syr Konrad, the Grim - Synergy (Human Kindred)",
+        "Azusa, Lost but Seeking - Synergy (Human Kindred)",
+        "Etali, Primal Storm - Synergy (Aggro)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Melee leveraging synergies with Politics and Aggro."
@@ -15163,7 +17136,7 @@
         "Rat Kindred",
         "Blood Token",
         "Ninja Kindred",
-        "Landcycling"
+        "Mutant Kindred"
       ],
       "primary_color": "Black",
       "secondary_color": "Red",
@@ -15188,9 +17161,9 @@
         "Saryth, the Viper's Fang - Synergy (Warlock Kindred)",
         "Honest Rutstein - Synergy (Warlock Kindred)",
         "Breena, the Demagogue - Synergy (Warlock Kindred)",
-        "Edgar, Charmed Groom // Edgar Markov's Coffin - Synergy (Blood Token)",
-        "Old Rutstein - Synergy (Blood Token)",
-        "Ragavan, Nimble Pilferer - Synergy (Pirate Kindred)"
+        "Nashi, Moon Sage's Scion - Synergy (Rat Kindred)",
+        "Lord Skitter, Sewer King - Synergy (Rat Kindred)",
+        "Edgar, Charmed Groom // Edgar Markov's Coffin - Synergy (Blood Token)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Builds around Menace leveraging synergies with Warlock Kindred and Goblin Kindred."
@@ -15227,8 +17200,8 @@
       "synergy_commanders": [
         "Boromir, Warden of the Tower - Synergy (Soldier Kindred)",
         "Anim Pakal, Thousandth Moon - Synergy (Soldier Kindred)",
-        "Thalia, Heretic Cathar - Synergy (Soldier Kindred)",
-        "Krenko, Tin Street Kingpin - Synergy (+1/+1 Counters)",
+        "Sephiroth, Fabled SOLDIER // Sephiroth, One-Winged Angel - Synergy (Soldier Kindred)",
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)",
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
       ],
       "popularity_bucket": "Rare",
@@ -15264,12 +17237,11 @@
         "The Infamous Cruelclaw"
       ],
       "synergy_commanders": [
+        "Ertha Jo, Frontier Mentor - Synergy (Mercenary Token)",
+        "Selvala, Eager Trailblazer - Synergy (Mercenary Token)",
         "Ragavan, Nimble Pilferer - Synergy (Outlaw Kindred)",
         "Lotho, Corrupt Shirriff - Synergy (Outlaw Kindred)",
-        "Captain Lannery Storm - Synergy (Outlaw Kindred)",
-        "Mondrak, Glory Dominus - Synergy (Horror Kindred)",
-        "Solphim, Mayhem Dominus - Synergy (Horror Kindred)",
-        "Sheoldred, the Apocalypse - Synergy (Phyrexian Kindred)"
+        "Kediss, Emberclaw Familiar - Synergy (Lizard Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Mercenary creatures into play with shared payoffs (e.g., Outlaw Kindred and Horror Kindred)."
@@ -15286,6 +17258,28 @@
       ],
       "primary_color": "White",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Ertha Jo, Frontier Mentor",
+        "Selvala, Eager Trailblazer",
+        "Cloud, Midgar Mercenary - Synergy (Mercenary Kindred)",
+        "Kellogg, Dangerous Mind - Synergy (Mercenary Kindred)",
+        "Deadpool, Trading Card - Synergy (Mercenary Kindred)"
+      ],
+      "example_cards": [
+        "At Knifepoint",
+        "Hellspur Posse Boss",
+        "Ertha Jo, Frontier Mentor",
+        "Angelic Sell-Sword",
+        "Nezumi Linkbreaker",
+        "We Ride at Dawn",
+        "Selvala, Eager Trailblazer",
+        "Brimstone Roundup"
+      ],
+      "synergy_commanders": [
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Mercenary Kindred and Creature Tokens reinforce the plan."
     },
@@ -15319,12 +17313,12 @@
         "Kiora's Follower"
       ],
       "synergy_commanders": [
+        "Emperor Mihail II - Synergy (Merfolk Token)",
+        "Namor, Atlantean King - Synergy (Merfolk Token)",
+        "Namora, the Sea Queen - Synergy (Merfolk Token)",
         "Wrexial, the Risen Deep - Synergy (Islandwalk)",
         "Thada Adel, Acquisitor - Synergy (Islandwalk)",
-        "Adrestia - Synergy (Islandwalk)",
-        "Hakbal of the Surging Soul - Synergy (Explore)",
-        "Amalia Benavides Aguirre - Synergy (Explore)",
-        "Nicanzil, Current Conductor - Synergy (Card Selection)"
+        "Hakbal of the Surging Soul - Synergy (Explore)"
       ],
       "popularity_bucket": "Common",
       "description": "Focuses on getting a high number of Merfolk creatures into play with shared payoffs (e.g., Islandwalk and Card Selection)."
@@ -15341,6 +17335,30 @@
       ],
       "primary_color": "Blue",
       "secondary_color": "White",
+      "example_commanders": [
+        "Emperor Mihail II",
+        "Namor, Atlantean King",
+        "Namora, the Sea Queen",
+        "Grandmother Goby",
+        "Tatyova, Benthic Druid - Synergy (Merfolk Kindred)"
+      ],
+      "example_cards": [
+        "Emperor Mihail II",
+        "Deeproot Waters",
+        "Deeproot Pilgrimage",
+        "Lullmage Mentor",
+        "Stonybrook Schoolmaster",
+        "Silvergill Mentor",
+        "Daughter of the Deep",
+        "Aquatic Incursion"
+      ],
+      "synergy_commanders": [
+        "Emry, Lurker of the Loch - Synergy (Merfolk Kindred)",
+        "Talrand, Sky Summoner - Synergy (Merfolk Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Urza, Lord High Artificer - Synergy (Creature Tokens)",
+        "Niv-Mizzet, Parun - Synergy (Wizard Kindred)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Merfolk Kindred and Creature Tokens reinforce the plan."
     },
@@ -15375,7 +17393,7 @@
       ],
       "synergy_commanders": [
         "Loran of the Third Path - Synergy (Artifacts Matter)",
-        "Syr Konrad, the Grim - Synergy (Human Kindred)"
+        "Boromir, Warden of the Tower - Synergy (Soldier Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Maintains ≥3 artifacts to turn on Metalcraft efficiencies and scaling bonuses. Synergies like Transform and Artifacts Matter reinforce the plan."
@@ -15390,7 +17408,8 @@
       "example_commanders": [
         "Ragavan, Nimble Pilferer - Synergy (Little Fellas)",
         "Azusa, Lost but Seeking - Synergy (Little Fellas)",
-        "Toski, Bearer of Secrets - Synergy (Little Fellas)"
+        "Toski, Bearer of Secrets - Synergy (Little Fellas)",
+        "Loran of the Third Path - Synergy (Little Fellas)"
       ],
       "example_cards": [
         "Metathran Soldier",
@@ -15472,11 +17491,11 @@
         "Sun Titan"
       ],
       "synergy_commanders": [
-        "Glarb, Calamity's Augur - Synergy (Surveil)",
-        "Desmond Miles - Synergy (Surveil)",
         "Fandaniel, Telophoroi Ascian - Synergy (Surveil)",
+        "Glarb, Calamity's Augur - Synergy (Surveil)",
+        "Golbez, Crystal Collector - Synergy (Surveil)",
         "Kiora, the Rising Tide - Synergy (Threshold)",
-        "Ishkanah, Grafwidow - Synergy (Delirium)"
+        "The Swarmweaver - Synergy (Delirium)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Attacks libraries as a resource—looping self-mill or opponent mill into recursion and payoff engines. Synergies like Surveil and Threshold reinforce the plan."
@@ -15550,11 +17569,11 @@
       ],
       "synergy_commanders": [
         "Kardur, Doomscourge - Synergy (Berserker Kindred)",
-        "Magda, Brazen Outlaw - Synergy (Berserker Kindred)",
         "Alexios, Deimos of Kosmos - Synergy (Berserker Kindred)",
+        "Magda, Brazen Outlaw - Synergy (Berserker Kindred)",
         "Kiki-Jiki, Mirror Breaker - Synergy (Shaman Kindred)",
-        "Delina, Wild Mage - Synergy (Shaman Kindred)",
-        "Aurelia, the Warleader - Synergy (Haste)"
+        "Meren of Clan Nel Toth - Synergy (Shaman Kindred)",
+        "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Minotaur creatures into play with shared payoffs (e.g., Shaman Kindred and Warrior Kindred)."
@@ -15623,9 +17642,8 @@
         "Infested Fleshcutter"
       ],
       "synergy_commanders": [
-        "Yawgmoth, Thran Physician - Synergy (Infect)",
-        "Vorinclex, Monstrous Raider - Synergy (Infect)",
-        "Mondrak, Glory Dominus - Synergy (Phyrexian Kindred)"
+        "Karumonix, the Rat King - Synergy (Toxic)",
+        "Brudiclad, Telchor Engineer - Synergy (Phyrexian Token)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Mite creatures into play with shared payoffs (e.g., Poison Counters and Infect)."
@@ -15642,6 +17660,26 @@
       ],
       "primary_color": "White",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Vishgraz, the Doomhive",
+        "Skrelv, Defector Mite - Synergy (Mite Kindred)",
+        "Ria Ivor, Bane of Bladehold - Synergy (Mite Kindred)",
+        "Brudiclad, Telchor Engineer - Synergy (Phyrexian Token)",
+        "Ovika, Enigma Goliath - Synergy (Phyrexian Token)"
+      ],
+      "example_cards": [
+        "White Sun's Twilight",
+        "Skrelv's Hive",
+        "Mirrex",
+        "Crawling Chorus",
+        "Vishgraz, the Doomhive",
+        "Mite Overseer",
+        "Charge of the Mites",
+        "Infested Fleshcutter"
+      ],
+      "synergy_commanders": [
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Poison Counters)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Mite Kindred and Phyrexian Token reinforce the plan."
     },
@@ -15675,9 +17713,9 @@
         "Nightblade Brigade"
       ],
       "synergy_commanders": [
-        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
-        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
-        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+        "God-Eternal Oketra - Synergy (Warrior Token)",
+        "Maja, Bretagard Protector - Synergy (Warrior Token)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Mobilize leveraging synergies with Warrior Kindred and Creature Tokens."
@@ -15741,7 +17779,7 @@
       ],
       "synergy_commanders": [
         "Elas il-Kor, Sadistic Pilgrim - Synergy (Aristocrats)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Aristocrats)",
+        "Yawgmoth, Thran Physician - Synergy (Aristocrats)",
         "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)"
       ],
       "popularity_bucket": "Rare",
@@ -15763,7 +17801,8 @@
         "Anzrag, the Quake-Mole",
         "Ragavan, Nimble Pilferer - Synergy (Little Fellas)",
         "Azusa, Lost but Seeking - Synergy (Little Fellas)",
-        "Toski, Bearer of Secrets - Synergy (Little Fellas)"
+        "Toski, Bearer of Secrets - Synergy (Little Fellas)",
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)"
       ],
       "example_cards": [
         "Anzrag, the Quake-Mole",
@@ -15774,6 +17813,13 @@
         "Pothole Mole",
         "Ravenous Gigamole",
         "Badgermole"
+      ],
+      "synergy_commanders": [
+        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)",
+        "Krenko, Tin Street Kingpin - Synergy (+1/+1 Counters)",
+        "Selvala, Heart of the Wilds - Synergy (Blink)",
+        "Sheoldred, Whispering One - Synergy (Blink)",
+        "Veyran, Voice of Duality - Synergy (Enter the Battlefield)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Mole creatures into play with shared payoffs (e.g., Little Fellas)."
@@ -15881,10 +17927,11 @@
         "Rhox Faithmender"
       ],
       "synergy_commanders": [
+        "Crescent Island Temple - Synergy (Monk Token)",
+        "Jaya, Fiery Negotiator - Synergy (Monk Token)",
         "Taigam, Master Opportunist - Synergy (Flurry)",
         "Shiko and Narset, Unified - Synergy (Flurry)",
-        "Kitsa, Otterball Elite - Synergy (Prowess)",
-        "Bria, Riptide Rogue - Synergy (Prowess)"
+        "Kitsa, Otterball Elite - Synergy (Prowess)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Focuses on getting a high number of Monk creatures into play with shared payoffs (e.g., Flurry and Prowess)."
@@ -15901,6 +17948,26 @@
       ],
       "primary_color": "Red",
       "secondary_color": "White",
+      "example_commanders": [
+        "Azusa, Lost but Seeking - Synergy (Monk Kindred)",
+        "Tifa Lockhart - Synergy (Monk Kindred)",
+        "Lyse Hext - Synergy (Monk Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Monastery Mentor",
+        "Cori-Steel Cutter",
+        "Aligned Heart",
+        "Jugan Defends the Temple // Remnant of the Rising Star",
+        "Crescent Island Temple",
+        "Careful Cultivation",
+        "Jaya, Fiery Negotiator",
+        "Rally the Monastery"
+      ],
+      "synergy_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Monk Kindred and Creature Tokens reinforce the plan."
     },
@@ -15934,11 +18001,11 @@
         "Wily Bandar"
       ],
       "synergy_commanders": [
-        "Azusa, Lost but Seeking - Synergy (Little Fellas)",
-        "Toski, Bearer of Secrets - Synergy (Little Fellas)",
-        "Etali, Primal Storm - Synergy (Aggro)",
-        "Kutzil, Malamet Exemplar - Synergy (Aggro)",
-        "Sheoldred, the Apocalypse - Synergy (Combat Matters)"
+        "Lotho, Corrupt Shirriff - Synergy (Artifact Tokens)",
+        "Peregrin Took - Synergy (Artifact Tokens)",
+        "Mondrak, Glory Dominus - Synergy (Token Creation)",
+        "Adeline, Resplendent Cathar - Synergy (Token Creation)",
+        "Talrand, Sky Summoner - Synergy (Tokens Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Monkey creatures into play with shared payoffs (e.g., Little Fellas)."
@@ -15955,8 +18022,28 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Gylwain, Casting Director",
+        "Syr Armont, the Redeemer",
+        "Ellivere of the Wild Court - Synergy (Role token)",
+        "Heliod, God of the Sun - Synergy (Enchantment Tokens)",
+        "Go-Shintai of Life's Origin - Synergy (Enchantment Tokens)"
+      ],
+      "example_cards": [
+        "Monstrous Rage",
+        "Giant Inheritance",
+        "Gylwain, Casting Director",
+        "Ferocious Werefox // Guard Change",
+        "Curse of the Werefox",
+        "Syr Armont, the Redeemer",
+        "Become Brutes",
+        "Faunsbane Troll"
+      ],
+      "synergy_commanders": [
+        "Sram, Senior Edificer - Synergy (Equipment Matters)"
+      ],
       "popularity_bucket": "Rare",
-      "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Role Token and Enchantment Tokens reinforce the plan."
+      "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Role token and Enchantment Tokens reinforce the plan."
     },
     {
       "id": "monstrosity",
@@ -15989,8 +18076,9 @@
       ],
       "synergy_commanders": [
         "Uro, Titan of Nature's Wrath - Synergy (Giant Kindred)",
-        "Thryx, the Sudden Storm - Synergy (Giant Kindred)",
         "Bonny Pall, Clearcutter - Synergy (Giant Kindred)",
+        "Thryx, the Sudden Storm - Synergy (Giant Kindred)",
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)",
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
       ],
       "popularity_bucket": "Rare",
@@ -16029,7 +18117,7 @@
         "Niv-Mizzet, Parun - Synergy (Wizard Kindred)",
         "Talrand, Sky Summoner - Synergy (Wizard Kindred)",
         "Avacyn, Angel of Hope - Synergy (Flying)",
-        "Old Gnawbone - Synergy (Flying)",
+        "Aurelia, the Warleader - Synergy (Flying)",
         "Azusa, Lost but Seeking - Synergy (Toughness Matters)"
       ],
       "popularity_bucket": "Rare",
@@ -16065,7 +18153,8 @@
         "Skirsdag High Priest"
       ],
       "synergy_commanders": [
-        "Sram, Senior Edificer - Synergy (Voltron)"
+        "Bristly Bill, Spine Sower - Synergy (Counters Matter)",
+        "Selvala, Heart of the Wilds - Synergy (Blink)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Morbid leveraging synergies with +1/+1 Counters and Counters Matter."
@@ -16135,8 +18224,9 @@
         "Akroma, Angel of Fury"
       ],
       "synergy_commanders": [
+        "Preston, the Vanisher - Synergy (Illusion Kindred)",
         "Toothy, Imaginary Friend - Synergy (Illusion Kindred)",
-        "Emry, Lurker of the Loch - Synergy (Wizard Kindred)"
+        "Vito, Thorn of the Dusk Rose - Synergy (Cleric Kindred)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Builds around Morph leveraging synergies with Beast Kindred and Illusion Kindred."
@@ -16171,9 +18261,9 @@
         "One Last Job"
       ],
       "synergy_commanders": [
-        "Shorikai, Genesis Engine - Synergy (Pilot Kindred)",
-        "Cid, Freeflier Pilot - Synergy (Pilot Kindred)",
-        "Keleth, Sunmane Familiar - Synergy (Horse Kindred)"
+        "Shorikai, Genesis Engine - Synergy (Pilot Token)",
+        "Valor's Flagship - Synergy (Pilot Token)",
+        "Tannuk, Memorial Ensign - Synergy (Pilot Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Mount creatures into play with shared payoffs (e.g., Saddle and Pilot Kindred)."
@@ -16204,7 +18294,10 @@
         "Chartooth Cougar"
       ],
       "synergy_commanders": [
-        "Baral, Chief of Compliance - Synergy (Loot)"
+        "Rocksteady, Crash Courser - Synergy (Landcycling)",
+        "Jennika, Bad Apple Big Sister - Synergy (Landcycling)",
+        "Zog, Triceraton Castaway - Synergy (Typecycling)",
+        "Bebop, Warthog Warrior - Synergy (Typecycling)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around the Mountaincycling theme and its supporting synergies."
@@ -16270,7 +18363,7 @@
         "Cheeky House-Mouse // Squeak By"
       ],
       "synergy_commanders": [
-        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Mouse creatures into play with shared payoffs (e.g., Soldier Kindred and Little Fellas)."
@@ -16306,7 +18399,7 @@
       ],
       "synergy_commanders": [
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
-        "Yahenni, Undying Partisan - Synergy (Counters Matter)"
+        "Bristly Bill, Spine Sower - Synergy (Counters Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Kicker / Multikicker spells scale flexibly—paying extra mana for amplified late-game impact. Synergies like +1/+1 Counters and Blink reinforce the plan."
@@ -16335,6 +18428,9 @@
         "Slime Against Humanity",
         "Dragon's Approach",
         "Shadowborn Apostle"
+      ],
+      "synergy_commanders": [
+        "Loran of the Third Path - Synergy (Little Fellas)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Multiple Copies leveraging synergies with Little Fellas."
@@ -16369,7 +18465,9 @@
         "Tato Farmer"
       ],
       "synergy_commanders": [
-        "Krenko, Tin Street Kingpin - Synergy (Goblin Kindred)"
+        "Slash, Reptile Rampager - Synergy (Mutant Token)",
+        "Sally Pride, Lioness Leader - Synergy (Mutant Token)",
+        "Jennika, Bad Apple Big Sister - Synergy (Mutant Token)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Mutant creatures into play with shared payoffs (e.g., Graft and Rad Counters)."
@@ -16386,6 +18484,31 @@
       ],
       "primary_color": "White",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Slash, Reptile Rampager",
+        "Sally Pride, Lioness Leader",
+        "Jennika, Bad Apple Big Sister",
+        "Splinter & Leo, Father & Son",
+        "Old Hob, Alleycat Blues"
+      ],
+      "example_cards": [
+        "Vault 12: The Necropolis",
+        "Slash, Reptile Rampager",
+        "Sally Pride, Lioness Leader",
+        "Mighty Mutanimals",
+        "The Curse of Fenric",
+        "Jennika, Bad Apple Big Sister",
+        "Splinter & Leo, Father & Son",
+        "Turtle Blimp"
+      ],
+      "synergy_commanders": [
+        "Deadpool, Trading Card - Synergy (Mutant Kindred)",
+        "Kuja, Genome Sorcerer // Trance Kuja, Fate Defied - Synergy (Mutant Kindred)",
+        "Agent Frank Horrigan - Synergy (Mutant Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Mutant Kindred and Creature Tokens reinforce the plan."
     },
@@ -16419,12 +18542,12 @@
         "Pouncing Shoreshark"
       ],
       "synergy_commanders": [
+        "Braids, Arisen Nightmare - Synergy (Nightmare Kindred)",
+        "Sephiroth, Fabled SOLDIER // Sephiroth, One-Winged Angel - Synergy (Nightmare Kindred)",
+        "The Mindskinner - Synergy (Nightmare Kindred)",
         "Loot, Exuberant Explorer - Synergy (Beast Kindred)",
-        "Questing Beast - Synergy (Beast Kindred)",
         "Kona, Rescue Beastie - Synergy (Beast Kindred)",
-        "Niv-Mizzet, Parun - Synergy (Flying)",
-        "Avacyn, Angel of Hope - Synergy (Flying)",
-        "Azusa, Lost but Seeking - Synergy (Toughness Matters)"
+        "Etali, Primal Storm - Synergy (Dinosaur Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Stacks mutate layers to reuse mutate triggers and build a resilient evolving threat. Synergies like Beast Kindred and Flying reinforce the plan."
@@ -16461,10 +18584,7 @@
       "synergy_commanders": [
         "Codsworth, Handy Helper - Synergy (Mana Rock)",
         "Karn, Legacy Reforged - Synergy (Mana Rock)",
-        "Ramos, Dragon Engine - Synergy (Mana Rock)",
-        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Mana Dork)",
-        "Selvala, Heart of the Wilds - Synergy (Mana Dork)",
-        "Azusa, Lost but Seeking - Synergy (Ramp)"
+        "Mondrak, Glory Dominus - Synergy (Phyrexian Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Myr creatures into play with shared payoffs (e.g., Artifacts Matter and Little Fellas)."
@@ -16481,6 +18601,23 @@
       ],
       "primary_color": "White",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Brudiclad, Telchor Engineer",
+        "Urtet, Remnant of Memnarch",
+        "Ragavan, Nimble Pilferer - Synergy (Artifact Tokens)",
+        "Lotho, Corrupt Shirriff - Synergy (Artifact Tokens)",
+        "Mondrak, Glory Dominus - Synergy (Phyrexian Kindred)"
+      ],
+      "example_cards": [
+        "Myr Battlesphere",
+        "Brudiclad, Telchor Engineer",
+        "Mirrodin Besieged",
+        "Genesis Chamber",
+        "Myr Turbine",
+        "Myr Sire",
+        "Urtet, Remnant of Memnarch",
+        "Myrsmith"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Myr Kindred and Artifact Tokens reinforce the plan."
     },
@@ -16514,7 +18651,7 @@
         "Hammers of Moradin"
       ],
       "synergy_commanders": [
-        "Kiki-Jiki, Mirror Breaker - Synergy (Clones)",
+        "Sakashima of a Thousand Faces - Synergy (Clones)",
         "Yawgmoth, Thran Physician - Synergy (Planeswalkers)"
       ],
       "popularity_bucket": "Rare",
@@ -16547,6 +18684,10 @@
         "Taoist Mystic",
         "Mystic Visionary",
         "Taoist Hermit"
+      ],
+      "synergy_commanders": [
+        "Pianna, Nomad Captain - Synergy (Nomad Kindred)",
+        "Kiora, the Rising Tide - Synergy (Threshold)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Mystic creatures into play with shared payoffs (e.g., Human Kindred and Little Fellas)."
@@ -16595,9 +18736,8 @@
         "Psychomancer"
       ],
       "synergy_commanders": [
-        "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)",
-        "Loran of the Third Path - Synergy (Artifacts Matter)",
-        "Emry, Lurker of the Loch - Synergy (Wizard Kindred)"
+        "Tri-Sentinel, Act of Vengeance - Synergy (Unearth)",
+        "God-Eternal Oketra - Synergy (Warrior Token)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Necron creatures into play with shared payoffs (e.g., Unearth and Artifacts Matter)."
@@ -16608,6 +18748,17 @@
       "synergies": [],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Nephilim Epochal"
+      ],
+      "example_cards": [
+        "Glint-Eye Nephilim",
+        "Yore-Tiller Nephilim",
+        "Ink-Treader Nephilim",
+        "Witch-Maw Nephilim",
+        "Dune-Brood Nephilim",
+        "Nephilim Epochal"
+      ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Nephilim creatures into play with shared payoffs."
     },
@@ -16653,6 +18804,9 @@
         "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury",
         "Hound Tamer // Untamed Pup"
       ],
+      "synergy_commanders": [
+        "Veyran, Voice of Duality - Synergy (Transform)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Nightbound leveraging synergies with Daybound and Werewolf Kindred."
     },
@@ -16686,11 +18840,12 @@
         "Ancient Cellarspawn"
       ],
       "synergy_commanders": [
-        "Mondrak, Glory Dominus - Synergy (Horror Kindred)",
-        "Solphim, Mayhem Dominus - Synergy (Horror Kindred)",
-        "Zopandrel, Hunger Dominus - Synergy (Horror Kindred)",
-        "Loot, Exuberant Explorer - Synergy (Beast Kindred)",
-        "Questing Beast - Synergy (Beast Kindred)"
+        "Nethroi, Apex of Death - Synergy (Mutate)",
+        "Brokkos, Apex of Forever - Synergy (Mutate)",
+        "Illuna, Apex of Wishes - Synergy (Mutate)",
+        "Calamity, Galloping Inferno - Synergy (Horse Kindred)",
+        "Keleth, Sunmane Familiar - Synergy (Horse Kindred)",
+        "Mondrak, Glory Dominus - Synergy (Horror Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Nightmare creatures into play with shared payoffs (e.g., Horror Kindred and Draw Triggers)."
@@ -16719,6 +18874,9 @@
         "Predatory Nightstalker",
         "Prowling Nightstalker",
         "Raiding Nightstalker"
+      ],
+      "synergy_commanders": [
+        "Loran of the Third Path - Synergy (Little Fellas)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Nightstalker creatures into play with shared payoffs (e.g., Little Fellas and Big Mana)."
@@ -16753,9 +18911,10 @@
         "Ingenious Infiltrator"
       ],
       "synergy_commanders": [
-        "Lord Skitter, Sewer King - Synergy (Rat Kindred)",
-        "Marrow-Gnawer - Synergy (Rat Kindred)",
-        "Syr Konrad, the Grim - Synergy (Human Kindred)"
+        "Higure, the Still Wind - Synergy (Ninjutsu)",
+        "Dark Leo & Shredder - Synergy (Ninja Token)",
+        "Kaito, Cunning Infiltrator - Synergy (Ninja Token)",
+        "Raphael, the Nightwatcher - Synergy (Sneak)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Ninja creatures into play with shared payoffs (e.g., Ninjutsu and Rat Kindred)."
@@ -16772,6 +18931,27 @@
       ],
       "primary_color": "Black",
       "secondary_color": "White",
+      "example_commanders": [
+        "Dark Leo & Shredder",
+        "Nashi, Moon Sage's Scion - Synergy (Ninja Kindred)",
+        "Yuriko, the Tiger's Shadow - Synergy (Ninja Kindred)",
+        "Ink-Eyes, Servant of Oni - Synergy (Ninja Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Kaito, Cunning Infiltrator",
+        "Endless Foot Assault",
+        "Kaito Shizuki",
+        "Dark Leo & Shredder",
+        "The Last Ronin's Technique",
+        "Foot Chopper",
+        "Foot Mystic",
+        "Uneasy Alliance"
+      ],
+      "synergy_commanders": [
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Ninja Kindred and Creature Tokens reinforce the plan."
     },
@@ -16817,10 +18997,10 @@
       "theme": "Noble Kindred",
       "synergies": [
         "Firebending",
-        "Firebend",
         "Bending",
         "Monarch",
-        "Octopus Kindred"
+        "Octopus Kindred",
+        "Human Token"
       ],
       "primary_color": "Black",
       "secondary_color": "White",
@@ -16842,12 +19022,12 @@
         "The Council of Four"
       ],
       "synergy_commanders": [
-        "Urabrask // The Great Work - Synergy (Lore Counters)",
-        "Sheoldred // The True Scriptures - Synergy (Lore Counters)",
-        "Vorinclex // The Grand Evolution - Synergy (Lore Counters)",
-        "Vito, Thorn of the Dusk Rose - Synergy (Vampire Kindred)",
-        "Yahenni, Undying Partisan - Synergy (Vampire Kindred)",
-        "Jhoira, Weatherlight Captain - Synergy (Sagas Matter)"
+        "Fire Lord Azula - Synergy (Firebending)",
+        "Ozai, the Phoenix King - Synergy (Firebending)",
+        "Zuko, Exiled Prince - Synergy (Firebending)",
+        "Toph, Hardheaded Teacher - Synergy (Bending)",
+        "Toph, Earthbending Master - Synergy (Bending)",
+        "Queen Marchesa - Synergy (Monarch)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Noble creatures into play with shared payoffs (e.g., Lore Counters and Sagas Matter)."
@@ -16858,6 +19038,13 @@
       "synergies": [],
       "primary_color": "Red",
       "secondary_color": "Blue",
+      "example_cards": [
+        "Noggle Ransacker",
+        "Noggle Robber",
+        "Noggle Bandit",
+        "Noggle Hedge-Mage",
+        "Noggle Bridgebreaker"
+      ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Noggle creatures into play with shared payoffs."
     },
@@ -16889,6 +19076,9 @@
         "Avalanche Riders",
         "Pianna, Nomad Captain",
         "Nomad Decoy"
+      ],
+      "synergy_commanders": [
+        "Prosper, Tome-Bound - Synergy (Mystic Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Nomad creatures into play with shared payoffs (e.g., Threshold and Human Kindred)."
@@ -16959,12 +19149,12 @@
         "Cephalid Facetaker"
       ],
       "synergy_commanders": [
-        "Lotho, Corrupt Shirriff - Synergy (Rogue Kindred)",
-        "Sakashima of a Thousand Faces - Synergy (Rogue Kindred)",
-        "Rankle, Master of Pranks - Synergy (Rogue Kindred)",
-        "Baral, Chief of Compliance - Synergy (Loot)",
-        "The Locust God - Synergy (Loot)",
-        "Ragavan, Nimble Pilferer - Synergy (Outlaw Kindred)"
+        "Charix, the Raging Isle - Synergy (Leviathan Kindred)",
+        "Slinn Voda, the Rising Deep - Synergy (Leviathan Kindred)",
+        "Xyris, the Writhing Storm - Synergy (Leviathan Kindred)",
+        "Arixmethes, Slumbering Isle - Synergy (Kraken Kindred)",
+        "Gyruda, Doom of Depths - Synergy (Kraken Kindred)",
+        "Aesi, Tyrant of Gyre Strait - Synergy (Serpent Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Octopus creatures into play with shared payoffs (e.g., Rogue Kindred and Loot)."
@@ -16975,6 +19165,12 @@
       "synergies": [],
       "primary_color": "Blue",
       "secondary_color": "Green",
+      "example_cards": [
+        "Octomancer",
+        "Fisher's Talent",
+        "Kiora, Master of the Depths",
+        "Crush of Tentacles"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines."
     },
@@ -17047,8 +19243,9 @@
         "Syr Konrad, the Grim - Synergy (Pingers)",
         "Elas il-Kor, Sadistic Pilgrim - Synergy (Pingers)",
         "Niv-Mizzet, Parun - Synergy (Pingers)",
-        "Ragavan, Nimble Pilferer - Synergy (Outlaw Kindred)",
-        "Lotho, Corrupt Shirriff - Synergy (Outlaw Kindred)"
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)",
+        "Lotho, Corrupt Shirriff - Synergy (Token Creation)",
+        "Sakashima of a Thousand Faces - Synergy (Outlaw Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Offspring leveraging synergies with Blink and Enter the Battlefield."
@@ -17085,9 +19282,9 @@
       "synergy_commanders": [
         "Kardur, Doomscourge - Synergy (Demon Kindred)",
         "Vilis, Broker of Blood - Synergy (Demon Kindred)",
-        "Razaketh, the Foulblooded - Synergy (Demon Kindred)",
+        "Valgavoth, Terror Eater - Synergy (Demon Kindred)",
         "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)",
-        "Chatterfang, Squirrel General - Synergy (Warrior Kindred)",
+        "Moraug, Fury of Akoum - Synergy (Warrior Kindred)",
         "Kiki-Jiki, Mirror Breaker - Synergy (Shaman Kindred)"
       ],
       "popularity_bucket": "Niche",
@@ -17123,8 +19320,8 @@
         "Atraxa's Skitterfang"
       ],
       "synergy_commanders": [
-        "Rishkar, Peema Renegade - Synergy (Counters Matter)",
-        "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)"
+        "Loot, Exuberant Explorer - Synergy (Beast Kindred)",
+        "Kona, Rescue Beastie - Synergy (Beast Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Accumulates oil counters to unlock scaling payoffs, removal triggers, or delayed value conversions."
@@ -17174,11 +19371,8 @@
       ],
       "synergy_commanders": [
         "Mondrak, Glory Dominus - Synergy (Clones)",
-        "Kiki-Jiki, Mirror Breaker - Synergy (Clones)",
         "Sakashima of a Thousand Faces - Synergy (Clones)",
-        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)",
-        "Krenko, Tin Street Kingpin - Synergy (+1/+1 Counters)",
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
+        "Yawgmoth, Thran Physician - Synergy (Midrange)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Ooze creatures into play with shared payoffs (e.g., Clones and +1/+1 Counters)."
@@ -17195,6 +19389,26 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Felix Five-Boots - Synergy (Ooze Kindred)",
+        "Mutagen Man, Living Ooze - Synergy (Ooze Kindred)",
+        "The Mimeoplasm - Synergy (Ooze Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Slime Against Humanity",
+        "Biogenic Ooze",
+        "Gelatinous Genesis",
+        "Printlifter Ooze",
+        "Convert to Slime",
+        "Mitotic Slime",
+        "Consuming Blob",
+        "Gutter Grime"
+      ],
+      "synergy_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Ooze Kindred and Creature Tokens reinforce the plan."
     },
@@ -17231,7 +19445,7 @@
         "Captain Rex Nebula - Synergy (Employee Kindred)",
         "Selvala, Heart of the Wilds - Synergy (Blink)",
         "Sheoldred, Whispering One - Synergy (Blink)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)"
+        "Veyran, Voice of Duality - Synergy (Enter the Battlefield)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Open an Attraction leveraging synergies with Employee Kindred and Blink."
@@ -17247,6 +19461,26 @@
       ],
       "primary_color": "Blue",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Lotho, Corrupt Shirriff - Synergy (Spells Matter)",
+        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Spells Matter)",
+        "Mangara, the Diplomat - Synergy (Spells Matter)",
+        "Niv-Mizzet, Parun - Synergy (Spellslinger)",
+        "Talrand, Sky Summoner - Synergy (Spellslinger)"
+      ],
+      "example_cards": [
+        "Molten-Core Maestro",
+        "Exhibition Tidecaller",
+        "Thunderdrum Soloist",
+        "Muse Seeker",
+        "Colorstorm Stallion",
+        "Spectacular Skywhale",
+        "Tackle Artist",
+        "Elemental Mascot"
+      ],
+      "synergy_commanders": [
+        "Azusa, Lost but Seeking - Synergy (Toughness Matters)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Opus leveraging synergies with Toughness Matters and Spells Matter."
     },
@@ -17291,10 +19525,10 @@
         "Gothmog, Morgul Lieutenant"
       ],
       "synergy_commanders": [
+        "The Mouth of Sauron - Synergy (Orc Token)",
         "Sauron, the Dark Lord - Synergy (Army Kindred)",
-        "Sauron, Lord of the Rings - Synergy (Amass)",
-        "Grishnákh, Brash Instigator - Synergy (Amass)",
-        "Ragavan, Nimble Pilferer - Synergy (Dash)"
+        "Mauhúr, Uruk-hai Captain - Synergy (Army Kindred)",
+        "Saruman the White - Synergy (Army Token)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Orc creatures into play with shared payoffs (e.g., Amass and Army Kindred)."
@@ -17311,6 +19545,28 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Saruman, the White Hand",
+        "Gothmog, Morgul Lieutenant",
+        "The Mouth of Sauron",
+        "Saruman the White",
+        "Shagrat, Loot Bearer"
+      ],
+      "example_cards": [
+        "Saruman, the White Hand",
+        "Gothmog, Morgul Lieutenant",
+        "Saruman's Trickery",
+        "Orcish Medicine",
+        "Moria Scavenger",
+        "Summons of Saruman",
+        "March from the Black Gate",
+        "Treason of Isengard"
+      ],
+      "synergy_commanders": [
+        "Sauron, the Dark Lord - Synergy (Army Kindred)",
+        "Mauhúr, Uruk-hai Captain - Synergy (Army Kindred)",
+        "Sauron, Lord of the Rings - Synergy (Amass)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Army Token and Army Kindred reinforce the plan."
     },
@@ -17391,10 +19647,8 @@
         "Lilypad Village"
       ],
       "synergy_commanders": [
-        "Talrand, Sky Summoner - Synergy (Wizard Kindred)",
-        "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)",
-        "Loran of the Third Path - Synergy (Artifacts Matter)",
-        "Selvala, Heart of the Wilds - Synergy (Blink)"
+        "Lyse Hext - Synergy (Prowess)",
+        "Lotho, Corrupt Shirriff - Synergy (Spells Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Otter creatures into play with shared payoffs (e.g., Wizard Kindred and Blink)."
@@ -17405,6 +19659,15 @@
       "synergies": [],
       "primary_color": "Blue",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Tolabow, Loch Rascal"
+      ],
+      "example_cards": [
+        "Ral, Crackling Wit",
+        "Stormchaser's Talent",
+        "Otterball Antics",
+        "Tolabow, Loch Rascal"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines."
     },
@@ -17436,6 +19699,10 @@
         "Gilder Bairn",
         "Glimmer Bairn",
         "Troublemaker Ouphe"
+      ],
+      "synergy_commanders": [
+        "Mangara, the Diplomat - Synergy (Stax)",
+        "Selvala, Heart of the Wilds - Synergy (Blink)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Ouphe creatures into play with shared payoffs (e.g., Stax and Little Fellas)."
@@ -17470,6 +19737,7 @@
         "Mer-Ek Nightblade"
       ],
       "synergy_commanders": [
+        "Bristly Bill, Spine Sower - Synergy (Counters Matter)",
         "Sram, Senior Edificer - Synergy (Voltron)"
       ],
       "popularity_bucket": "Rare",
@@ -17541,11 +19809,11 @@
         "Counterflux"
       ],
       "synergy_commanders": [
-        "Samut, Voice of Dissent - Synergy (Combat Tricks)",
-        "Naru Meha, Master Wizard - Synergy (Combat Tricks)",
         "The Wandering Rescuer - Synergy (Combat Tricks)",
-        "Ulamog, the Infinite Gyre - Synergy (Removal)",
-        "Zacama, Primal Calamity - Synergy (Removal)"
+        "Ambrosia Whiteheart - Synergy (Combat Tricks)",
+        "Samut, Voice of Dissent - Synergy (Combat Tricks)",
+        "Avacyn, Angel of Hope - Synergy (Interaction)",
+        "Boromir, Warden of the Tower - Synergy (Interaction)"
       ],
       "popularity_bucket": "Rare",
       "description": "Overloads modal spells into one-sided board impacts or mass disruption swings. Synergies like Spells Matter and Spellslinger reinforce the plan."
@@ -17580,9 +19848,11 @@
         "Bulwark Ox"
       ],
       "synergy_commanders": [
-        "Adeline, Resplendent Cathar - Synergy (Tokens Matter)",
-        "Talrand, Sky Summoner - Synergy (Tokens Matter)",
-        "Azusa, Lost but Seeking - Synergy (Toughness Matters)"
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Urza, Lord High Artificer - Synergy (Creature Tokens)",
+        "Azusa, Lost but Seeking - Synergy (Lands Matter)",
+        "Tatyova, Benthic Druid - Synergy (Lands Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Ox creatures into play with shared payoffs (e.g., Token Creation and Tokens Matter)."
@@ -17597,6 +19867,24 @@
       ],
       "primary_color": "White",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Bruse Tarl, Roving Rancher",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Urza, Lord High Artificer - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
+      "example_cards": [
+        "Bovine Intervention",
+        "Contraband Livestock",
+        "Transmogrifying Wand",
+        "Ox Drover",
+        "Bruse Tarl, Roving Rancher"
+      ],
+      "synergy_commanders": [
+        "Lotho, Corrupt Shirriff - Synergy (Token Creation)",
+        "Mondrak, Glory Dominus - Synergy (Tokens Matter)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Creature Tokens and Token Creation reinforce the plan."
     },
@@ -17636,7 +19924,8 @@
         "Gnoll Hunter"
       ],
       "synergy_commanders": [
-        "Sheoldred, the Apocalypse - Synergy (Combat Matters)"
+        "Sram, Senior Edificer - Synergy (Combat Matters)",
+        "Azusa, Lost but Seeking - Synergy (Little Fellas)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around the Pack tactics theme and its supporting synergies."
@@ -17667,6 +19956,23 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Etali, Primal Storm - Synergy (Exile Matters)",
+        "Ragavan, Nimble Pilferer - Synergy (Exile Matters)",
+        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Exile Matters)",
+        "Syr Konrad, the Grim - Synergy (Big Mana)",
+        "Ghalta, Primal Hunger - Synergy (Big Mana)"
+      ],
+      "example_cards": [
+        "Improvisation Capstone",
+        "Germination Practicum",
+        "Decorum Dissertation",
+        "Echocasting Symposium",
+        "Restoration Seminar"
+      ],
+      "synergy_commanders": [
+        "Lotho, Corrupt Shirriff - Synergy (Spells Matter)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Paradigm leveraging synergies with Exile Matters and Big Mana."
     },
@@ -17698,9 +20004,10 @@
       ],
       "synergy_commanders": [
         "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Spells Matter)",
-        "Niv-Mizzet, Parun - Synergy (Spells Matter)",
+        "Mangara, the Diplomat - Synergy (Spells Matter)",
+        "Niv-Mizzet, Parun - Synergy (Spellslinger)",
         "Talrand, Sky Summoner - Synergy (Spellslinger)",
-        "Mangara, the Diplomat - Synergy (Spellslinger)"
+        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around the Paradox theme and its supporting synergies."
@@ -17735,9 +20042,9 @@
         "Selvala's Enforcer"
       ],
       "synergy_commanders": [
-        "Sheoldred, the Apocalypse - Synergy (Draw Triggers)",
-        "Selvala, Heart of the Wilds - Synergy (Draw Triggers)",
-        "Niv-Mizzet, Parun - Synergy (Wheels)"
+        "Selvala, Heart of the Wilds - Synergy (Wheels)",
+        "Sheoldred, the Apocalypse - Synergy (Wheels)",
+        "Niv-Mizzet, Parun - Synergy (Draw Triggers)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Parley leveraging synergies with Politics and Draw Triggers."
@@ -17772,12 +20079,12 @@
         "Esior, Wardwing Familiar"
       ],
       "synergy_commanders": [
-        "Pippin, Warden of Isengard - Synergy (Partner with)",
-        "Merry, Warden of Isengard - Synergy (Partner with)",
-        "Pir, Imaginative Rascal - Synergy (Partner with)",
         "Ragavan, Nimble Pilferer - Synergy (Pirate Kindred)",
         "Captain Lannery Storm - Synergy (Pirate Kindred)",
-        "Loran of the Third Path - Synergy (Artificer Kindred)"
+        "Malcolm, Alluring Scoundrel - Synergy (Pirate Kindred)",
+        "Loran of the Third Path - Synergy (Artificer Kindred)",
+        "Urza, Lord High Artificer - Synergy (Artificer Kindred)",
+        "Selvala, Heart of the Wilds - Synergy (Elf Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Builds around Partner leveraging synergies with Partner with and Pirate Kindred."
@@ -17805,6 +20112,18 @@
       "synergies": [],
       "primary_color": "Red",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Ellie, Brick Master",
+        "Abby, Merciless Soldier",
+        "Ellie, Vengeful Hunter",
+        "Joel, Resolute Survivor"
+      ],
+      "example_cards": [
+        "Ellie, Brick Master",
+        "Abby, Merciless Soldier",
+        "Ellie, Vengeful Hunter",
+        "Joel, Resolute Survivor"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around the Partner - Survivors theme and its supporting synergies."
     },
@@ -17838,12 +20157,12 @@
         "Sam, Loyal Attendant"
       ],
       "synergy_commanders": [
-        "Kodama of the East Tree - Synergy (Partner)",
-        "Sakashima of a Thousand Faces - Synergy (Partner)",
-        "Kediss, Emberclaw Familiar - Synergy (Partner)",
         "Selvala, Heart of the Wilds - Synergy (Blink)",
         "Sheoldred, Whispering One - Synergy (Blink)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)"
+        "Veyran, Voice of Duality - Synergy (Blink)",
+        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)",
+        "Kodama of the East Tree - Synergy (Enter the Battlefield)",
+        "Elesh Norn, Mother of Machines - Synergy (Leave the Battlefield)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Partner with leveraging synergies with Partner and Warrior Kindred."
@@ -17880,7 +20199,8 @@
       "synergy_commanders": [
         "Lotho, Corrupt Shirriff - Synergy (Halfling Kindred)",
         "Peregrin Took - Synergy (Halfling Kindred)",
-        "Syr Ginger, the Meal Ender - Synergy (Food)"
+        "Camellia, the Seedmiser - Synergy (Food Token)",
+        "The Cabbage Merchant - Synergy (Food)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Peasant creatures into play with shared payoffs (e.g., Halfling Kindred and Food Token)."
@@ -17913,8 +20233,9 @@
         "Thurid, Mare of Destiny"
       ],
       "synergy_commanders": [
+        "Aurelia, the Warleader - Synergy (Flying)",
         "Azusa, Lost but Seeking - Synergy (Little Fellas)",
-        "Sheoldred, the Apocalypse - Synergy (Toughness Matters)"
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Pegasus creatures into play with shared payoffs (e.g., Flying and Little Fellas)."
@@ -17928,6 +20249,24 @@
         "Tokens Matter"
       ],
       "primary_color": "White",
+      "example_commanders": [
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Urza, Lord High Artificer - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)",
+        "Lotho, Corrupt Shirriff - Synergy (Token Creation)"
+      ],
+      "example_cards": [
+        "Archon of Sun's Grace",
+        "Storm Herd",
+        "Pegasus Guardian // Rescue the Foal",
+        "Sacred Mesa",
+        "Pegasus Stampede",
+        "Pegasus Refuge"
+      ],
+      "synergy_commanders": [
+        "Mondrak, Glory Dominus - Synergy (Tokens Matter)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Creature Tokens and Token Creation reinforce the plan."
     },
@@ -17963,10 +20302,10 @@
       "synergy_commanders": [
         "Selvala, Heart of the Wilds - Synergy (Blink)",
         "Sheoldred, Whispering One - Synergy (Blink)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Blink)",
-        "Elesh Norn, Mother of Machines - Synergy (Enter the Battlefield)",
+        "Veyran, Voice of Duality - Synergy (Blink)",
+        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)",
         "Kodama of the East Tree - Synergy (Enter the Battlefield)",
-        "Nezahal, Primal Tide - Synergy (Leave the Battlefield)"
+        "Elesh Norn, Mother of Machines - Synergy (Leave the Battlefield)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Performer creatures into play with shared payoffs (e.g., Blink and Enter the Battlefield)."
@@ -18001,6 +20340,7 @@
         "Lesser Masticore"
       ],
       "synergy_commanders": [
+        "Tekuthal, Inquiry Dominus - Synergy (-1/-1 Counters)",
         "Sheoldred, the Apocalypse - Synergy (Aristocrats)"
       ],
       "popularity_bucket": "Rare",
@@ -18014,7 +20354,7 @@
         "Warlock Kindred",
         "Sacrifice Matters",
         "Aristocrats",
-        "Lifegain"
+        "Creature Tokens"
       ],
       "primary_color": "Black",
       "secondary_color": "Green",
@@ -18036,10 +20376,9 @@
         "Nuisance Engine"
       ],
       "synergy_commanders": [
-        "Sheoldred, the Apocalypse - Synergy (Sacrifice Matters)",
-        "Elas il-Kor, Sadistic Pilgrim - Synergy (Aristocrats)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Aristocrats)",
-        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+        "Moseo, Vein's New Dean - Synergy (Pest Token)",
+        "Saryth, the Viper's Fang - Synergy (Warlock Kindred)",
+        "Honest Rutstein - Synergy (Warlock Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Pest creatures into play with shared payoffs (e.g., Sacrifice Matters and Aristocrats)."
@@ -18056,6 +20395,27 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Beledros Witherbloom",
+        "Moseo, Vein's New Dean",
+        "Valentin, Dean of the Vein // Lisette, Dean of the Root",
+        "Blex, Vexing Pest // Search for Blex - Synergy (Pest Kindred)",
+        "Saryth, the Viper's Fang - Synergy (Warlock Kindred)"
+      ],
+      "example_cards": [
+        "Beledros Witherbloom",
+        "Sedgemoor Witch",
+        "Blight Mound",
+        "Moseo, Vein's New Dean",
+        "Tend the Pests",
+        "Pest Rescuer",
+        "Ribtruss Roaster",
+        "Valentin, Dean of the Vein // Lisette, Dean of the Root"
+      ],
+      "synergy_commanders": [
+        "Honest Rutstein - Synergy (Warlock Kindred)",
+        "Syr Konrad, the Grim - Synergy (Sacrifice Matters)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Pest Kindred and Warlock Kindred reinforce the plan."
     },
@@ -18089,11 +20449,11 @@
         "Teferi, Master of Time"
       ],
       "synergy_commanders": [
-        "Kodama of the West Tree - Synergy (Equipment Matters)",
         "Danitha Capashen, Paragon - Synergy (Equipment Matters)",
-        "Toski, Bearer of Secrets - Synergy (Protective Effects)",
-        "Mondrak, Glory Dominus - Synergy (Protective Effects)",
-        "Syr Konrad, the Grim - Synergy (Interaction)"
+        "Kodama of the West Tree - Synergy (Equipment Matters)",
+        "Avacyn, Angel of Hope - Synergy (Interaction)",
+        "Boromir, Warden of the Tower - Synergy (Interaction)",
+        "Toski, Bearer of Secrets - Synergy (Protective Effects)"
       ],
       "popularity_bucket": "Niche",
       "description": "Builds around Phasing leveraging synergies with Equipment Matters and Protective Effects."
@@ -18104,6 +20464,13 @@
       "synergies": [],
       "primary_color": "Blue",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Phelddagrif"
+      ],
+      "example_cards": [
+        "Phelddagrif",
+        "Questing Phelddagrif"
+      ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Phelddagrif creatures into play with shared payoffs."
     },
@@ -18138,8 +20505,9 @@
       "synergy_commanders": [
         "Aurelia, the Warleader - Synergy (Haste)",
         "Yahenni, Undying Partisan - Synergy (Haste)",
-        "Kiki-Jiki, Mirror Breaker - Synergy (Haste)",
-        "Rishkar, Peema Renegade - Synergy (Midrange)"
+        "Captain Lannery Storm - Synergy (Haste)",
+        "Six - Synergy (Graveyard Recursion)",
+        "Muldrotha, the Gravetide - Synergy (Graveyard Recursion)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Phoenix creatures into play with shared payoffs (e.g., Flying and Mill)."
@@ -18174,8 +20542,9 @@
         "Sheoldred, Whispering One"
       ],
       "synergy_commanders": [
+        "Ekthi, Contaminator Priest - Synergy (Germ Kindred)",
         "Bitterthorn, Nissa's Animus - Synergy (Germ Kindred)",
-        "Kaldra Compleat - Synergy (Living weapon)"
+        "Vishgraz, the Doomhive - Synergy (Mite Token)"
       ],
       "popularity_bucket": "Common",
       "description": "Focuses on getting a high number of Phyrexian creatures into play with shared payoffs (e.g., Germ Kindred and Carrier Kindred)."
@@ -18192,6 +20561,27 @@
       ],
       "primary_color": "White",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Brudiclad, Telchor Engineer",
+        "Ovika, Enigma Goliath",
+        "Vishgraz, the Doomhive",
+        "Malcator, Purity Overseer",
+        "Ich-Tekik, Salvage Splicer"
+      ],
+      "example_cards": [
+        "Wurmcoil Engine",
+        "Nettlecyst",
+        "Ezuri's Predation",
+        "White Sun's Twilight",
+        "Bitterthorn, Nissa's Animus",
+        "Skrelv's Hive",
+        "Brudiclad, Telchor Engineer",
+        "Urabrask's Forge"
+      ],
+      "synergy_commanders": [
+        "Ekthi, Contaminator Priest - Synergy (Germ Kindred)",
+        "Bitterthorn, Nissa's Animus - Synergy (Germ Kindred)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Germ Kindred and Germ Token reinforce the plan."
     },
@@ -18228,8 +20618,8 @@
         "Adeline, Resplendent Cathar - Synergy (Planeswalkers)",
         "Yawgmoth, Thran Physician - Synergy (Planeswalkers)",
         "Vorinclex, Monstrous Raider - Synergy (Planeswalkers)",
-        "Lae'zel, Vlaakith's Champion - Synergy (Superfriends)",
         "Tekuthal, Inquiry Dominus - Synergy (Superfriends)",
+        "Lae'zel, Vlaakith's Champion - Synergy (Superfriends)",
         "Lotho, Corrupt Shirriff - Synergy (Control)"
       ],
       "popularity_bucket": "Rare",
@@ -18265,11 +20655,9 @@
         "Prodigy's Prototype"
       ],
       "synergy_commanders": [
+        "Valor's Flagship - Synergy (Pilot Token)",
         "Sram, Senior Edificer - Synergy (Vehicles)",
-        "The Indomitable - Synergy (Vehicles)",
-        "The Gitrog, Ravenous Ride - Synergy (Mount Kindred)",
-        "Calamity, Galloping Inferno - Synergy (Mount Kindred)",
-        "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)"
+        "The Gitrog, Ravenous Ride - Synergy (Mount Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Pilot creatures into play with shared payoffs (e.g., Vehicles and Mount Kindred)."
@@ -18286,6 +20674,26 @@
       ],
       "primary_color": "White",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Tannuk, Memorial Ensign - Synergy (Pilot Kindred)",
+        "Cid, Freeflier Pilot - Synergy (Pilot Kindred)",
+        "Tannuk, Steadfast Second - Synergy (Pilot Kindred)",
+        "The Gitrog, Ravenous Ride - Synergy (Mount Kindred)",
+        "Calamity, Galloping Inferno - Synergy (Mount Kindred)"
+      ],
+      "example_cards": [
+        "Shorikai, Genesis Engine",
+        "Defend the Rider",
+        "Reckoner Bankbuster",
+        "Prodigy's Prototype",
+        "Valor's Flagship",
+        "Country Roads",
+        "Born to Drive",
+        "Rocky Roads"
+      ],
+      "synergy_commanders": [
+        "Sram, Senior Edificer - Synergy (Vehicles)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Pilot Kindred and Mount Kindred reinforce the plan."
     },
@@ -18320,8 +20728,9 @@
       ],
       "synergy_commanders": [
         "Sorin of House Markov // Sorin, Ravenous Neonate - Synergy (Extort)",
-        "Mahadi, Emporium Master - Synergy (Devil Kindred)",
-        "Zurzoth, Chaos Rider - Synergy (Devil Kindred)"
+        "The Kingpin of Crime - Synergy (Extort)",
+        "Zurzoth, Chaos Rider - Synergy (Devil Token)",
+        "Raphael, Fiendish Savior - Synergy (Devil Token)"
       ],
       "popularity_bucket": "Common",
       "description": "Builds around Pingers leveraging synergies with Extort and Burn."
@@ -18356,10 +20765,8 @@
         "Dire Fleet Daredevil"
       ],
       "synergy_commanders": [
-        "Malcolm, the Eyes - Synergy (Siren Kindred)",
-        "Alesha, Who Laughs at Fate - Synergy (Raid)",
-        "Rose, Cutthroat Raider - Synergy (Raid)",
-        "Sliver Gravemother - Synergy (Encore)"
+        "Vraska, Relic Seeker - Synergy (Pirate Token)",
+        "Alesha, Who Laughs at Fate - Synergy (Raid)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Focuses on getting a high number of Pirate creatures into play with shared payoffs (e.g., Siren Kindred and Raid)."
@@ -18375,6 +20782,25 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Pirate Kindred)",
+        "Captain Lannery Storm - Synergy (Pirate Kindred)",
+        "Malcolm, Alluring Scoundrel - Synergy (Pirate Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Skeleton Crew",
+        "Nettling Nuisance",
+        "Vraska, Relic Seeker",
+        "Fathom Fleet Captain",
+        "Daring Piracy",
+        "Corpses of the Lost",
+        "Pursued Whale"
+      ],
+      "synergy_commanders": [
+        "Lotho, Corrupt Shirriff - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Pirate Kindred and Creature Tokens reinforce the plan."
     },
@@ -18420,7 +20846,10 @@
         "Shepherding Spirits"
       ],
       "synergy_commanders": [
-        "Baral, Chief of Compliance - Synergy (Loot)"
+        "Rocksteady, Crash Courser - Synergy (Landcycling)",
+        "Jennika, Bad Apple Big Sister - Synergy (Landcycling)",
+        "Zog, Triceraton Castaway - Synergy (Typecycling)",
+        "Bebop, Warthog Warrior - Synergy (Typecycling)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Plainscycling leveraging synergies with Land Types Matter and Cycling."
@@ -18456,7 +20885,7 @@
       ],
       "synergy_commanders": [
         "Atraxa, Praetors' Voice - Synergy (Proliferate)",
-        "The Master, Multiplied - Synergy (Myriad)"
+        "Vraska, Betrayal's Sting - Synergy (Compleated)"
       ],
       "popularity_bucket": "Common",
       "description": "Protects and reuses planeswalkers—amplifying loyalty via proliferate and recursion for inevitability. Synergies like Proliferate and Superfriends reinforce the plan."
@@ -18491,12 +20920,9 @@
         "Dowsing Dagger // Lost Vale"
       ],
       "synergy_commanders": [
-        "The Pride of Hull Clade - Synergy (Defender)",
+        "The Walls of Ba Sing Se - Synergy (Defender)",
         "Sokrates, Athenian Teacher - Synergy (Defender)",
-        "Pramikon, Sky Rampart - Synergy (Defender)",
-        "Rammas Echor, Ancient Shield - Synergy (Wall Kindred)",
-        "Teyo, Geometric Tactician - Synergy (Wall Kindred)",
-        "Tatyova, Benthic Druid - Synergy (Landfall)"
+        "The Goose Mother - Synergy (Hydra Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Plant creatures into play with shared payoffs (e.g., Defender and Wall Kindred)."
@@ -18513,6 +20939,28 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Black",
+      "example_commanders": [
+        "The Necrobloom",
+        "Phylath, World Sculptor",
+        "Grismold, the Dreadsower",
+        "Yuma, Proud Protector",
+        "Bristly Bill, Spine Sower - Synergy (Plant Kindred)"
+      ],
+      "example_cards": [
+        "Avenger of Zendikar",
+        "Insidious Roots",
+        "Dowsing Dagger // Lost Vale",
+        "Khalni Garden",
+        "The Necrobloom",
+        "Phylath, World Sculptor",
+        "Nissa, Voice of Zendikar",
+        "Turntimber Sower"
+      ],
+      "synergy_commanders": [
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Plant Kindred and Creature Tokens reinforce the plan."
     },
@@ -18584,8 +21032,8 @@
         "Grafted Exoskeleton"
       ],
       "synergy_commanders": [
-        "Ixhel, Scion of Atraxa - Synergy (Toxic)",
-        "Vishgraz, the Doomhive - Synergy (Mite Kindred)"
+        "Ixhel, Scion of Atraxa - Synergy (Corrupted)",
+        "Vishgraz, the Doomhive - Synergy (Mite Token)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Leverages Infect/Toxic pressure and proliferate to accelerate poison win thresholds. Synergies like Toxic and Corrupted reinforce the plan."
@@ -18620,7 +21068,7 @@
         "Grasp of Fate"
       ],
       "synergy_commanders": [
-        "Sliver Gravemother - Synergy (Encore)",
+        "Tifa, Martial Artist - Synergy (Melee)",
         "Adriana, Captain of the Guard - Synergy (Melee)",
         "Wulfgar of Icewind Dale - Synergy (Melee)",
         "Tivit, Seller of Secrets - Synergy (Council's dilemma)"
@@ -18658,8 +21106,8 @@
         "Cayth, Famed Mechanist"
       ],
       "synergy_commanders": [
-        "Kiki-Jiki, Mirror Breaker - Synergy (Clones)",
         "Sakashima of a Thousand Faces - Synergy (Clones)",
+        "Kiki-Jiki, Mirror Breaker - Synergy (Clones)",
         "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
         "Talrand, Sky Summoner - Synergy (Creature Tokens)",
         "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
@@ -18704,6 +21152,31 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Human Torch, Johnny Storm",
+        "Nick Fury, Agent of S.H.I.E.L.D.",
+        "Quicksilver, Brash Blur",
+        "Captain Marvel, Earth's Protector",
+        "Loki Laufeyson"
+      ],
+      "example_cards": [
+        "Human Torch, Johnny Storm",
+        "Nick Fury, Agent of S.H.I.E.L.D.",
+        "Quicksilver, Brash Blur",
+        "Captain Marvel, Earth's Protector",
+        "Loki Laufeyson",
+        "Viv Vision, Teen Synthezoid",
+        "Hulk, Gamma Goliath",
+        "Thanos, the Mad Titan"
+      ],
+      "synergy_commanders": [
+        "Deadpool, Trading Card - Synergy (Hero Kindred)",
+        "Gwenom, Remorseless - Synergy (Hero Kindred)",
+        "Iron Spider, Stark Upgrade - Synergy (Hero Kindred)",
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)",
+        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)",
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Builds around Power-up leveraging synergies with Hero Kindred and +1/+1 Counters."
     },
@@ -18739,8 +21212,7 @@
       "synergy_commanders": [
         "Ragavan, Nimble Pilferer - Synergy (Artifact Tokens)",
         "Lotho, Corrupt Shirriff - Synergy (Artifact Tokens)",
-        "Peregrin Took - Synergy (Artifact Tokens)",
-        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Mana Dork)"
+        "Selvala, Heart of the Wilds - Synergy (Mana Dork)"
       ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Artificer Kindred and Artifact Tokens reinforce the plan."
@@ -18751,9 +21223,9 @@
       "synergies": [
         "Phyrexian Kindred",
         "Transform",
+        "Stax",
         "Blink",
-        "Enter the Battlefield",
-        "Stax"
+        "Enter the Battlefield"
       ],
       "primary_color": "Black",
       "secondary_color": "Blue",
@@ -18795,6 +21267,31 @@
       ],
       "primary_color": "Blue",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Sanar, Unfinished Genius // Wild Idea",
+        "Lluwen, Exchange Student // Pest Friend",
+        "Tam, Observant Sequencer // Deep Sight",
+        "Abigale, Poet Laureate // Heroic Stanza",
+        "Kirol, History Buff // Pack a Punch"
+      ],
+      "example_cards": [
+        "Grave Researcher // Reanimate",
+        "Emeritus of Woe // Demonic Tutor",
+        "Studious First-Year // Rampant Growth",
+        "Scheming Silvertongue // Sign in Blood",
+        "Stensian Sanguinist // Exsanguinate",
+        "Harmonized Trio // Brainstorm",
+        "Blazing Firesinger // Seething Song",
+        "Emeritus of Ideation // Ancestral Recall"
+      ],
+      "synergy_commanders": [
+        "Saryth, the Viper's Fang - Synergy (Warlock Kindred)",
+        "Honest Rutstein - Synergy (Warlock Kindred)",
+        "Breena, the Demagogue - Synergy (Warlock Kindred)",
+        "Danitha Capashen, Paragon - Synergy (First strike)",
+        "Gisela, Blade of Goldnight - Synergy (First strike)",
+        "Tatyova, Benthic Druid - Synergy (Druid Kindred)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Prepared leveraging synergies with Wizard Kindred and Toughness Matters."
     },
@@ -18830,7 +21327,8 @@
         "Ulalek, Fused Atrocity - Synergy (Devoid)",
         "Kozilek, Butcher of Truth - Synergy (Eldrazi Kindred)",
         "Ulamog, the Infinite Gyre - Synergy (Eldrazi Kindred)",
-        "Etali, Primal Storm - Synergy (Exile Matters)"
+        "Etali, Primal Storm - Synergy (Exile Matters)",
+        "Ulamog, the Ceaseless Hunger - Synergy (Eldrazi Kindred)"
       ],
       "example_cards": [
         "Ulamog's Nullifier",
@@ -18841,6 +21339,9 @@
         "Wasteland Strangler",
         "Ulamog's Reclaimer",
         "Mind Raker"
+      ],
+      "synergy_commanders": [
+        "Valgavoth, Terror Eater - Synergy (Graveyard Hate)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Processor creatures into play with shared payoffs (e.g., Devoid and Eldrazi Kindred)."
@@ -18965,8 +21466,9 @@
       "synergies": [
         "Protection",
         "Protective Effects",
-        "Human Kindred",
-        "Little Fellas"
+        "Lifegain",
+        "Life Matters",
+        "Human Kindred"
       ],
       "primary_color": "White",
       "secondary_color": "Black",
@@ -18988,9 +21490,10 @@
         "Grave Bramble"
       ],
       "synergy_commanders": [
+        "Animar, Soul of Elements - Synergy (Protection)",
         "Toski, Bearer of Secrets - Synergy (Protective Effects)",
         "Mondrak, Glory Dominus - Synergy (Protective Effects)",
-        "Syr Konrad, the Grim - Synergy (Human Kindred)"
+        "Sheoldred, the Apocalypse - Synergy (Lifegain)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Protection from Creature Type leveraging synergies with Protection and Protective Effects."
@@ -19053,10 +21556,10 @@
       ],
       "synergy_commanders": [
         "Yawgmoth, Thran Physician - Synergy (Protection)",
-        "Greensleeves, Maro-Sorcerer - Synergy (Protection)",
+        "Animar, Soul of Elements - Synergy (Protection)",
         "Toski, Bearer of Secrets - Synergy (Protective Effects)",
         "Mondrak, Glory Dominus - Synergy (Protective Effects)",
-        "Vito, Thorn of the Dusk Rose - Synergy (Cleric Kindred)"
+        "Avacyn, Angel of Hope - Synergy (Interaction)"
       ],
       "popularity_bucket": "Niche",
       "description": "Builds around Protection from Quality leveraging synergies with Protection and Protective Effects."
@@ -19091,9 +21594,9 @@
         "Flawless Maneuver"
       ],
       "synergy_commanders": [
-        "Adrix and Nev, Twincasters - Synergy (Ward)",
-        "Miirym, Sentinel Wyrm - Synergy (Ward)",
-        "Padeem, Consul of Innovation - Synergy (Hexproof)"
+        "Padeem, Consul of Innovation - Synergy (Hexproof)",
+        "Skrelv, Defector Mite - Synergy (Hexproof)",
+        "Valgavoth, Terror Eater - Synergy (Ward)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Builds around Protective Effects leveraging synergies with Indestructible and Hexproof."
@@ -19128,6 +21631,7 @@
         "Arcane Proxy"
       ],
       "synergy_commanders": [
+        "Traxos, Scourge of Kroog - Synergy (Construct Kindred)",
         "Syr Konrad, the Grim - Synergy (Big Mana)"
       ],
       "popularity_bucket": "Rare",
@@ -19160,6 +21664,7 @@
         "Lowland Tracker"
       ],
       "synergy_commanders": [
+        "Sram, Senior Edificer - Synergy (Combat Matters)",
         "Syr Konrad, the Grim - Synergy (Big Mana)"
       ],
       "popularity_bucket": "Rare",
@@ -19197,8 +21702,7 @@
       "synergy_commanders": [
         "Lotho, Corrupt Shirriff - Synergy (Spellslinger)",
         "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Spellslinger)",
-        "Niv-Mizzet, Parun - Synergy (Spellslinger)",
-        "Azusa, Lost but Seeking - Synergy (Monk Kindred)"
+        "Mangara, the Diplomat - Synergy (Spellslinger)"
       ],
       "popularity_bucket": "Rare",
       "description": "Chains cheap instants & sorceries for velocity—converting triggers into scalable damage or card advantage before a finisher. Synergies like Spellslinger and Noncreature Spells reinforce the plan."
@@ -19272,7 +21776,7 @@
         "Aesi, Tyrant of Gyre Strait - Synergy (Landfall)",
         "Bristly Bill, Spine Sower - Synergy (Landfall)",
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
-        "Rishkar, Peema Renegade - Synergy (Counters Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)",
         "Sram, Senior Edificer - Synergy (Enchantments Matter)"
       ],
       "popularity_bucket": "Rare",
@@ -19308,12 +21812,9 @@
         "Preston, the Vanisher"
       ],
       "synergy_commanders": [
-        "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)",
-        "Chatterfang, Squirrel General - Synergy (Warrior Kindred)",
-        "Moraug, Fury of Akoum - Synergy (Warrior Kindred)",
-        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
-        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
-        "Azusa, Lost but Seeking - Synergy (Lands Matter)"
+        "Loran of the Third Path - Synergy (Vigilance)",
+        "Adeline, Resplendent Cathar - Synergy (Vigilance)",
+        "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Rabbit creatures into play with shared payoffs (e.g., Warrior Kindred and Creature Tokens)."
@@ -19329,6 +21830,27 @@
       ],
       "primary_color": "White",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Cadira, Caller of the Small",
+        "Kwain, Itinerant Meddler - Synergy (Rabbit Kindred)",
+        "Baylen, the Haymaker - Synergy (Rabbit Kindred)",
+        "Ms. Bumbleflower - Synergy (Rabbit Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Tempt with Bunnies",
+        "Jacked Rabbit",
+        "Cadira, Caller of the Small",
+        "Hop to It",
+        "Season of the Burrow",
+        "Hare Apparent",
+        "Warren Warleader",
+        "Carrot Cake"
+      ],
+      "synergy_commanders": [
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Rabbit Kindred and Creature Tokens reinforce the plan."
     },
@@ -19362,12 +21884,11 @@
         "Scrapshooter"
       ],
       "synergy_commanders": [
+        "Selvala, Heart of the Wilds - Synergy (Mana Dork)",
+        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Mana Dork)",
+        "Urza, Lord High Artificer - Synergy (Mana Dork)",
         "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)",
-        "Chatterfang, Squirrel General - Synergy (Warrior Kindred)",
-        "Moraug, Fury of Akoum - Synergy (Warrior Kindred)",
-        "Selvala, Heart of the Wilds - Synergy (Blink)",
-        "Sheoldred, Whispering One - Synergy (Blink)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)"
+        "Moraug, Fury of Akoum - Synergy (Warrior Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Raccoon creatures into play with shared payoffs (e.g., Aggro and Combat Matters)."
@@ -19403,6 +21924,7 @@
       ],
       "synergy_commanders": [
         "Deadpool, Trading Card - Synergy (Mutant Kindred)",
+        "Kuja, Genome Sorcerer // Trance Kuja, Fate Defied - Synergy (Mutant Kindred)",
         "Neheb, the Eternal - Synergy (Zombie Kindred)",
         "Mikaeus, the Unhallowed - Synergy (Zombie Kindred)",
         "Syr Konrad, the Grim - Synergy (Mill)"
@@ -19469,9 +21991,9 @@
       ],
       "synergy_commanders": [
         "Malcolm, Alluring Scoundrel - Synergy (Pirate Kindred)",
-        "Lotho, Corrupt Shirriff - Synergy (Outlaw Kindred)",
-        "Saryth, the Viper's Fang - Synergy (Outlaw Kindred)",
-        "Braids, Arisen Nightmare - Synergy (Draw Triggers)"
+        "Plargg and Nassari - Synergy (Orc Kindred)",
+        "Zurgo Stormrender - Synergy (Orc Kindred)",
+        "Lotho, Corrupt Shirriff - Synergy (Outlaw Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Raid leveraging synergies with Pirate Kindred and Outlaw Kindred."
@@ -19505,7 +22027,9 @@
         "Tajuru Warcaller"
       ],
       "synergy_commanders": [
-        "Azusa, Lost but Seeking - Synergy (Little Fellas)"
+        "The Earth King - Synergy (Ally Kindred)",
+        "Syr Konrad, the Grim - Synergy (Human Kindred)",
+        "Azusa, Lost but Seeking - Synergy (Human Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Rally leveraging synergies with Ally Kindred."
@@ -19518,7 +22042,7 @@
         "Land Tutors",
         "Mana Dork",
         "Mana Rock",
-        "Firebend"
+        "Basic landcycling"
       ],
       "primary_color": "Green",
       "secondary_color": "Blue",
@@ -19576,7 +22100,10 @@
         "Horrible Hordes"
       ],
       "synergy_commanders": [
-        "Tatyova, Benthic Druid - Synergy (Big Mana)"
+        "Ghalta, Primal Hunger - Synergy (Big Mana)",
+        "Azusa, Lost but Seeking - Synergy (Toughness Matters)",
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)",
+        "Ragavan, Nimble Pilferer - Synergy (Aggro)"
       ],
       "popularity_bucket": "Rare",
       "description": "Accelerates mana ahead of curve, then converts surplus into oversized threats or multi-spell bursts."
@@ -19612,10 +22139,10 @@
       ],
       "synergy_commanders": [
         "Selvala, Heart of the Wilds - Synergy (Elf Kindred)",
+        "Ayara, First of Locthwain - Synergy (Elf Kindred)",
         "Rishkar, Peema Renegade - Synergy (Elf Kindred)",
-        "Jaheira, Friend of the Forest - Synergy (Elf Kindred)",
         "Delney, Streetwise Lookout - Synergy (Scout Kindred)",
-        "Gwenna, Eyes of Gaea - Synergy (Scout Kindred)",
+        "Ardenn, Intrepid Archaeologist - Synergy (Scout Kindred)",
         "Six - Synergy (Reach)"
       ],
       "popularity_bucket": "Niche",
@@ -19651,10 +22178,8 @@
         "Silver-Fur Master"
       ],
       "synergy_commanders": [
-        "Yuriko, the Tiger's Shadow - Synergy (Ninjutsu)",
-        "Satoru, the Infiltrator - Synergy (Ninja Kindred)",
-        "Satoru Umezawa - Synergy (Ninja Kindred)",
-        "Kiora, the Rising Tide - Synergy (Threshold)"
+        "Vren, the Relentless - Synergy (Rat Token)",
+        "Yuriko, the Tiger's Shadow - Synergy (Ninja Kindred)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Focuses on getting a high number of Rat creatures into play with shared payoffs (e.g., Ninjutsu and Ninja Kindred)."
@@ -19665,12 +22190,36 @@
       "synergies": [
         "Rat Kindred",
         "Creature Tokens",
+        "Rogue Kindred",
         "Token Creation",
-        "Tokens Matter",
-        "Sacrifice Matters"
+        "Tokens Matter"
       ],
       "primary_color": "Black",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Lord Skitter, Sewer King",
+        "Marrow-Gnawer",
+        "Vren, the Relentless",
+        "Totentanz, Swarm Piper",
+        "Rat King, Verminister"
+      ],
+      "example_cards": [
+        "Ogre Slumlord",
+        "Song of Totentanz",
+        "Lord Skitter, Sewer King",
+        "Piper of the Swarm",
+        "Marrow-Gnawer",
+        "Chittering Witch",
+        "Experimental Confectioner",
+        "Lord Skitter's Butcher"
+      ],
+      "synergy_commanders": [
+        "Nashi, Moon Sage's Scion - Synergy (Rat Kindred)",
+        "Ink-Eyes, Servant of Oni - Synergy (Rat Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Rat Kindred and Creature Tokens reinforce the plan."
     },
@@ -19704,7 +22253,7 @@
         "Mawloc"
       ],
       "synergy_commanders": [
-        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)"
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Ravenous leveraging synergies with Tyranid Kindred and X Spells."
@@ -19716,8 +22265,8 @@
         "Spider Kindred",
         "Archer Kindred",
         "Spider Token",
-        "Plant Kindred",
-        "Scientist Kindred"
+        "Ape Kindred",
+        "Plant Kindred"
       ],
       "primary_color": "Green",
       "secondary_color": "White",
@@ -19739,11 +22288,11 @@
         "Nyx Weaver"
       ],
       "synergy_commanders": [
-        "Shelob, Dread Weaver - Synergy (Spider Kindred)",
-        "Shelob, Child of Ungoliant - Synergy (Spider Kindred)",
-        "Legolas Greenleaf - Synergy (Archer Kindred)",
+        "Gwenom, Remorseless - Synergy (Spider Kindred)",
+        "Iron Spider, Stark Upgrade - Synergy (Spider Kindred)",
         "Finneas, Ace Archer - Synergy (Archer Kindred)",
-        "Bristly Bill, Spine Sower - Synergy (Plant Kindred)"
+        "Legolas Greenleaf - Synergy (Archer Kindred)",
+        "Ishkanah, Grafwidow - Synergy (Spider Token)"
       ],
       "popularity_bucket": "Common",
       "description": "Builds around Reach leveraging synergies with Spider Kindred and Archer Kindred."
@@ -19779,7 +22328,8 @@
       ],
       "synergy_commanders": [
         "Urabrask // The Great Work - Synergy (Lore Counters)",
-        "Vorinclex, Monstrous Raider - Synergy (Ore Counters)"
+        "Vorinclex, Monstrous Raider - Synergy (Ore Counters)",
+        "Lae'zel, Vlaakith's Champion - Synergy (Ore Counters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Read Ahead leveraging synergies with Lore Counters and Sagas Matter."
@@ -19814,9 +22364,8 @@
         "Entomb"
       ],
       "synergy_commanders": [
-        "Sheoldred, Whispering One - Synergy (Mill)",
         "Selvala, Heart of the Wilds - Synergy (Enter the Battlefield)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)",
+        "Sheoldred, Whispering One - Synergy (Enter the Battlefield)",
         "Octavia, Living Thesis - Synergy (Graveyard Matters)"
       ],
       "popularity_bucket": "Very Common",
@@ -19852,9 +22401,8 @@
         "Lyse Hext"
       ],
       "synergy_commanders": [
-        "Halvar, God of Battle // Sword of the Realms - Synergy (Equip)",
-        "Toralf, God of Fury // Toralf's Hammer - Synergy (Equip)",
-        "The Reality Chip - Synergy (Equipment)"
+        "Barret, Avalanche Leader - Synergy (Rebel Token)",
+        "Drana, Liberator of Malakir - Synergy (Ally Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Rebel creatures into play with shared payoffs (e.g., For Mirrodin! and Equip)."
@@ -19871,6 +22419,22 @@
       ],
       "primary_color": "Red",
       "secondary_color": "White",
+      "example_commanders": [
+        "Otharri, Suns' Glory",
+        "Barret, Avalanche Leader",
+        "Longshot, Rebel Bowman - Synergy (Rebel Kindred)",
+        "Halvar, God of Battle // Sword of the Realms - Synergy (Equip)"
+      ],
+      "example_cards": [
+        "Otharri, Suns' Glory",
+        "Hexplate Wallbreaker",
+        "Glimmer Lens",
+        "Bladehold War-Whip",
+        "Barret, Avalanche Leader",
+        "Hexgold Halberd",
+        "Kemba's Banner",
+        "Goldwardens' Gambit"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like For Mirrodin! and Rebel Kindred reinforce the plan."
     },
@@ -19904,7 +22468,7 @@
         "Recurring Insight"
       ],
       "synergy_commanders": [
-        "Talrand, Sky Summoner - Synergy (Spellslinger)"
+        "Mangara, the Diplomat - Synergy (Spells Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Uses Rebound to double-cast value spells, banking a delayed second resolution. Synergies like Exile Matters and Spells Matter reinforce the plan."
@@ -19940,7 +22504,8 @@
       ],
       "synergy_commanders": [
         "Toralf, God of Fury // Toralf's Hammer - Synergy (Equipment)",
-        "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)"
+        "Danitha Capashen, Paragon - Synergy (Equipment Matters)",
+        "Yawgmoth, Thran Physician - Synergy (Voltron)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Reconfigure leveraging synergies with Equipment and Equipment Matters."
@@ -19973,7 +22538,8 @@
         "Krovikan Rot"
       ],
       "synergy_commanders": [
-        "Purphoros, God of the Forge - Synergy (Interaction)"
+        "Muldrotha, the Gravetide - Synergy (Graveyard Recursion)",
+        "Uro, Titan of Nature's Wrath - Synergy (Graveyard Recursion)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Recover leveraging synergies with Reanimate and Mill."
@@ -20009,6 +22575,29 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Ezuri, Renegade Leader",
+        "Skithiryx, the Blight Dragon",
+        "Ink-Eyes, Servant of Oni",
+        "Wolverine, Best There Is",
+        "Rhys the Exiled"
+      ],
+      "example_cards": [
+        "Swarmyard",
+        "Nightscape Familiar",
+        "Asceticism",
+        "Golgari Charm",
+        "Dawn Charm",
+        "Wrap in Vigor",
+        "Ezuri, Renegade Leader",
+        "Accursed Duneyard"
+      ],
+      "synergy_commanders": [
+        "Wolverine, Fierce Fighter - Synergy (Heal)",
+        "Gyome, Master Chef - Synergy (Troll Kindred)",
+        "Svella, Ice Shaper - Synergy (Troll Kindred)",
+        "Tinybones, the Pickpocket - Synergy (Skeleton Kindred)"
+      ],
       "popularity_bucket": "Common",
       "description": "Builds around Regenerate leveraging synergies with Heal and Troll Kindred."
     },
@@ -20042,6 +22631,7 @@
         "Mosquito Guard"
       ],
       "synergy_commanders": [
+        "Bristly Bill, Spine Sower - Synergy (Counters Matter)",
         "Sram, Senior Edificer - Synergy (Voltron)"
       ],
       "popularity_bucket": "Rare",
@@ -20077,10 +22667,11 @@
         "Eternal Witness"
       ],
       "synergy_commanders": [
-        "He Who Hungers - Synergy (Soulshift)",
-        "Syr Konrad, the Grim - Synergy (Interaction)",
-        "Purphoros, God of the Forge - Synergy (Interaction)",
-        "Lotho, Corrupt Shirriff - Synergy (Control)"
+        "Avacyn, Angel of Hope - Synergy (Interaction)",
+        "Boromir, Warden of the Tower - Synergy (Interaction)",
+        "Padeem, Consul of Innovation - Synergy (Interaction)",
+        "Valgavoth, Terror Eater - Synergy (Graveyard Hate)",
+        "Idris, Soul of the TARDIS - Synergy (Imprint)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Builds around Removal leveraging synergies with Soulshift and Interaction."
@@ -20115,7 +22706,9 @@
         "Alchemist's Assistant"
       ],
       "synergy_commanders": [
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
+        "Six - Synergy (Mill)",
+        "The Gitrog Monster - Synergy (Reanimate)",
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Renew leveraging synergies with Mill and +1/+1 Counters."
@@ -20150,6 +22743,7 @@
         "Pharika's Disciple"
       ],
       "synergy_commanders": [
+        "Sephiroth, Fabled SOLDIER // Sephiroth, One-Winged Angel - Synergy (Soldier Kindred)",
         "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)",
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
       ],
@@ -20168,6 +22762,26 @@
       ],
       "primary_color": "White",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Sheoldred, the Apocalypse - Synergy (Lifegain)",
+        "Tatyova, Benthic Druid - Synergy (Lifegain)",
+        "Vito, Thorn of the Dusk Rose - Synergy (Lifegain)",
+        "Elas il-Kor, Sadistic Pilgrim - Synergy (Life Matters)",
+        "Mangara, the Diplomat - Synergy (Life Matters)"
+      ],
+      "example_cards": [
+        "Stirring Hopesinger",
+        "Informed Inkwright",
+        "Graduation Day",
+        "Melancholic Poet",
+        "Forum Necroscribe",
+        "Conciliator's Duelist",
+        "Scolding Administrator",
+        "Lecturing Scornmage"
+      ],
+      "synergy_commanders": [
+        "Lotho, Corrupt Shirriff - Synergy (Spells Matter)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Repartee leveraging synergies with Lifegain and Life Matters."
     },
@@ -20196,6 +22810,10 @@
         "Izzet Generatorium",
         "Asmodeus the Archfiend",
         "Island Sanctuary"
+      ],
+      "synergy_commanders": [
+        "Sram, Senior Edificer - Synergy (Enchantments Matter)",
+        "Purphoros, God of the Forge - Synergy (Enchantments Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Replacement Draw leveraging synergies with Card Draw."
@@ -20230,6 +22848,8 @@
         "Stream of Thought"
       ],
       "synergy_commanders": [
+        "Zada, Hedron Grinder - Synergy (Spell Copy)",
+        "Mangara, the Diplomat - Synergy (Control)",
         "Kutzil, Malamet Exemplar - Synergy (Stax)"
       ],
       "popularity_bucket": "Rare",
@@ -20265,7 +22885,8 @@
         "Decoction Module"
       ],
       "synergy_commanders": [
-        "Cayth, Famed Mechanist - Synergy (Servo Kindred)"
+        "Nissa, Worldsoul Speaker - Synergy (Energy Counters)",
+        "Saheeli, the Gifted - Synergy (Servo Token)"
       ],
       "popularity_bucket": "Niche",
       "description": "Builds around Resource Engine leveraging synergies with Energy and Energy Counters."
@@ -20300,7 +22921,9 @@
         "Oona's Grace"
       ],
       "synergy_commanders": [
-        "Niv-Mizzet, Parun - Synergy (Spellslinger)"
+        "Six - Synergy (Graveyard Recursion)",
+        "Muldrotha, the Gravetide - Synergy (Graveyard Recursion)",
+        "Uro, Titan of Nature's Wrath - Synergy (Graveyard Recursion)"
       ],
       "popularity_bucket": "Rare",
       "description": "Turns dead land draws into fuel by recasting Retrace spells for attrition resilience. Synergies like Mill and Spells Matter reinforce the plan."
@@ -20335,7 +22958,9 @@
         "Renegade Rallier"
       ],
       "synergy_commanders": [
-        "Selvala, Heart of the Wilds - Synergy (Blink)"
+        "Selvala, Heart of the Wilds - Synergy (Blink)",
+        "Sheoldred, Whispering One - Synergy (Blink)",
+        "Veyran, Voice of Duality - Synergy (Enter the Battlefield)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Revolt leveraging synergies with Warrior Kindred and +1/+1 Counters."
@@ -20370,11 +22995,11 @@
         "Mr. Orfeo, the Boulder"
       ],
       "synergy_commanders": [
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Trample)",
-        "Ghalta, Stampede Tyrant - Synergy (Trample)",
-        "Boromir, Warden of the Tower - Synergy (Soldier Kindred)",
-        "Anim Pakal, Thousandth Moon - Synergy (Soldier Kindred)",
-        "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)"
+        "W'Kabi, Shield of the Nation - Synergy (Rhino Token)",
+        "Vivien on the Hunt - Synergy (Rhino Token)",
+        "God-Eternal Oketra - Synergy (Warrior Token)",
+        "Zurgo Stormrender - Synergy (Warrior Token)",
+        "Azusa, Lost but Seeking - Synergy (Monk Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Rhino creatures into play with shared payoffs (e.g., Trample and Warrior Kindred)."
@@ -20391,6 +23016,27 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Ghired, Conclave Exile",
+        "W'Kabi, Shield of the Nation",
+        "Mr. Orfeo, the Boulder - Synergy (Rhino Kindred)",
+        "Rocksteady, Mutant Marauder - Synergy (Rhino Kindred)",
+        "God-Eternal Oketra - Synergy (Warrior Token)"
+      ],
+      "example_cards": [
+        "Titan of Industry",
+        "Killer Service",
+        "Vivien on the Hunt",
+        "Ghired, Conclave Exile",
+        "Crash the Party",
+        "Crashing Footfalls",
+        "Workshop Warchief",
+        "Fugitive of the Judoon"
+      ],
+      "synergy_commanders": [
+        "Zurgo Stormrender - Synergy (Warrior Token)",
+        "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Rhino Kindred and Warrior Token reinforce the plan."
     },
@@ -20435,7 +23081,7 @@
         "Zhur-Taa Goblin"
       ],
       "synergy_commanders": [
-        "Yahenni, Undying Partisan - Synergy (Counters Matter)",
+        "Bristly Bill, Spine Sower - Synergy (Counters Matter)",
         "Sram, Senior Edificer - Synergy (Voltron)"
       ],
       "popularity_bucket": "Rare",
@@ -20471,7 +23117,7 @@
         "More Than Meets the Eye",
         "Living metal",
         "Robot Token",
-        "Clown Kindred"
+        "Eye Kindred"
       ],
       "primary_color": "White",
       "secondary_color": "Blue",
@@ -20495,9 +23141,9 @@
       "synergy_commanders": [
         "Starscream, Power Hungry // Starscream, Seeker Leader - Synergy (Convert)",
         "Ratchet, Field Medic // Ratchet, Rescue Racer - Synergy (Convert)",
-        "Blitzwing, Cruel Tormentor // Blitzwing, Adaptive Assailant - Synergy (Living metal)",
-        "Optimus Prime, Hero // Optimus Prime, Autobot Leader - Synergy (Living metal)",
-        "Prowl, Stoic Strategist // Prowl, Pursuit Vehicle - Synergy (More Than Meets the Eye)"
+        "Blitzwing, Cruel Tormentor // Blitzwing, Adaptive Assailant - Synergy (More Than Meets the Eye)",
+        "Optimus Prime, Hero // Optimus Prime, Autobot Leader - Synergy (More Than Meets the Eye)",
+        "Prowl, Stoic Strategist // Prowl, Pursuit Vehicle - Synergy (Living metal)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Robot creatures into play with shared payoffs (e.g., Convert and Living metal)."
@@ -20514,6 +23160,31 @@
       ],
       "primary_color": "Red",
       "secondary_color": "White",
+      "example_commanders": [
+        "Mr. House, President and CEO",
+        "Dyadrine, Synthesis Amalgam",
+        "Ultron, Unlimited",
+        "Doctor Doom",
+        "Sami, Ship's Engineer"
+      ],
+      "example_cards": [
+        "Clown Car",
+        "Secluded Starforge",
+        "Elegy Acolyte",
+        "Big Mother Mouser",
+        "Mr. House, President and CEO",
+        "Kavaron, Memorial World",
+        "Eusocial Engineering",
+        "Automated Assembly Line"
+      ],
+      "synergy_commanders": [
+        "Codsworth, Handy Helper - Synergy (Robot Kindred)",
+        "Kilo, Apogee Mind - Synergy (Robot Kindred)",
+        "Slicer, Hired Muscle // Slicer, High-Speed Antagonist - Synergy (Robot Kindred)",
+        "Ragavan, Nimble Pilferer - Synergy (Artifact Tokens)",
+        "Lotho, Corrupt Shirriff - Synergy (Artifact Tokens)",
+        "Loran of the Third Path - Synergy (Artificer Kindred)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Robot Kindred and Artifact Tokens reinforce the plan."
     },
@@ -20547,8 +23218,10 @@
         "Grim Hireling"
       ],
       "synergy_commanders": [
-        "Ragavan, Nimble Pilferer - Synergy (Outlaw Kindred)",
-        "Raffine, Scheming Seer - Synergy (Connive)"
+        "Gisa, the Hellraiser - Synergy (Rogue Token)",
+        "Alela, Cunning Conqueror - Synergy (Rogue Token)",
+        "Baron Bertram Graywater - Synergy (Rogue Token)",
+        "Ragavan, Nimble Pilferer - Synergy (Outlaw Kindred)"
       ],
       "popularity_bucket": "Common",
       "description": "Focuses on getting a high number of Rogue creatures into play with shared payoffs (e.g., Prowl and Outlaw Kindred)."
@@ -20565,6 +23238,29 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Gisa, the Hellraiser",
+        "Alela, Cunning Conqueror",
+        "Baron Bertram Graywater",
+        "Oona, Queen of the Fae",
+        "Geralf, the Fleshwright"
+      ],
+      "example_cards": [
+        "Bitterblossom",
+        "Currency Converter",
+        "Gisa, the Hellraiser",
+        "Alela, Cunning Conqueror",
+        "Notorious Throng",
+        "Baron Bertram Graywater",
+        "Oona, Queen of the Fae",
+        "Shadow Puppeteers"
+      ],
+      "synergy_commanders": [
+        "Alela, Artful Provocateur - Synergy (Faerie Token)",
+        "Rankle, Master of Pranks - Synergy (Faerie Kindred)",
+        "Talion, the Kindly Lord - Synergy (Faerie Kindred)",
+        "Lotho, Corrupt Shirriff - Synergy (Rogue Kindred)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Faerie Token and Faerie Kindred reinforce the plan."
     },
@@ -20587,11 +23283,11 @@
       "id": "role-token",
       "theme": "Role token",
       "synergies": [
-        "Enchantment Tokens",
-        "Hero Kindred",
-        "Equipment Matters",
-        "Auras",
-        "Scry"
+        "Wicked Role Token",
+        "Monster Role Token",
+        "Cursed Role Token",
+        "Young Hero Role Token",
+        "Enchantment Tokens"
       ],
       "primary_color": "Black",
       "secondary_color": "White",
@@ -20611,11 +23307,6 @@
         "Asinine Antics",
         "Twisted Sewer-Witch",
         "Giant Inheritance"
-      ],
-      "synergy_commanders": [
-        "Deadpool, Trading Card - Synergy (Hero Kindred)",
-        "G'raha Tia, Scion Reborn - Synergy (Hero Kindred)",
-        "Sram, Senior Edificer - Synergy (Equipment Matters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Enchantment Tokens and Equipment Matters reinforce the plan."
@@ -20663,6 +23354,9 @@
         "Unholy Annex // Ritual Chamber",
         "Charred Foyer // Warped Space"
       ],
+      "synergy_commanders": [
+        "Kodama of the West Tree - Synergy (Spirit Kindred)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Rooms Matter leveraging synergies with Eerie and Enchantments Matter."
     },
@@ -20694,10 +23388,6 @@
         "Village Rites",
         "Zulaport Cutthroat",
         "Syr Konrad, the Grim"
-      ],
-      "synergy_commanders": [
-        "Zabaz, the Glimmerwasp - Synergy (Modular)",
-        "Blaster, Combat DJ // Blaster, Morale Booster - Synergy (Modular)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Leverages sacrifice outlets and death triggers to grind incremental value and drain opponents. Synergies like Persist and Modular reinforce the plan."
@@ -20734,7 +23424,10 @@
       "synergy_commanders": [
         "Lonis, Cryptozoologist - Synergy (Clue Token)",
         "Astrid Peth - Synergy (Clue Token)",
-        "Tivit, Seller of Secrets - Synergy (Investigate)"
+        "Piper Wright, Publick Reporter - Synergy (Clue Token)",
+        "Kellan, Inquisitive Prodigy // Tail the Suspect - Synergy (Investigate)",
+        "Tivit, Seller of Secrets - Synergy (Investigate)",
+        "G'raha Tia, Scion Reborn - Synergy (Gates Matter)"
       ],
       "popularity_bucket": "Common",
       "description": "Leverages sacrifice outlets and death triggers to grind incremental value and drain opponents. Synergies like Clue Token and Investigate reinforce the plan."
@@ -20770,7 +23463,8 @@
       ],
       "synergy_commanders": [
         "Keleth, Sunmane Familiar - Synergy (Horse Kindred)",
-        "Bill the Pony - Synergy (Horse Kindred)"
+        "Bill the Pony - Synergy (Horse Kindred)",
+        "Loot, Exuberant Explorer - Synergy (Beast Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Saddle leveraging synergies with Mount Kindred and Aggro."
@@ -20783,7 +23477,7 @@
         "Read Ahead",
         "Ore Counters",
         "Doctor's Companion",
-        "Doctor Kindred"
+        "Doctor's companion"
       ],
       "primary_color": "White",
       "secondary_color": "Blue",
@@ -20844,7 +23538,8 @@
       "synergy_commanders": [
         "Ragavan, Nimble Pilferer - Synergy (Little Fellas)",
         "Azusa, Lost but Seeking - Synergy (Little Fellas)",
-        "Toski, Bearer of Secrets - Synergy (Little Fellas)",
+        "Loran of the Third Path - Synergy (Little Fellas)",
+        "Six - Synergy (Mill)",
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
       ],
       "popularity_bucket": "Rare",
@@ -20883,9 +23578,9 @@
         "Toshiro Umezawa - Synergy (Bushido)",
         "Konda, Lord of Eiganjo - Synergy (Bushido)",
         "Sensei Golden-Tail - Synergy (Bushido)",
-        "Pearl-Ear, Imperial Advisor - Synergy (Fox Kindred)",
-        "Light-Paws, Emperor's Voice - Synergy (Fox Kindred)",
-        "Sram, Senior Edificer - Synergy (Equipment Matters)"
+        "Naomi, Pillar of Order - Synergy (Samurai Token)",
+        "The Eternal Wanderer - Synergy (Samurai Token)",
+        "Pearl-Ear, Imperial Advisor - Synergy (Fox Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Samurai creatures into play with shared payoffs (e.g., Bushido and Fox Kindred)."
@@ -20901,6 +23596,26 @@
       ],
       "primary_color": "White",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Naomi, Pillar of Order",
+        "Isshin, Two Heavens as One - Synergy (Samurai Kindred)",
+        "Goro-Goro, Disciple of Ryusei - Synergy (Samurai Kindred)",
+        "Godo, Bandit Warlord - Synergy (Samurai Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "The Eternal Wanderer",
+        "The Wandering Emperor",
+        "Experimental Synthesizer",
+        "Banishing Slash",
+        "Eiganjo Uprising",
+        "Imperial Oath",
+        "Naomi, Pillar of Order"
+      ],
+      "synergy_commanders": [
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Samurai Kindred and Creature Tokens reinforce the plan."
     },
@@ -20928,6 +23643,16 @@
       "synergies": [],
       "primary_color": "White",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Hazezon, Shaper of Sand",
+        "Hazezon Tamar"
+      ],
+      "example_cards": [
+        "Sand Scout",
+        "Hazezon, Shaper of Sand",
+        "Dune-Brood Nephilim",
+        "Hazezon Tamar"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines."
     },
@@ -20962,8 +23687,7 @@
       ],
       "synergy_commanders": [
         "Thelon of Havenwood - Synergy (Spore Counters)",
-        "The Mycotyrant - Synergy (Fungus Kindred)",
-        "Vorinclex, Monstrous Raider - Synergy (Ore Counters)"
+        "The Mycotyrant - Synergy (Fungus Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Saproling creatures into play with shared payoffs (e.g., Spore Counters and Fungus Kindred)."
@@ -20980,6 +23704,28 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Nemata, Primeval Warden",
+        "Slimefoot, the Stowaway",
+        "Verdeloth the Ancient",
+        "Nemata, Grove Guardian",
+        "Slimefoot and Squee"
+      ],
+      "example_cards": [
+        "Tendershoot Dryad",
+        "Mycoloth",
+        "Artifact Mutation",
+        "Aura Mutation",
+        "Brightcap Badger // Fungus Frolic",
+        "Sporemound",
+        "Nemata, Primeval Warden",
+        "Utopia Mycon"
+      ],
+      "synergy_commanders": [
+        "Shroofus Sproutsire - Synergy (Saproling Kindred)",
+        "Thelon of Havenwood - Synergy (Spore Counters)",
+        "The Mycotyrant - Synergy (Fungus Kindred)"
+      ],
       "popularity_bucket": "Uncommon",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Saproling Kindred and Spore Counters reinforce the plan."
     },
@@ -21015,7 +23761,9 @@
       "synergy_commanders": [
         "Syr Konrad, the Grim - Synergy (Sacrifice Matters)",
         "Braids, Arisen Nightmare - Synergy (Sacrifice Matters)",
-        "Tatyova, Benthic Druid - Synergy (Lands Matter)"
+        "Sheoldred, the Apocalypse - Synergy (Sacrifice Matters)",
+        "Elas il-Kor, Sadistic Pilgrim - Synergy (Aristocrats)",
+        "Yawgmoth, Thran Physician - Synergy (Aristocrats)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Satyr creatures into play with shared payoffs (e.g., Ramp and Lands Matter)."
@@ -21030,6 +23778,24 @@
       ],
       "primary_color": "Red",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Anax, Hardened in the Forge",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Urza, Lord High Artificer - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
+      "example_cards": [
+        "Xenagos, the Reveler",
+        "Anax, Hardened in the Forge",
+        "Satyr's Cunning",
+        "Revel of the Fallen God",
+        "Heroes of the Revel"
+      ],
+      "synergy_commanders": [
+        "Lotho, Corrupt Shirriff - Synergy (Token Creation)",
+        "Mondrak, Glory Dominus - Synergy (Tokens Matter)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Creature Tokens and Token Creation reinforce the plan."
     },
@@ -21048,7 +23814,9 @@
       "example_commanders": [
         "Rendmaw, Creaking Nest",
         "The Swarmweaver",
-        "Reaper King"
+        "Reaper King",
+        "Yawgmoth, Thran Physician - Synergy (-1/-1 Counters)",
+        "Vorinclex, Monstrous Raider - Synergy (-1/-1 Counters)"
       ],
       "example_cards": [
         "Scaretiller",
@@ -21059,6 +23827,12 @@
         "Scarecrone",
         "Scuttlemutt",
         "Osseous Sticktwister"
+      ],
+      "synergy_commanders": [
+        "Tekuthal, Inquiry Dominus - Synergy (-1/-1 Counters)",
+        "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)",
+        "Loran of the Third Path - Synergy (Artifacts Matter)",
+        "Azusa, Lost but Seeking - Synergy (Ramp)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Scarecrow creatures into play with shared payoffs."
@@ -21093,7 +23867,9 @@
         "Sewer Shambler"
       ],
       "synergy_commanders": [
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
+        "Six - Synergy (Graveyard Recursion)",
+        "Muldrotha, the Gravetide - Synergy (Graveyard Recursion)",
+        "Uro, Titan of Nature's Wrath - Synergy (Graveyard Recursion)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Scavenge leveraging synergies with +1/+1 Counters and Mill."
@@ -21128,12 +23904,12 @@
         "Ian Chesterton"
       ],
       "synergy_commanders": [
-        "Azusa, Lost but Seeking - Synergy (Toughness Matters)",
-        "Sheoldred, the Apocalypse - Synergy (Toughness Matters)",
-        "Vito, Thorn of the Dusk Rose - Synergy (Toughness Matters)",
-        "Syr Konrad, the Grim - Synergy (Human Kindred)",
-        "Loran of the Third Path - Synergy (Human Kindred)",
-        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
+        "Deadpool, Trading Card - Synergy (Hero Kindred)",
+        "Gwenom, Remorseless - Synergy (Hero Kindred)",
+        "Iron Spider, Stark Upgrade - Synergy (Hero Kindred)",
+        "Codsworth, Handy Helper - Synergy (Robot Kindred)",
+        "Kilo, Apogee Mind - Synergy (Robot Kindred)",
+        "Six - Synergy (Reach)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Scientist creatures into play with shared payoffs (e.g., Human Kindred and Toughness Matters)."
@@ -21182,6 +23958,20 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Kiora, the Rising Tide - Synergy (Scion Kindred)",
+        "Ulalek, Fused Atrocity - Synergy (Devoid)"
+      ],
+      "example_cards": [
+        "Warping Wail",
+        "Eldrazi Confluence",
+        "Spawnbed Protector",
+        "Sifter of Skulls",
+        "Spawning Bed",
+        "From Beyond",
+        "Drowner of Hope",
+        "Carrier Thrall"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Scion Kindred and Eldrazi Token reinforce the plan."
     },
@@ -21216,9 +24006,9 @@
       ],
       "synergy_commanders": [
         "The Gitrog Monster - Synergy (Deathtouch)",
-        "Selvala, Heart of the Wilds - Synergy (Blink)",
-        "Sheoldred, Whispering One - Synergy (Blink)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)"
+        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)",
+        "Azusa, Lost but Seeking - Synergy (Little Fellas)",
+        "Selvala, Heart of the Wilds - Synergy (Blink)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Scorpion creatures into play with shared payoffs (e.g., Deathtouch and Blink)."
@@ -21305,8 +24095,8 @@
         "Temple of Mystery"
       ],
       "synergy_commanders": [
-        "The Reality Chip - Synergy (Topdeck)",
         "Loot, Exuberant Explorer - Synergy (Topdeck)",
+        "The Reality Chip - Synergy (Topdeck)",
         "Kinnan, Bonder Prodigy - Synergy (Topdeck)",
         "Ellivere of the Wild Court - Synergy (Role token)",
         "Gylwain, Casting Director - Synergy (Role token)",
@@ -21387,12 +24177,12 @@
         "Xolatoyac, the Smiling Flood"
       ],
       "synergy_commanders": [
-        "The Balrog of Moria - Synergy (Cycling)",
-        "Monstrosity of the Lake - Synergy (Cycling)",
-        "Yidaro, Wandering Monster - Synergy (Cycling)",
-        "Ghalta, Primal Hunger - Synergy (Cost Reduction)",
-        "Emry, Lurker of the Loch - Synergy (Cost Reduction)",
-        "Kutzil, Malamet Exemplar - Synergy (Stax)"
+        "Arixmethes, Slumbering Isle - Synergy (Kraken Kindred)",
+        "Gyruda, Doom of Depths - Synergy (Kraken Kindred)",
+        "Tromokratis - Synergy (Kraken Kindred)",
+        "Charix, the Raging Isle - Synergy (Leviathan Kindred)",
+        "Slinn Voda, the Rising Deep - Synergy (Leviathan Kindred)",
+        "Kiora, the Rising Tide - Synergy (Octopus Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Serpent creatures into play with shared payoffs (e.g., Cost Reduction and Stax)."
@@ -21426,9 +24216,6 @@
         "Retrofitter Foundry",
         "Hidden Stockpile"
       ],
-      "synergy_commanders": [
-        "Dr. Madison Li - Synergy (Energy Counters)"
-      ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Servo creatures into play with shared payoffs (e.g., Fabricate and Artificer Kindred)."
     },
@@ -21444,6 +24231,26 @@
       ],
       "primary_color": "White",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Saheeli, the Gifted",
+        "Oviya Pashiri, Sage Lifecrafter",
+        "Cayth, Famed Mechanist - Synergy (Servo Kindred)",
+        "Satya, Aetherflux Genius - Synergy (Energy Counters)",
+        "Dr. Madison Li - Synergy (Energy Counters)"
+      ],
+      "example_cards": [
+        "Saheeli, Sublime Artificer",
+        "Animation Module",
+        "Retrofitter Foundry",
+        "Servo Schematic",
+        "Sram's Expertise",
+        "Hidden Stockpile",
+        "Saheeli, the Gifted",
+        "Nesting Bot"
+      ],
+      "synergy_commanders": [
+        "Liberty Prime, Recharged - Synergy (Energy)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Servo Kindred and Energy Counters reinforce the plan."
     },
@@ -21476,8 +24283,9 @@
         "Chilling Shade"
       ],
       "synergy_commanders": [
-        "Avacyn, Angel of Hope - Synergy (Flying)",
-        "Sheoldred, the Apocalypse - Synergy (Toughness Matters)"
+        "Loran of the Third Path - Synergy (Little Fellas)",
+        "Tatyova, Benthic Druid - Synergy (Lands Matter)",
+        "Six - Synergy (Lands Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Shade creatures into play with shared payoffs (e.g., Little Fellas and Flying)."
@@ -21489,11 +24297,16 @@
         "Dauthi Kindred",
         "Soltari Kindred",
         "Thalakos Kindred",
-        "Soldier Kindred",
-        "Aggro"
+        "Cleric Kindred",
+        "Soldier Kindred"
       ],
       "primary_color": "Black",
       "secondary_color": "White",
+      "example_commanders": [
+        "The Weaver King",
+        "Lyna, Veil of Vengeance",
+        "Boss Uramon, Shadow's Reach"
+      ],
       "example_cards": [
         "Dauthi Voidwalker",
         "Nether Traitor",
@@ -21537,9 +24350,7 @@
         "Ignoble Hierarch"
       ],
       "synergy_commanders": [
-        "Moraug, Fury of Akoum - Synergy (Minotaur Kindred)",
-        "Neheb, the Eternal - Synergy (Minotaur Kindred)",
-        "Gyome, Master Chef - Synergy (Troll Kindred)"
+        "Veyran, Voice of Duality - Synergy (Magecraft)"
       ],
       "popularity_bucket": "Common",
       "description": "Focuses on getting a high number of Shaman creatures into play with shared payoffs (e.g., Goblin Kindred and Minotaur Kindred)."
@@ -21555,6 +24366,23 @@
       ],
       "primary_color": "Red",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Kiki-Jiki, Mirror Breaker - Synergy (Shaman Kindred)",
+        "Meren of Clan Nel Toth - Synergy (Shaman Kindred)",
+        "Ashling, Flame Dancer - Synergy (Shaman Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Fable of the Mirror-Breaker // Reflection of Kiki-Jiki",
+        "Reach of Branches",
+        "Hostility",
+        "Hearthcage Giant",
+        "Rebellion of the Flamekin"
+      ],
+      "synergy_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Shaman Kindred and Creature Tokens reinforce the plan."
     },
@@ -21588,9 +24416,7 @@
         "Glasspool Mimic // Glasspool Shore"
       ],
       "synergy_commanders": [
-        "Mondrak, Glory Dominus - Synergy (Clones)",
-        "Kiki-Jiki, Mirror Breaker - Synergy (Clones)",
-        "Liberator, Urza's Battlethopter - Synergy (Flash)"
+        "Mondrak, Glory Dominus - Synergy (Clones)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Shapeshifter creatures into play with shared payoffs (e.g., Changeling and Clones)."
@@ -21606,6 +24432,26 @@
       ],
       "primary_color": "White",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Morophon, the Boundless - Synergy (Shapeshifter Kindred)",
+        "Chameleon, Master of Disguise - Synergy (Shapeshifter Kindred)",
+        "Irma, Part-Time Mutant - Synergy (Shapeshifter Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Black Market Connections",
+        "Maskwood Nexus",
+        "Springleaf Parade",
+        "Crib Swap",
+        "Abundant Countryside",
+        "Irregular Cohort",
+        "Formless Genesis",
+        "Personify"
+      ],
+      "synergy_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Shapeshifter Kindred and Creature Tokens reinforce the plan."
     },
@@ -21615,6 +24461,16 @@
       "synergies": [],
       "primary_color": "White",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Niko, Light of Hope"
+      ],
+      "example_cards": [
+        "Niko, Light of Hope",
+        "Niko Aris",
+        "Powerstone Shard",
+        "Marrow Shards",
+        "Shard Volley"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines."
     },
@@ -21649,10 +24505,11 @@
       ],
       "synergy_commanders": [
         "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Discard Matters)",
-        "Solphim, Mayhem Dominus - Synergy (Discard Matters)",
         "Yawgmoth, Thran Physician - Synergy (Discard Matters)",
-        "Lotho, Corrupt Shirriff - Synergy (Stax)",
-        "Braids, Arisen Nightmare - Synergy (Card Draw)"
+        "Solphim, Mayhem Dominus - Synergy (Discard Matters)",
+        "Ragavan, Nimble Pilferer - Synergy (Outlaw Kindred)",
+        "Lotho, Corrupt Shirriff - Synergy (Outlaw Kindred)",
+        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Shark creatures into play with shared payoffs (e.g., Stax and Toughness Matters)."
@@ -21668,6 +24525,13 @@
       ],
       "primary_color": "White",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Selvala, Heart of the Wilds - Synergy (Blink)",
+        "Sheoldred, Whispering One - Synergy (Blink)",
+        "Veyran, Voice of Duality - Synergy (Blink)",
+        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)",
+        "Kodama of the East Tree - Synergy (Enter the Battlefield)"
+      ],
       "example_cards": [
         "Enduring Innocence",
         "Nyx-Fleece Ram",
@@ -21676,6 +24540,9 @@
         "Ovinomancer",
         "Baaallerina",
         "Rustspore Ram"
+      ],
+      "synergy_commanders": [
+        "Elesh Norn, Mother of Machines - Synergy (Leave the Battlefield)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Sheep creatures into play with shared payoffs."
@@ -21710,11 +24577,11 @@
         "Falco Spara, Pactweaver"
       ],
       "synergy_commanders": [
+        "Peregrin Took - Synergy (Citizen Kindred)",
+        "The Cabbage Merchant - Synergy (Citizen Kindred)",
+        "Ms. Bumbleflower - Synergy (Citizen Kindred)",
         "Anim Pakal, Thousandth Moon - Synergy (Soldier Kindred)",
-        "Thalia, Heretic Cathar - Synergy (Soldier Kindred)",
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
-        "Rishkar, Peema Renegade - Synergy (Counters Matter)",
-        "Tatyova, Benthic Druid - Synergy (Lifegain)"
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Applies shield counters to insulate threats and create lopsided removal trades. Synergies like Soldier Kindred and Counters Matter reinforce the plan."
@@ -21751,7 +24618,10 @@
       "synergy_commanders": [
         "Sram, Senior Edificer - Synergy (Enchantments Matter)",
         "Purphoros, God of the Forge - Synergy (Enchantments Matter)",
-        "Jaheira, Friend of the Forest - Synergy (Enchantments Matter)"
+        "Danitha Capashen, Paragon - Synergy (Enchantments Matter)",
+        "Selvala, Heart of the Wilds - Synergy (Blink)",
+        "Sheoldred, Whispering One - Synergy (Blink)",
+        "Veyran, Voice of Duality - Synergy (Enter the Battlefield)"
       ],
       "popularity_bucket": "Rare",
       "description": "Accumulates Shrines whose upkeep triggers scale multiplicatively into inevitability. Synergies like Enchantments Matter reinforce the plan."
@@ -21789,9 +24659,9 @@
         "Toski, Bearer of Secrets - Synergy (Protective Effects)",
         "Mondrak, Glory Dominus - Synergy (Protective Effects)",
         "Purphoros, God of the Forge - Synergy (Protective Effects)",
-        "The Locust God - Synergy (Insect Kindred)",
         "Mazirek, Kraul Death Priest - Synergy (Insect Kindred)",
-        "Loot, Exuberant Explorer - Synergy (Beast Kindred)"
+        "The Locust God - Synergy (Insect Kindred)",
+        "Katilda, Dawnhart Martyr // Katilda's Rising Dawn - Synergy (Enchant)"
       ],
       "popularity_bucket": "Niche",
       "description": "Builds around Shroud leveraging synergies with Protective Effects and Insect Kindred."
@@ -21827,7 +24697,7 @@
       "synergy_commanders": [
         "Captain Lannery Storm - Synergy (Pirate Kindred)",
         "Lotho, Corrupt Shirriff - Synergy (Outlaw Kindred)",
-        "Saryth, the Viper's Fang - Synergy (Outlaw Kindred)",
+        "Sakashima of a Thousand Faces - Synergy (Outlaw Kindred)",
         "Niv-Mizzet, Parun - Synergy (Flying)"
       ],
       "popularity_bucket": "Rare",
@@ -21863,12 +24733,10 @@
         "Tinybones, Bauble Burglar"
       ],
       "synergy_commanders": [
-        "Etali, Primal Storm - Synergy (Exile Matters)",
-        "Ragavan, Nimble Pilferer - Synergy (Exile Matters)",
-        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Exile Matters)",
-        "Syr Konrad, the Grim - Synergy (Mill)",
-        "Emry, Lurker of the Loch - Synergy (Mill)",
-        "Lotho, Corrupt Shirriff - Synergy (Outlaw Kindred)"
+        "Gut, True Soul Zealot - Synergy (Skeleton Token)",
+        "Wolverine, Best There Is - Synergy (Heal)",
+        "Wolverine, Fierce Fighter - Synergy (Heal)",
+        "Ezuri, Renegade Leader - Synergy (Regenerate)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Skeleton creatures into play with shared payoffs (e.g., Exile Matters and Mill)."
@@ -21885,6 +24753,27 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Gut, True Soul Zealot",
+        "Tinybones, the Pickpocket - Synergy (Skeleton Kindred)",
+        "Skithiryx, the Blight Dragon - Synergy (Skeleton Kindred)",
+        "Tinybones, Bauble Burglar - Synergy (Skeleton Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Skeleton Crew",
+        "Case of the Stashed Skeleton",
+        "Gut, True Soul Zealot",
+        "Altar of Bhaal // Bone Offering",
+        "Death-Priest of Myrkul",
+        "Corpses of the Lost",
+        "Skeletal Swarming",
+        "Skeletonize"
+      ],
+      "synergy_commanders": [
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Skeleton Kindred and Creature Tokens reinforce the plan."
     },
@@ -21916,9 +24805,9 @@
         "Cybermat"
       ],
       "synergy_commanders": [
+        "Loran of the Third Path - Synergy (Little Fellas)",
         "Etali, Primal Storm - Synergy (Aggro)",
-        "Kutzil, Malamet Exemplar - Synergy (Aggro)",
-        "Sheoldred, the Apocalypse - Synergy (Combat Matters)"
+        "Kutzil, Malamet Exemplar - Synergy (Combat Matters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Skulk leveraging synergies with Little Fellas and Aggro."
@@ -21928,6 +24817,9 @@
       "theme": "Skunk Kindred",
       "synergies": [],
       "primary_color": "Black",
+      "example_commanders": [
+        "Olinda the Oblivious"
+      ],
       "example_cards": [
         "Downwind Ambusher"
       ],
@@ -21980,6 +24872,7 @@
         "Slith Bloodletter"
       ],
       "synergy_commanders": [
+        "Bristly Bill, Spine Sower - Synergy (Counters Matter)",
         "Sram, Senior Edificer - Synergy (Voltron)"
       ],
       "popularity_bucket": "Rare",
@@ -22013,11 +24906,11 @@
         "Diffusion Sliver"
       ],
       "synergy_commanders": [
+        "Sliver Queen - Synergy (Sliver Token)",
+        "Rukarumel, Biologist - Synergy (Sliver Token)",
         "Ragavan, Nimble Pilferer - Synergy (Little Fellas)",
         "Azusa, Lost but Seeking - Synergy (Little Fellas)",
-        "Toski, Bearer of Secrets - Synergy (Little Fellas)",
-        "Syr Konrad, the Grim - Synergy (Pingers)",
-        "Elas il-Kor, Sadistic Pilgrim - Synergy (Pingers)"
+        "Syr Konrad, the Grim - Synergy (Pingers)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Sliver creatures into play with shared payoffs (e.g., Little Fellas and Burn)."
@@ -22033,6 +24926,28 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Sliver Queen",
+        "Rukarumel, Biologist",
+        "Sliver Hivelord - Synergy (Sliver Kindred)",
+        "The First Sliver - Synergy (Sliver Kindred)",
+        "Sliver Legion - Synergy (Sliver Kindred)"
+      ],
+      "example_cards": [
+        "Sliver Hive",
+        "Thrumming Hivepool",
+        "Brood Sliver",
+        "Lazotep Sliver",
+        "Sliver Queen",
+        "Rukarumel, Biologist",
+        "Hive Stirrings",
+        "Sliversmith"
+      ],
+      "synergy_commanders": [
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Sliver Kindred and Creature Tokens reinforce the plan."
     },
@@ -22046,6 +24961,13 @@
       ],
       "primary_color": "Green",
       "secondary_color": "White",
+      "example_commanders": [
+        "Loot, Exuberant Explorer - Synergy (Beast Kindred)",
+        "Kona, Rescue Beastie - Synergy (Beast Kindred)",
+        "Questing Beast - Synergy (Beast Kindred)",
+        "Etali, Primal Storm - Synergy (Aggro)",
+        "Ragavan, Nimble Pilferer - Synergy (Aggro)"
+      ],
       "example_cards": [
         "Arboreal Grazer",
         "Lumbering Megasloth",
@@ -22054,6 +24976,9 @@
         "Hungry Megasloth",
         "Relic Sloth",
         "Aardvark Sloth"
+      ],
+      "synergy_commanders": [
+        "Toski, Bearer of Secrets - Synergy (Combat Matters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Sloth creatures into play with shared payoffs."
@@ -22083,6 +25008,11 @@
         "Catacomb Slug",
         "Giant Slug",
         "Spitting Slug"
+      ],
+      "synergy_commanders": [
+        "Syr Konrad, the Grim - Synergy (Big Mana)",
+        "Etali, Primal Storm - Synergy (Big Mana)",
+        "Ghalta, Primal Hunger - Synergy (Big Mana)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Slug creatures into play with shared payoffs (e.g., Little Fellas)."
@@ -22132,12 +25062,12 @@
         "Enduring Tenacity"
       ],
       "synergy_commanders": [
+        "Hapatra, Vizier of Poisons - Synergy (Snake Token)",
+        "Xyris, the Writhing Storm - Synergy (Snake Token)",
+        "Pharika, God of Affliction - Synergy (Snake Token)",
         "Sheoldred, Whispering One - Synergy (Swampwalk)",
         "Wrexial, the Risen Deep - Synergy (Swampwalk)",
-        "Sol'kanar the Swamp King - Synergy (Swampwalk)",
-        "Sheoldred, the Apocalypse - Synergy (Deathtouch)",
-        "Elas il-Kor, Sadistic Pilgrim - Synergy (Deathtouch)",
-        "Legolas Greenleaf - Synergy (Archer Kindred)"
+        "Sheoldred, the Apocalypse - Synergy (Deathtouch)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Focuses on getting a high number of Snake creatures into play with shared payoffs (e.g., Swampwalk and Deathtouch)."
@@ -22154,6 +25084,30 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Hapatra, Vizier of Poisons",
+        "Xyris, the Writhing Storm",
+        "Pharika, God of Affliction",
+        "Aphelia, Viper Whisperer",
+        "Shigeki, Jukai Visionary - Synergy (Snake Kindred)"
+      ],
+      "example_cards": [
+        "Ophiomancer",
+        "Hooded Hydra",
+        "Hapatra, Vizier of Poisons",
+        "Xyris, the Writhing Storm",
+        "Pharika, God of Affliction",
+        "Aphelia, Viper Whisperer",
+        "Orochi Hatchery",
+        "Snake Pit"
+      ],
+      "synergy_commanders": [
+        "Imoti, Celebrant of Bounty - Synergy (Snake Kindred)",
+        "Sidisi, Undead Vizier - Synergy (Snake Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Snake Kindred and Creature Tokens reinforce the plan."
     },
@@ -22169,6 +25123,31 @@
       ],
       "primary_color": "Black",
       "secondary_color": "White",
+      "example_commanders": [
+        "Raphael, the Nightwatcher",
+        "Dark Leo & Shredder",
+        "Shark Shredder, Killer Clone",
+        "Leonardo, Cutting Edge",
+        "Donatello, Gadget Master"
+      ],
+      "example_cards": [
+        "Splinter's Technique",
+        "Raphael, the Nightwatcher",
+        "Shredder's Technique",
+        "Dark Leo & Shredder",
+        "Shark Shredder, Killer Clone",
+        "Kitsune's Technique",
+        "Leonardo, Cutting Edge",
+        "Donatello, Gadget Master"
+      ],
+      "synergy_commanders": [
+        "Nashi, Moon Sage's Scion - Synergy (Ninja Kindred)",
+        "Yuriko, the Tiger's Shadow - Synergy (Ninja Kindred)",
+        "Ink-Eyes, Servant of Oni - Synergy (Ninja Kindred)",
+        "Kogla and Yidaro - Synergy (Turtle Kindred)",
+        "The Pride of Hull Clade - Synergy (Turtle Kindred)",
+        "Deadpool, Trading Card - Synergy (Mutant Kindred)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Sneak leveraging synergies with Ninja Kindred and Turtle Kindred."
     },
@@ -22202,12 +25181,11 @@
         "Charismatic Conqueror"
       ],
       "synergy_commanders": [
+        "Caesar, Legion's Emperor - Synergy (Soldier Token)",
+        "Abdel Adrian, Gorion's Ward - Synergy (Soldier Token)",
         "Lu Xun, Scholar General - Synergy (Horsemanship)",
         "Xiahou Dun, the One-Eyed - Synergy (Horsemanship)",
-        "Lu Bu, Master-at-Arms - Synergy (Horsemanship)",
-        "Paladin Elizabeth Taggerdy - Synergy (Battalion)",
-        "Sentinel Sarah Lyons - Synergy (Battalion)",
-        "Danny Pink - Synergy (Mentor)"
+        "Paladin Elizabeth Taggerdy - Synergy (Battalion)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Focuses on getting a high number of Soldier creatures into play with shared payoffs (e.g., Horsemanship and Banding)."
@@ -22224,6 +25202,29 @@
       ],
       "primary_color": "White",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Myrel, Shield of Argive",
+        "Caesar, Legion's Emperor",
+        "Abdel Adrian, Gorion's Ward",
+        "Brimaz, King of Oreskos",
+        "Aragorn, the Uniter"
+      ],
+      "example_cards": [
+        "Bastion of Remembrance",
+        "Elspeth, Storm Slayer",
+        "Elspeth, Sun's Champion",
+        "Keeper of the Accord",
+        "Third Path Iconoclast",
+        "Martial Coup",
+        "Myrel, Shield of Argive",
+        "Call the Coppercoats"
+      ],
+      "synergy_commanders": [
+        "Brigid, Clachan's Heart // Brigid, Doun's Mind - Synergy (Kithkin Token)",
+        "Ajani, Outland Chaperone - Synergy (Kithkin Token)",
+        "Adeline, Resplendent Cathar - Synergy (Human Token)",
+        "Boromir, Warden of the Tower - Synergy (Soldier Kindred)"
+      ],
       "popularity_bucket": "Common",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Kithkin Token and Human Token reinforce the plan."
     },
@@ -22242,7 +25243,8 @@
         "Etali, Primal Storm - Synergy (Aggro)",
         "Ragavan, Nimble Pilferer - Synergy (Aggro)",
         "Toski, Bearer of Secrets - Synergy (Combat Matters)",
-        "Azusa, Lost but Seeking - Synergy (Little Fellas)"
+        "Azusa, Lost but Seeking - Synergy (Little Fellas)",
+        "The Weaver King - Synergy (Shadow)"
       ],
       "example_cards": [
         "Soltari Visionary",
@@ -22253,6 +25255,12 @@
         "Soltari Priest",
         "Soltari Lancer",
         "Soltari Guerrillas"
+      ],
+      "synergy_commanders": [
+        "Lyna, Veil of Vengeance - Synergy (Shadow)",
+        "Boss Uramon, Shadow's Reach - Synergy (Shadow)",
+        "Boromir, Warden of the Tower - Synergy (Soldier Kindred)",
+        "Anim Pakal, Thousandth Moon - Synergy (Soldier Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Soltari creatures into play with shared payoffs (e.g., Shadow and Aggro)."
@@ -22266,6 +25274,20 @@
       ],
       "primary_color": "Blue",
       "secondary_color": "White",
+      "example_commanders": [
+        "Sram, Senior Edificer - Synergy (Enchantments Matter)",
+        "Purphoros, God of the Forge - Synergy (Enchantments Matter)"
+      ],
+      "example_cards": [
+        "Case of the Locked Hothouse",
+        "Case of the Ransacked Lab",
+        "Case of the Uneaten Feast",
+        "Case of the Stashed Skeleton",
+        "Case of the Shifting Visage",
+        "Case of the Trampled Garden",
+        "Case of the Shattered Pact",
+        "Case of the Crimson Pulse"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Solved leveraging synergies with Cases Matter and Enchantments Matter."
     },
@@ -22277,6 +25299,13 @@
         "Artifacts Matter"
       ],
       "primary_color": "Black",
+      "example_commanders": [
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)",
+        "Rishkar, Peema Renegade - Synergy (Counters Matter)",
+        "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)",
+        "Loran of the Third Path - Synergy (Artifacts Matter)"
+      ],
       "example_cards": [
         "Séance Board",
         "Ravenous Amulet",
@@ -22319,7 +25348,7 @@
       ],
       "synergy_commanders": [
         "Toski, Bearer of Secrets - Synergy (Little Fellas)",
-        "Sheoldred, the Apocalypse - Synergy (Toughness Matters)"
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Soulbond leveraging synergies with Human Kindred and Little Fellas."
@@ -22354,8 +25383,8 @@
         "Body of Jukai"
       ],
       "synergy_commanders": [
-        "Sheoldred, Whispering One - Synergy (Control)",
-        "Ulamog, the Infinite Gyre - Synergy (Removal)"
+        "Six - Synergy (Graveyard Recursion)",
+        "Muldrotha, the Gravetide - Synergy (Graveyard Recursion)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Soulshift leveraging synergies with Spirit Kindred and Control."
@@ -22389,9 +25418,6 @@
         "Emrakul's Messenger",
         "Malevolent Rumble"
       ],
-      "synergy_commanders": [
-        "Ulalek, Fused Atrocity - Synergy (Devoid)"
-      ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Spawn creatures into play with shared payoffs (e.g., Eldrazi Kindred and Drone Kindred)."
     },
@@ -22407,6 +25433,20 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Magnus the Red",
+        "Kozilek, Butcher of Truth - Synergy (Eldrazi Kindred)"
+      ],
+      "example_cards": [
+        "Glaring Fleshraker",
+        "Awakening Zone",
+        "Pawn of Ulamog",
+        "Basking Broodscale",
+        "Kozilek's Command",
+        "Glimpse the Impossible",
+        "Emrakul's Messenger",
+        "Kozilek's Unsealing"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Spawn Kindred and Eldrazi Token reinforce the plan."
     },
@@ -22439,7 +25479,8 @@
         "Hackrobat"
       ],
       "synergy_commanders": [
-        "Toski, Bearer of Secrets - Synergy (Combat Matters)"
+        "Loran of the Third Path - Synergy (Card Draw)",
+        "Toski, Bearer of Secrets - Synergy (Card Draw)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Spectacle leveraging synergies with Burn and Aggro."
@@ -22509,9 +25550,9 @@
         "Lithoform Engine"
       ],
       "synergy_commanders": [
-        "Aeve, Progenitor Ooze - Synergy (Storm)",
+        "Prismari, the Inspiration - Synergy (Storm)",
         "Storm, Force of Nature - Synergy (Storm)",
-        "Ral, Crackling Wit - Synergy (Storm)",
+        "Aeve, Progenitor Ooze - Synergy (Storm)",
         "Ob Nixilis, the Adversary - Synergy (Casualty)"
       ],
       "popularity_bucket": "Uncommon",
@@ -22547,6 +25588,7 @@
         "Send to Sleep"
       ],
       "synergy_commanders": [
+        "The Gitrog Monster - Synergy (Reanimate)",
         "Lotho, Corrupt Shirriff - Synergy (Spells Matter)"
       ],
       "popularity_bucket": "Rare",
@@ -22583,7 +25625,7 @@
       ],
       "synergy_commanders": [
         "Sythis, Harvest's Hand - Synergy (Cantrips)",
-        "Kwain, Itinerant Meddler - Synergy (Cantrips)",
+        "Tataru Taru - Synergy (Cantrips)",
         "Boromir, Warden of the Tower - Synergy (Counterspells)"
       ],
       "popularity_bucket": "Very Common",
@@ -22620,8 +25662,8 @@
       ],
       "synergy_commanders": [
         "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Discard Matters)",
-        "Solphim, Mayhem Dominus - Synergy (Discard Matters)",
         "Yawgmoth, Thran Physician - Synergy (Discard Matters)",
+        "Solphim, Mayhem Dominus - Synergy (Discard Matters)",
         "Syr Konrad, the Grim - Synergy (Human Kindred)",
         "Azusa, Lost but Seeking - Synergy (Human Kindred)",
         "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
@@ -22729,12 +25771,12 @@
         "Dazzling Sphinx"
       ],
       "synergy_commanders": [
-        "The Scarab God - Synergy (Scry)",
-        "Thassa, God of the Sea - Synergy (Scry)",
-        "Thrasios, Triton Hero - Synergy (Scry)",
         "Niv-Mizzet, Parun - Synergy (Flying)",
         "Avacyn, Angel of Hope - Synergy (Flying)",
-        "The Reality Chip - Synergy (Topdeck)"
+        "Aurelia, the Warleader - Synergy (Flying)",
+        "Valgavoth, Terror Eater - Synergy (Ward)",
+        "Adrix and Nev, Twincasters - Synergy (Ward)",
+        "The Scarab God - Synergy (Scry)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Sphinx creatures into play with shared payoffs (e.g., Scry and Flying)."
@@ -22771,9 +25813,7 @@
       "synergy_commanders": [
         "Spider-Man, Brooklyn Visionary - Synergy (Web-slinging)",
         "Peter Parker // Amazing Spider-Man - Synergy (Web-slinging)",
-        "Spider-Man India - Synergy (Web-slinging)",
-        "Deadpool, Trading Card - Synergy (Hero Kindred)",
-        "G'raha Tia, Scion Reborn - Synergy (Hero Kindred)",
+        "Silk, Web Weaver - Synergy (Web-slinging)",
         "Six - Synergy (Reach)"
       ],
       "popularity_bucket": "Niche",
@@ -22791,6 +25831,30 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Arasta of the Endless Web",
+        "Ishkanah, Grafwidow",
+        "Peter Parker // Amazing Spider-Man",
+        "Spiders-Man, Heroic Horde",
+        "Izoni, Center of the Web"
+      ],
+      "example_cards": [
+        "Arasta of the Endless Web",
+        "Arachnogenesis",
+        "Twitching Doll",
+        "Lolth, Spider Queen",
+        "Ishkanah, Grafwidow",
+        "Peter Parker // Amazing Spider-Man",
+        "Curse of Clinging Webs",
+        "Spider Spawning"
+      ],
+      "synergy_commanders": [
+        "Gwenom, Remorseless - Synergy (Spider Kindred)",
+        "Iron Spider, Stark Upgrade - Synergy (Spider Kindred)",
+        "Six - Synergy (Reach)",
+        "Kodama of the West Tree - Synergy (Reach)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Spider Kindred and Reach reinforce the plan."
     },
@@ -22824,6 +25888,7 @@
         "Spike Worker"
       ],
       "synergy_commanders": [
+        "Bristly Bill, Spine Sower - Synergy (Counters Matter)",
         "Sram, Senior Edificer - Synergy (Voltron)"
       ],
       "popularity_bucket": "Rare",
@@ -22861,8 +25926,7 @@
       "synergy_commanders": [
         "He Who Hungers - Synergy (Soulshift)",
         "Katilda, Dawnhart Martyr // Katilda's Rising Dawn - Synergy (Disturb)",
-        "Dennick, Pious Apprentice // Dennick, Pious Apparition - Synergy (Disturb)",
-        "Anafenza, Unyielding Lineage - Synergy (Endure)"
+        "Dorothea, Vengeful Victim // Dorothea's Retribution - Synergy (Disturb)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Focuses on getting a high number of Spirit creatures into play with shared payoffs (e.g., Soulshift and Disturb)."
@@ -22879,7 +25943,28 @@
       ],
       "primary_color": "White",
       "secondary_color": "Black",
-      "popularity_bucket": "Uncommon",
+      "example_commanders": [
+        "Thalisse, Reverent Medium",
+        "Goro-Goro, Disciple of Ryusei",
+        "Kykar, Wind's Fury",
+        "Teysa, Orzhov Scion",
+        "Kura, the Boundless Sky"
+      ],
+      "example_cards": [
+        "Forbidden Orchard",
+        "Sokenzan, Crucible of Defiance",
+        "Ugin, the Ineffable",
+        "Court of Grace",
+        "Warden of the Grove",
+        "Thalisse, Reverent Medium",
+        "Goro-Goro, Disciple of Ryusei",
+        "Hallowed Haunting"
+      ],
+      "synergy_commanders": [
+        "Anafenza, Unyielding Lineage - Synergy (Endure)",
+        "Kodama of the West Tree - Synergy (Spirit Kindred)"
+      ],
+      "popularity_bucket": "Common",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Afterlife and Endure reinforce the plan."
     },
     {
@@ -22910,7 +25995,7 @@
         "Wear Away"
       ],
       "synergy_commanders": [
-        "Ulamog, the Infinite Gyre - Synergy (Removal)"
+        "Avacyn, Angel of Hope - Synergy (Interaction)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Splice leveraging synergies with Spells Matter and Spellslinger."
@@ -22945,9 +26030,10 @@
         "Sudden Substitution"
       ],
       "synergy_commanders": [
-        "Samut, Voice of Dissent - Synergy (Combat Tricks)",
-        "Naru Meha, Master Wizard - Synergy (Combat Tricks)",
-        "Syr Konrad, the Grim - Synergy (Interaction)"
+        "Mangara, the Diplomat - Synergy (Stax)",
+        "The Wandering Rescuer - Synergy (Combat Tricks)",
+        "Ambrosia Whiteheart - Synergy (Combat Tricks)",
+        "Avacyn, Angel of Hope - Synergy (Interaction)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Split second leveraging synergies with Stax and Spells Matter."
@@ -22994,8 +26080,9 @@
         "Thallid Germinator"
       ],
       "synergy_commanders": [
-        "Verdeloth the Ancient - Synergy (Saproling Kindred)",
-        "Vorinclex, Monstrous Raider - Synergy (Ore Counters)"
+        "Slimefoot and Squee - Synergy (Fungus Kindred)",
+        "Verdeloth the Ancient - Synergy (Saproling Token)",
+        "Shroofus Sproutsire - Synergy (Saproling Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Accumulates spore counters to unlock scaling payoffs, removal triggers, or delayed value conversions."
@@ -23040,6 +26127,31 @@
       ],
       "primary_color": "White",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Black Widow, Agile Avenger",
+        "Agent Phil Coulson",
+        "Director Nick Fury",
+        "Nick Fury, Agent of S.H.I.E.L.D.",
+        "Black Widow, Super Spy"
+      ],
+      "example_cards": [
+        "Black Widow, Agile Avenger",
+        "Agent Phil Coulson",
+        "Director Nick Fury",
+        "Nick Fury, Agent of S.H.I.E.L.D.",
+        "Black Widow, Super Spy",
+        "Hatut Zeraze Strike Force",
+        "Black Widow, Intel Expert",
+        "Quake, Agent of S.H.I.E.L.D."
+      ],
+      "synergy_commanders": [
+        "Deadpool, Trading Card - Synergy (Hero Kindred)",
+        "Gwenom, Remorseless - Synergy (Hero Kindred)",
+        "Iron Spider, Stark Upgrade - Synergy (Hero Kindred)",
+        "Syr Konrad, the Grim - Synergy (Human Kindred)",
+        "Azusa, Lost but Seeking - Synergy (Human Kindred)",
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Spy creatures into play with shared payoffs (e.g., Hero Kindred and Human Kindred)."
     },
@@ -23073,7 +26185,11 @@
         "Zephyrim"
       ],
       "synergy_commanders": [
-        "Nezahal, Primal Tide - Synergy (Leave the Battlefield)"
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)",
+        "Lotho, Corrupt Shirriff - Synergy (Token Creation)",
+        "Mondrak, Glory Dominus - Synergy (Token Creation)",
+        "Adeline, Resplendent Cathar - Synergy (Tokens Matter)",
+        "Talrand, Sky Summoner - Synergy (Tokens Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Squad leveraging synergies with Blink and Enter the Battlefield."
@@ -23088,7 +26204,8 @@
       "example_commanders": [
         "Ragavan, Nimble Pilferer - Synergy (Little Fellas)",
         "Azusa, Lost but Seeking - Synergy (Little Fellas)",
-        "Toski, Bearer of Secrets - Synergy (Little Fellas)"
+        "Toski, Bearer of Secrets - Synergy (Little Fellas)",
+        "Loran of the Third Path - Synergy (Little Fellas)"
       ],
       "example_cards": [
         "Chasm Skulker",
@@ -23133,12 +26250,9 @@
         "Valley Rotcaller"
       ],
       "synergy_commanders": [
-        "Peregrin Took - Synergy (Food Token)",
-        "Rosie Cotton of South Lane - Synergy (Food Token)",
-        "Samwise Gamgee - Synergy (Food Token)",
-        "Farmer Cotton - Synergy (Food)",
-        "Syr Ginger, the Meal Ender - Synergy (Food)",
-        "Saryth, the Viper's Fang - Synergy (Warlock Kindred)"
+        "Cloakwood Hermit - Synergy (Squirrel Token)",
+        "The Unbeatable Squirrel Girl - Synergy (Squirrel Token)",
+        "Peregrin Took - Synergy (Food Token)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Squirrel creatures into play with shared payoffs (e.g., Food Token and Food)."
@@ -23155,6 +26269,28 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Camellia, the Seedmiser",
+        "Cloakwood Hermit",
+        "The Unbeatable Squirrel Girl",
+        "Toski, Bearer of Secrets - Synergy (Squirrel Kindred)",
+        "Chatterfang, Squirrel General - Synergy (Squirrel Kindred)"
+      ],
+      "example_cards": [
+        "Swarmyard Massacre",
+        "Scurry Oak",
+        "Camellia, the Seedmiser",
+        "Chatterstorm",
+        "Chitterspitter",
+        "Squirrel Nest",
+        "Rootcast Apprenticeship",
+        "Deep Forest Hermit"
+      ],
+      "synergy_commanders": [
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Squirrel Kindred and Creature Tokens reinforce the plan."
     },
@@ -23162,12 +26298,17 @@
       "id": "starfish-kindred",
       "theme": "Starfish Kindred",
       "synergies": [
+        "Toughness Matters",
         "Little Fellas"
       ],
       "primary_color": "Black",
       "secondary_color": "Blue",
       "example_commanders": [
-        "Plagon, Lord of the Beach"
+        "Plagon, Lord of the Beach",
+        "Azusa, Lost but Seeking - Synergy (Toughness Matters)",
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)",
+        "Sheoldred, the Apocalypse - Synergy (Toughness Matters)",
+        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
       ],
       "example_cards": [
         "Sinister Starfish",
@@ -23175,6 +26316,9 @@
         "Plagon, Lord of the Beach",
         "Spiny Starfish",
         "Purple Pentapus"
+      ],
+      "synergy_commanders": [
+        "Loran of the Third Path - Synergy (Little Fellas)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Starfish creatures into play with shared payoffs."
@@ -23209,9 +26353,9 @@
         "Starting Column"
       ],
       "synergy_commanders": [
-        "Sram, Senior Edificer - Synergy (Vehicles)",
-        "Shorikai, Genesis Engine - Synergy (Vehicles)",
-        "Selvala, Heart of the Wilds - Synergy (Scout Kindred)"
+        "Selvala, Heart of the Wilds - Synergy (Scout Kindred)",
+        "Delney, Streetwise Lookout - Synergy (Scout Kindred)",
+        "Sram, Senior Edificer - Synergy (Vehicles)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Start your engines! leveraging synergies with Max speed and Vehicles."
@@ -23263,8 +26407,11 @@
         "Hearthhull, the Worldseed"
       ],
       "synergy_commanders": [
-        "Niv-Mizzet, Parun - Synergy (Flying)",
-        "Avacyn, Angel of Hope - Synergy (Flying)",
+        "Immard, the Stormcleaver - Synergy (Charge Counters)",
+        "The Eternity Elevator - Synergy (Charge Counters)",
+        "Umezawa's Jitte - Synergy (Charge Counters)",
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)",
         "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)"
       ],
       "popularity_bucket": "Rare",
@@ -23364,6 +26511,9 @@
         "Mind's Desire",
         "Tendrils of Agony"
       ],
+      "synergy_commanders": [
+        "Mangara, the Diplomat - Synergy (Spellslinger)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds storm count with cheap spells & mana bursts, converting it into a lethal payoff turn. Synergies like Spellslinger and Rituals reinforce the plan."
     },
@@ -23396,7 +26546,8 @@
         "Silence the Believers"
       ],
       "synergy_commanders": [
-        "Niv-Mizzet, Parun - Synergy (Spellslinger)"
+        "Ambrosia Whiteheart - Synergy (Combat Tricks)",
+        "Mangara, the Diplomat - Synergy (Spellslinger)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Strive leveraging synergies with Combat Tricks and Spells Matter."
@@ -23431,12 +26582,12 @@
         "Lulu, Stern Guardian"
       ],
       "synergy_commanders": [
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
-        "Rishkar, Peema Renegade - Synergy (Counters Matter)",
-        "Krenko, Tin Street Kingpin - Synergy (Counters Matter)",
-        "Kutzil, Malamet Exemplar - Synergy (Stax)",
-        "Lotho, Corrupt Shirriff - Synergy (Stax)",
-        "Baral, Chief of Compliance - Synergy (Loot)"
+        "Urabrask // The Great Work - Synergy (Lore Counters)",
+        "Sheoldred // The True Scriptures - Synergy (Lore Counters)",
+        "Vorinclex // The Grand Evolution - Synergy (Lore Counters)",
+        "Vorinclex, Monstrous Raider - Synergy (Ore Counters)",
+        "Lae'zel, Vlaakith's Champion - Synergy (Ore Counters)",
+        "Jhoira, Weatherlight Captain - Synergy (Sagas Matter)"
       ],
       "popularity_bucket": "Niche",
       "description": "Accumulates stun counters to unlock scaling payoffs, removal triggers, or delayed value conversions."
@@ -23507,6 +26658,7 @@
         "Shoulder to Shoulder"
       ],
       "synergy_commanders": [
+        "Bristly Bill, Spine Sower - Synergy (+1/+1 Counters)",
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
       ],
       "popularity_bucket": "Rare",
@@ -23539,7 +26691,8 @@
         "Boulder Salvo"
       ],
       "synergy_commanders": [
-        "Niv-Mizzet, Parun - Synergy (Spellslinger)"
+        "Ghalta, Primal Hunger - Synergy (Big Mana)",
+        "Mangara, the Diplomat - Synergy (Spellslinger)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Surge leveraging synergies with Big Mana and Spells Matter."
@@ -23590,10 +26743,10 @@
       ],
       "synergy_commanders": [
         "Syr Konrad, the Grim - Synergy (Mill)",
+        "Six - Synergy (Mill)",
         "Emry, Lurker of the Loch - Synergy (Mill)",
-        "Sheoldred, Whispering One - Synergy (Mill)",
-        "Six - Synergy (Reanimate)",
-        "Kozilek, Butcher of Truth - Synergy (Reanimate)",
+        "Sheoldred, Whispering One - Synergy (Reanimate)",
+        "The Gitrog Monster - Synergy (Reanimate)",
         "Octavia, Living Thesis - Synergy (Graveyard Matters)"
       ],
       "popularity_bucket": "Uncommon",
@@ -23660,7 +26813,7 @@
       "synergy_commanders": [
         "Syr Konrad, the Grim - Synergy (Human Kindred)",
         "Azusa, Lost but Seeking - Synergy (Human Kindred)",
-        "Etali, Primal Storm - Synergy (Aggro)"
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Survivor creatures into play with shared payoffs (e.g., Survival and Human Kindred)."
@@ -23694,8 +26847,8 @@
         "Repeat Offender"
       ],
       "synergy_commanders": [
-        "Kodama of the East Tree - Synergy (Enter the Battlefield)",
-        "Nezahal, Primal Tide - Synergy (Leave the Battlefield)"
+        "Veyran, Voice of Duality - Synergy (Blink)",
+        "Kodama of the East Tree - Synergy (Enter the Battlefield)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around the Suspect theme and its supporting synergies."
@@ -23731,7 +26884,7 @@
       ],
       "synergy_commanders": [
         "Ojer Pakpatiq, Deepest Epoch // Temple of Cyclical Time - Synergy (Time Counters)",
-        "Etali, Primal Storm - Synergy (Exile Matters)"
+        "Jenova, Ancient Calamity - Synergy (Alien Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Suspends spells early to pay off delayed powerful effects at discounted timing. Synergies like Time Counters and Exile Matters reinforce the plan."
@@ -23765,7 +26918,10 @@
         "Jhessian Zombies"
       ],
       "synergy_commanders": [
-        "Baral, Chief of Compliance - Synergy (Loot)"
+        "Rocksteady, Crash Courser - Synergy (Landcycling)",
+        "Jennika, Bad Apple Big Sister - Synergy (Landcycling)",
+        "Zog, Triceraton Castaway - Synergy (Typecycling)",
+        "Bebop, Warthog Warrior - Synergy (Typecycling)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Swampcycling leveraging synergies with Land Types Matter and Cycling."
@@ -23835,6 +26991,26 @@
       ],
       "primary_color": "Blue",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Avacyn, Angel of Hope - Synergy (Interaction)",
+        "Boromir, Warden of the Tower - Synergy (Interaction)",
+        "Padeem, Consul of Innovation - Synergy (Interaction)",
+        "Lotho, Corrupt Shirriff - Synergy (Spells Matter)",
+        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Spells Matter)"
+      ],
+      "example_cards": [
+        "HULK SMASH!",
+        "We Say Thee Nay!",
+        "Earth's Mightiest Heroes",
+        "Go Nuts!",
+        "Too Evil to Stay Dead",
+        "Murdock's Crusade",
+        "Team Tactics",
+        "Repulsor Blast"
+      ],
+      "synergy_commanders": [
+        "Mangara, the Diplomat - Synergy (Spellslinger)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Teamwork leveraging synergies with Interaction and Spells Matter."
     },
@@ -23863,7 +27039,7 @@
         "Tempt with Glory"
       ],
       "synergy_commanders": [
-        "Niv-Mizzet, Parun - Synergy (Spellslinger)"
+        "Mangara, the Diplomat - Synergy (Spellslinger)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Tempting offer leveraging synergies with Politics and Spells Matter."
@@ -23896,7 +27072,9 @@
       "example_commanders": [
         "Etali, Primal Storm - Synergy (Aggro)",
         "Ragavan, Nimble Pilferer - Synergy (Aggro)",
-        "Toski, Bearer of Secrets - Synergy (Combat Matters)"
+        "Toski, Bearer of Secrets - Synergy (Combat Matters)",
+        "The Weaver King - Synergy (Shadow)",
+        "Lyna, Veil of Vengeance - Synergy (Shadow)"
       ],
       "example_cards": [
         "Thalakos Seer",
@@ -23906,6 +27084,10 @@
         "Thalakos Scout",
         "Thalakos Dreamsower",
         "Thalakos Mistfolk"
+      ],
+      "synergy_commanders": [
+        "Boss Uramon, Shadow's Reach - Synergy (Shadow)",
+        "Azusa, Lost but Seeking - Synergy (Little Fellas)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Thalakos creatures into play with shared payoffs (e.g., Shadow and Aggro)."
@@ -23942,9 +27124,8 @@
       "synergy_commanders": [
         "Glóin, Dwarf Emissary - Synergy (Goad)",
         "Slicer, Hired Muscle // Slicer, High-Speed Antagonist - Synergy (Goad)",
-        "Braids, Arisen Nightmare - Synergy (Sacrifice to Draw)",
-        "Peregrin Took - Synergy (Sacrifice to Draw)",
-        "Syr Konrad, the Grim - Synergy (Sacrifice Matters)"
+        "Captain Lannery Storm - Synergy (Pirate Kindred)",
+        "Lotho, Corrupt Shirriff - Synergy (Treasure Token)"
       ],
       "popularity_bucket": "Common",
       "description": "Acquires opponents’ permanents temporarily or permanently to convert their resources into board control. Synergies like Sacrifice to Draw and Sacrifice Matters reinforce the plan."
@@ -23979,12 +27160,10 @@
         "Stridehangar Automaton"
       ],
       "synergy_commanders": [
+        "Sai, Master Thopterist - Synergy (Thopter Token)",
         "Loran of the Third Path - Synergy (Artificer Kindred)",
-        "Sai, Master Thopterist - Synergy (Artificer Kindred)",
         "Urza, Lord High Artificer - Synergy (Artificer Kindred)",
-        "Ragavan, Nimble Pilferer - Synergy (Artifact Tokens)",
-        "Lotho, Corrupt Shirriff - Synergy (Artifact Tokens)",
-        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+        "Ragavan, Nimble Pilferer - Synergy (Artifact Tokens)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Thopter creatures into play with shared payoffs (e.g., Artificer Kindred and Artifact Tokens)."
@@ -24001,6 +27180,30 @@
       ],
       "primary_color": "Blue",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Sai, Master Thopterist",
+        "Breya, Etherium Shaper",
+        "Pia Nalaar, Consul of Revival",
+        "Pia and Kiran Nalaar",
+        "Pia Nalaar"
+      ],
+      "example_cards": [
+        "Loyal Apprentice",
+        "Sai, Master Thopterist",
+        "Thopter Spy Network",
+        "Hangarback Walker",
+        "Whirler Rogue",
+        "Efficient Construction",
+        "Access Denied",
+        "Sharding Sphinx"
+      ],
+      "synergy_commanders": [
+        "Liberator, Urza's Battlethopter - Synergy (Thopter Kindred)",
+        "Hope of Ghirapur - Synergy (Thopter Kindred)",
+        "Loran of the Third Path - Synergy (Artificer Kindred)",
+        "Urza, Lord High Artificer - Synergy (Artificer Kindred)",
+        "Ragavan, Nimble Pilferer - Synergy (Artifact Tokens)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Thopter Kindred and Artificer Kindred reinforce the plan."
     },
@@ -24032,6 +27235,9 @@
         "Far Wanderings",
         "Barbarian Ring",
         "Putrid Imp"
+      ],
+      "synergy_commanders": [
+        "Prosper, Tome-Bound - Synergy (Mystic Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Fills the graveyard quickly to meet Threshold counts and upgrade spell/creature efficiencies. Synergies like Nomad Kindred and Minion Kindred reinforce the plan."
@@ -24067,7 +27273,7 @@
       ],
       "synergy_commanders": [
         "Elas il-Kor, Sadistic Pilgrim - Synergy (Aristocrats)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Aristocrats)",
+        "Yawgmoth, Thran Physician - Synergy (Aristocrats)",
         "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
       ],
       "popularity_bucket": "Rare",
@@ -24078,6 +27284,9 @@
       "theme": "Tide Counters",
       "synergies": [],
       "primary_color": "Blue",
+      "example_commanders": [
+        "Rikala, Homarid King"
+      ],
       "example_cards": [
         "Homarid",
         "Tidal Influence"
@@ -24120,7 +27329,7 @@
         "Rankle, Master of Pranks - Synergy (Rogue Kindred)",
         "Ragavan, Nimble Pilferer - Synergy (Outlaw Kindred)",
         "Captain Lannery Storm - Synergy (Outlaw Kindred)",
-        "Selvala, Heart of the Wilds - Synergy (Blink)"
+        "Mondrak, Glory Dominus - Synergy (Token Creation)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Tiefling creatures into play with shared payoffs (e.g., Blink and Enter the Battlefield)."
@@ -24135,6 +27344,25 @@
       ],
       "primary_color": "Red",
       "secondary_color": "White",
+      "example_commanders": [
+        "Avacyn, Angel of Hope - Synergy (Interaction)",
+        "Boromir, Warden of the Tower - Synergy (Interaction)",
+        "Padeem, Consul of Innovation - Synergy (Interaction)",
+        "Lotho, Corrupt Shirriff - Synergy (Spells Matter)",
+        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Spells Matter)"
+      ],
+      "example_cards": [
+        "Restoration Magic",
+        "Fire Magic",
+        "Tifa's Limit Break",
+        "Cloud's Limit Break",
+        "Thunder Magic",
+        "Vincent's Limit Break",
+        "Ice Magic"
+      ],
+      "synergy_commanders": [
+        "Mangara, the Diplomat - Synergy (Spellslinger)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Tiered leveraging synergies with Interaction and Spells Matter."
     },
@@ -24203,7 +27431,7 @@
       ],
       "synergy_commanders": [
         "Taigam, Master Opportunist - Synergy (Suspend)",
-        "The Eleventh Doctor - Synergy (Suspend)",
+        "The War Doctor - Synergy (Time Counters)",
         "Etali, Primal Storm - Synergy (Exile Matters)"
       ],
       "popularity_bucket": "Rare",
@@ -24239,7 +27467,7 @@
         "Black Market Connections"
       ],
       "synergy_commanders": [
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Creature Tokens)",
+        "Urza, Lord High Artificer - Synergy (Creature Tokens)",
         "Trostani, Selesnya's Voice - Synergy (Populate)",
         "Cayth, Famed Mechanist - Synergy (Populate)"
       ],
@@ -24276,10 +27504,10 @@
         "Vorinclex, Monstrous Raider"
       ],
       "synergy_commanders": [
-        "Kiki-Jiki, Mirror Breaker - Synergy (Clones)",
         "Sakashima of a Thousand Faces - Synergy (Clones)",
-        "Adeline, Resplendent Cathar - Synergy (Planeswalkers)",
-        "Yawgmoth, Thran Physician - Synergy (Planeswalkers)"
+        "Kiki-Jiki, Mirror Breaker - Synergy (Clones)",
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Infect)",
+        "Yawgmoth, Thran Physician - Synergy (Infect)"
       ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Clones and Planeswalkers reinforce the plan."
@@ -24349,9 +27577,9 @@
         "Rakdos Charm"
       ],
       "synergy_commanders": [
-        "Yawgmoth, Thran Physician - Synergy (Proliferate)",
-        "Tekuthal, Inquiry Dominus - Synergy (Proliferate)",
-        "Peregrin Took - Synergy (Citizen Kindred)"
+        "Toby, Beastie Befriender - Synergy (Beast Token)",
+        "Radagast, Wizard of Wilds - Synergy (Beast Token)",
+        "Yawgmoth, Thran Physician - Synergy (Proliferate)"
       ],
       "popularity_bucket": "Common",
       "description": "Builds around Toolbox leveraging synergies with Entwine and Proliferate."
@@ -24389,8 +27617,8 @@
         "The Scarab God - Synergy (Scry)",
         "Thassa, God of the Sea - Synergy (Scry)",
         "Thrasios, Triton Hero - Synergy (Scry)",
-        "Glarb, Calamity's Augur - Synergy (Surveil)",
-        "Desmond Miles - Synergy (Surveil)"
+        "Fandaniel, Telophoroi Ascian - Synergy (Surveil)",
+        "Glarb, Calamity's Augur - Synergy (Surveil)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Builds around Topdeck leveraging synergies with Scry and Surveil."
@@ -24425,11 +27653,12 @@
         "Pitiless Plunderer"
       ],
       "synergy_commanders": [
-        "The Pride of Hull Clade - Synergy (Defender)",
+        "The Walls of Ba Sing Se - Synergy (Defender)",
         "Sokrates, Athenian Teacher - Synergy (Defender)",
-        "Pramikon, Sky Rampart - Synergy (Defender)",
-        "Atla Palani, Nest Tender - Synergy (Egg Kindred)",
-        "Slicer, Hired Muscle // Slicer, High-Speed Antagonist - Synergy (Convert)"
+        "The Pride of Hull Clade - Synergy (Defender)",
+        "Invisible Woman, Sue Storm - Synergy (Wall Token)",
+        "Invisible Woman - Synergy (Wall Token)",
+        "Atla Palani, Nest Tender - Synergy (Egg Kindred)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Builds around Toughness Matters leveraging synergies with Defender and Egg Kindred."
@@ -24464,11 +27693,10 @@
         "Karumonix, the Rat King"
       ],
       "synergy_commanders": [
+        "Ria Ivor, Bane of Bladehold - Synergy (Mite Kindred)",
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Poison Counters)",
         "Skithiryx, the Blight Dragon - Synergy (Poison Counters)",
-        "Yawgmoth, Thran Physician - Synergy (Infect)",
-        "Vorinclex, Monstrous Raider - Synergy (Infect)",
-        "Mondrak, Glory Dominus - Synergy (Phyrexian Kindred)"
+        "Yawgmoth, Thran Physician - Synergy (Infect)"
       ],
       "popularity_bucket": "Rare",
       "description": "Leverages Infect/Toxic pressure and proliferate to accelerate poison win thresholds. Synergies like Poison Counters and Infect reinforce the plan."
@@ -24503,7 +27731,8 @@
       ],
       "synergy_commanders": [
         "Azusa, Lost but Seeking - Synergy (Little Fellas)",
-        "Toski, Bearer of Secrets - Synergy (Little Fellas)"
+        "Toski, Bearer of Secrets - Synergy (Little Fellas)",
+        "Etali, Primal Storm - Synergy (Aggro)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Toy creatures into play with shared payoffs (e.g., Artifacts Matter)."
@@ -24576,12 +27805,8 @@
         "Kalonian Hydra"
       ],
       "synergy_commanders": [
-        "Mr. Orfeo, the Boulder - Synergy (Rhino Kindred)",
-        "Ghired, Conclave Exile - Synergy (Rhino Kindred)",
-        "Roon of the Hidden Realm - Synergy (Rhino Kindred)",
-        "Grothama, All-Devouring - Synergy (Wurm Kindred)",
-        "Baru, Fist of Krosa - Synergy (Wurm Kindred)",
-        "The Goose Mother - Synergy (Hydra Kindred)"
+        "Zog, Triceraton Castaway - Synergy (Mountaincycling)",
+        "Mr. Orfeo, the Boulder - Synergy (Rhino Kindred)"
       ],
       "popularity_bucket": "Common",
       "description": "Accelerates mana ahead of curve, then converts surplus into oversized threats or multi-spell bursts. Synergies like Hydra Kindred and Rhino Kindred reinforce the plan."
@@ -24616,10 +27841,9 @@
         "Invasion of Ikoria // Zilortha, Apex of Ikoria"
       ],
       "synergy_commanders": [
-        "Elesh Norn // The Argent Etchings - Synergy (Incubator Token)",
-        "Brimaz, Blight of Oreskos - Synergy (Incubator Token)",
-        "Glissa, Herald of Predation - Synergy (Incubator Token)",
-        "Jor Kadeen, the Prevailer - Synergy (Metalcraft)"
+        "Tovolar, Dire Overlord // Tovolar, the Midnight Scourge - Synergy (Daybound)",
+        "Arlinn, the Pack's Hope // Arlinn, the Moon's Fury - Synergy (Daybound)",
+        "Elesh Norn // The Argent Etchings - Synergy (Incubator Token)"
       ],
       "popularity_bucket": "Common",
       "description": "Builds around Transform leveraging synergies with Incubator Token and Incubate."
@@ -24653,7 +27877,8 @@
         "Shred Memory"
       ],
       "synergy_commanders": [
-        "Niv-Mizzet, Parun - Synergy (Spellslinger)"
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)",
+        "Mangara, the Diplomat - Synergy (Spellslinger)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Transmute leveraging synergies with Toughness Matters and Spells Matter."
@@ -24726,8 +27951,7 @@
         "Syr Konrad, the Grim - Synergy (Sacrifice Matters)",
         "Braids, Arisen Nightmare - Synergy (Sacrifice Matters)",
         "Sheoldred, the Apocalypse - Synergy (Sacrifice Matters)",
-        "Azusa, Lost but Seeking - Synergy (Ramp)",
-        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Ramp)"
+        "Azusa, Lost but Seeking - Synergy (Ramp)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Sacrifice Matters and Artifacts Matter reinforce the plan."
@@ -24762,11 +27986,10 @@
         "Woodfall Primus"
       ],
       "synergy_commanders": [
+        "Wrenn and Seven - Synergy (Treefolk Token)",
         "Tatyova, Benthic Druid - Synergy (Druid Kindred)",
         "Rishkar, Peema Renegade - Synergy (Druid Kindred)",
-        "Jaheira, Friend of the Forest - Synergy (Druid Kindred)",
-        "Kiki-Jiki, Mirror Breaker - Synergy (Shaman Kindred)",
-        "Delina, Wild Mage - Synergy (Shaman Kindred)"
+        "Kiki-Jiki, Mirror Breaker - Synergy (Shaman Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Treefolk creatures into play with shared payoffs (e.g., Shaman Kindred and Druid Kindred)."
@@ -24782,6 +28005,26 @@
         "Big Mana"
       ],
       "primary_color": "Green",
+      "example_commanders": [
+        "Six - Synergy (Treefolk Kindred)",
+        "Yedora, Grave Gardener - Synergy (Treefolk Kindred)",
+        "Treebeard, Gracious Host - Synergy (Treefolk Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Wrenn and Seven",
+        "Sylvan Offering",
+        "Sapling Nursery",
+        "Assemble the Entmoot",
+        "Tend the Sprigs",
+        "Kalonian Twingrove",
+        "Arboreal Alliance",
+        "Reach of Branches"
+      ],
+      "synergy_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Treefolk Kindred and Creature Tokens reinforce the plan."
     },
@@ -24814,7 +28057,7 @@
         "Shrike Harpy"
       ],
       "synergy_commanders": [
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Enter the Battlefield)"
+        "Veyran, Voice of Duality - Synergy (Enter the Battlefield)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Tribute leveraging synergies with +1/+1 Counters and Blink."
@@ -24839,6 +28082,16 @@
       "synergies": [],
       "primary_color": "Red",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Jeska, Thrice Reborn"
+      ],
+      "example_cards": [
+        "City on Fire",
+        "Fiery Emancipation",
+        "Jeska, Thrice Reborn",
+        "Tifa's Limit Break",
+        "Isengard Unleashed"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around the Triple theme and its supporting synergies."
     },
@@ -24872,12 +28125,12 @@
         "Feasting Troll King"
       ],
       "synergy_commanders": [
-        "Kiki-Jiki, Mirror Breaker - Synergy (Shaman Kindred)",
-        "Delina, Wild Mage - Synergy (Shaman Kindred)",
-        "Meren of Clan Nel Toth - Synergy (Shaman Kindred)",
-        "Ghalta, Primal Hunger - Synergy (Trample)",
-        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Trample)",
-        "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)"
+        "Ezuri, Renegade Leader - Synergy (Regenerate)",
+        "Skithiryx, the Blight Dragon - Synergy (Regenerate)",
+        "Ink-Eyes, Servant of Oni - Synergy (Regenerate)",
+        "Tatyova, Benthic Druid - Synergy (Druid Kindred)",
+        "Rishkar, Peema Renegade - Synergy (Druid Kindred)",
+        "Kiki-Jiki, Mirror Breaker - Synergy (Shaman Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Troll creatures into play with shared payoffs (e.g., Shaman Kindred and Warrior Kindred)."
@@ -24888,6 +28141,11 @@
       "synergies": [],
       "primary_color": "Green",
       "secondary_color": "Red",
+      "example_cards": [
+        "Waking the Trolls",
+        "Old-Growth Troll",
+        "Gnottvold Slumbermound"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines."
     },
@@ -24921,12 +28179,12 @@
         "Snapping Voidcraw"
       ],
       "synergy_commanders": [
-        "Adrix and Nev, Twincasters - Synergy (Ward)",
-        "Miirym, Sentinel Wyrm - Synergy (Ward)",
-        "Daxos, Blessed by the Sun - Synergy (Ward)",
-        "Toski, Bearer of Secrets - Synergy (Protective Effects)",
-        "Mondrak, Glory Dominus - Synergy (Protective Effects)",
-        "Azusa, Lost but Seeking - Synergy (Toughness Matters)"
+        "Nashi, Moon Sage's Scion - Synergy (Ninja Kindred)",
+        "Yuriko, the Tiger's Shadow - Synergy (Ninja Kindred)",
+        "Ink-Eyes, Servant of Oni - Synergy (Ninja Kindred)",
+        "Raphael, the Nightwatcher - Synergy (Sneak)",
+        "Dark Leo & Shredder - Synergy (Sneak)",
+        "Deadpool, Trading Card - Synergy (Mutant Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Turtle creatures into play with shared payoffs (e.g., Ward and Protective Effects)."
@@ -24943,6 +28201,23 @@
       ],
       "primary_color": "Blue",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Monstrosity of the Lake",
+        "Rocksteady, Crash Courser",
+        "Jennika, Bad Apple Big Sister",
+        "Zog, Triceraton Castaway",
+        "Bebop, Warthog Warrior"
+      ],
+      "example_cards": [
+        "Ash Barrens",
+        "Angel of the Ruins",
+        "Lórien Revealed",
+        "Step Through",
+        "Troll of Khazad-dûm",
+        "Oliphaunt",
+        "Ruin Grinder",
+        "Generous Ent"
+      ],
       "popularity_bucket": "Niche",
       "description": "Builds around Typecycling leveraging synergies with Landcycling and Basic landcycling."
     },
@@ -24976,9 +28251,7 @@
         "Aberrant"
       ],
       "synergy_commanders": [
-        "Ghalta, Primal Hunger - Synergy (X Spells)",
-        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (X Spells)",
-        "Azusa, Lost but Seeking - Synergy (Ramp)"
+        "Ghalta, Primal Hunger - Synergy (X Spells)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Tyranid creatures into play with shared payoffs (e.g., Ravenous and X Spells)."
@@ -24994,6 +28267,24 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Old One Eye",
+        "Ghyrson Starn, Kelermorph - Synergy (Tyranid Kindred)",
+        "Magus Lucea Kane - Synergy (Tyranid Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Termagant Swarm",
+        "Old One Eye",
+        "Tyranid Harridan",
+        "Gargoyle Flock",
+        "Tyranid Invasion",
+        "Lictor"
+      ],
+      "synergy_commanders": [
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Tyranid Kindred and Creature Tokens reinforce the plan."
     },
@@ -25027,6 +28318,8 @@
         "Felidar Umbra"
       ],
       "synergy_commanders": [
+        "Super State - Synergy (Enchant)",
+        "Danitha Capashen, Paragon - Synergy (Auras)",
         "Purphoros, God of the Forge - Synergy (Enchantments Matter)"
       ],
       "popularity_bucket": "Rare",
@@ -25130,7 +28423,7 @@
         "Rhizome Lurcher"
       ],
       "synergy_commanders": [
-        "Kozilek, Butcher of Truth - Synergy (Mill)",
+        "The Gitrog Monster - Synergy (Reanimate)",
         "Selvala, Heart of the Wilds - Synergy (Blink)"
       ],
       "popularity_bucket": "Rare",
@@ -25168,8 +28461,8 @@
       "synergy_commanders": [
         "Sheoldred, the Apocalypse - Synergy (Sacrifice Matters)",
         "Elas il-Kor, Sadistic Pilgrim - Synergy (Aristocrats)",
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Aristocrats)",
-        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)"
+        "Yawgmoth, Thran Physician - Synergy (Aristocrats)",
+        "Neheb, the Eternal - Synergy (Zombie Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Undying leveraging synergies with Sacrifice Matters and Aristocrats."
@@ -25239,10 +28532,10 @@
         "Celestial Unicorn"
       ],
       "synergy_commanders": [
-        "Vito, Thorn of the Dusk Rose - Synergy (Lifegain)",
-        "Elas il-Kor, Sadistic Pilgrim - Synergy (Life Matters)",
-        "Mangara, the Diplomat - Synergy (Life Matters)",
-        "Azusa, Lost but Seeking - Synergy (Toughness Matters)"
+        "Vito, Thorn of the Dusk Rose - Synergy (Lifelink)",
+        "Mangara, the Diplomat - Synergy (Lifelink)",
+        "Danitha Capashen, Paragon - Synergy (Lifelink)",
+        "Elas il-Kor, Sadistic Pilgrim - Synergy (Life Matters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Unicorn creatures into play with shared payoffs (e.g., Lifegain and Life Matters)."
@@ -25278,7 +28571,7 @@
       ],
       "synergy_commanders": [
         "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)",
-        "Yahenni, Undying Partisan - Synergy (Counters Matter)",
+        "Bristly Bill, Spine Sower - Synergy (Counters Matter)",
         "Sram, Senior Edificer - Synergy (Voltron)"
       ],
       "popularity_bucket": "Rare",
@@ -25295,7 +28588,9 @@
       "example_commanders": [
         "Arthur, Marigold Knight - Synergy (Mouse Kindred)",
         "Mabel, Heir to Cragflame - Synergy (Mouse Kindred)",
-        "Tusk and Whiskers - Synergy (Mouse Kindred)"
+        "Tusk and Whiskers - Synergy (Mouse Kindred)",
+        "Boromir, Warden of the Tower - Synergy (Soldier Kindred)",
+        "Anim Pakal, Thousandth Moon - Synergy (Soldier Kindred)"
       ],
       "example_cards": [
         "Whiskervale Forerunner",
@@ -25338,11 +28633,10 @@
         "Twilight Prophet"
       ],
       "synergy_commanders": [
-        "Edgar, Charmed Groom // Edgar Markov's Coffin - Synergy (Blood Token)",
-        "Old Rutstein - Synergy (Blood Token)",
-        "Kamber, the Plunderer - Synergy (Blood Token)",
-        "Heliod, Sun-Crowned - Synergy (Lifegain Triggers)",
-        "Emrakul, the World Anew - Synergy (Madness)"
+        "Edgar Markov - Synergy (Vampire Token)",
+        "Aclazotz, Deepest Betrayal // Temple of the Dead - Synergy (Bat Token)",
+        "Timothar, Baron of Bats - Synergy (Bat Token)",
+        "Edgar, Charmed Groom // Edgar Markov's Coffin - Synergy (Blood Token)"
       ],
       "popularity_bucket": "Common",
       "description": "Focuses on getting a high number of Vampire creatures into play with shared payoffs (e.g., Blood Token and Lifegain Triggers)."
@@ -25359,8 +28653,32 @@
       ],
       "primary_color": "White",
       "secondary_color": "Black",
+      "example_commanders": [
+        "Elenda, the Dusk Rose",
+        "Ghalta and Mavren",
+        "Edgar Markov",
+        "Clavileño, First of the Blessed",
+        "Edgar, Charmed Groom // Edgar Markov's Coffin"
+      ],
+      "example_cards": [
+        "Charismatic Conqueror",
+        "Elenda, the Dusk Rose",
+        "Ghalta and Mavren",
+        "Elenda's Hierophant",
+        "Bloodline Keeper // Lord of Lineage",
+        "Edgar Markov",
+        "Clavileño, First of the Blessed",
+        "Edgar, Charmed Groom // Edgar Markov's Coffin"
+      ],
+      "synergy_commanders": [
+        "Tasha, the Witch Queen - Synergy (Demon Token)",
+        "Vito, Fanatic of Aclazotz - Synergy (Demon Token)",
+        "Vito, Thorn of the Dusk Rose - Synergy (Vampire Kindred)",
+        "Yahenni, Undying Partisan - Synergy (Vampire Kindred)",
+        "Mangara, the Diplomat - Synergy (Lifelink)"
+      ],
       "popularity_bucket": "Niche",
-      "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Vampire Kindred and Lifelink reinforce the plan."
+      "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Demon Token and Vampire Kindred reinforce the plan."
     },
     {
       "id": "vanishing",
@@ -25390,7 +28708,8 @@
         "Chronozoa"
       ],
       "synergy_commanders": [
-        "Rishkar, Peema Renegade - Synergy (Counters Matter)",
+        "Taigam, Master Opportunist - Synergy (Time Counters)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)",
         "Sram, Senior Edificer - Synergy (Enchantments Matter)"
       ],
       "popularity_bucket": "Rare",
@@ -25438,12 +28757,12 @@
         "Unctus, Grand Metatect"
       ],
       "synergy_commanders": [
-        "Loran of the Third Path - Synergy (Artificer Kindred)",
-        "Sai, Master Thopterist - Synergy (Artificer Kindred)",
-        "Urza, Lord High Artificer - Synergy (Artificer Kindred)",
-        "Dr. Madison Li - Synergy (Energy Counters)",
         "Satya, Aetherflux Genius - Synergy (Energy Counters)",
-        "Liberty Prime, Recharged - Synergy (Energy)"
+        "Dr. Madison Li - Synergy (Energy Counters)",
+        "Liberty Prime, Recharged - Synergy (Energy Counters)",
+        "Loran of the Third Path - Synergy (Artificer Kindred)",
+        "Urza, Lord High Artificer - Synergy (Artificer Kindred)",
+        "Nissa, Worldsoul Speaker - Synergy (Energy)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Vedalken creatures into play with shared payoffs (e.g., Artificer Kindred and Energy Counters)."
@@ -25481,7 +28800,8 @@
         "Ragavan, Nimble Pilferer - Synergy (Artifacts Matter)",
         "Loran of the Third Path - Synergy (Artifacts Matter)",
         "Lotho, Corrupt Shirriff - Synergy (Artifacts Matter)",
-        "Cid, Freeflier Pilot - Synergy (Pilot Kindred)"
+        "Cosima, God of the Voyage // The Omenkeel - Synergy (Crew)",
+        "Tannuk, Memorial Ensign - Synergy (Pilot Kindred)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Leverages efficient Vehicles and crew bodies to field evasive, sweep-resilient threats. Synergies like Artifacts Matter and Crew reinforce the plan."
@@ -25516,12 +28836,12 @@
         "Triumphant Adventurer"
       ],
       "synergy_commanders": [
+        "Azusa, Lost but Seeking - Synergy (Toughness Matters)",
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)",
+        "Sheoldred, the Apocalypse - Synergy (Toughness Matters)",
         "Etali, Primal Storm - Synergy (Aggro)",
         "Ragavan, Nimble Pilferer - Synergy (Aggro)",
-        "Toski, Bearer of Secrets - Synergy (Aggro)",
-        "Kutzil, Malamet Exemplar - Synergy (Combat Matters)",
-        "Sheoldred, the Apocalypse - Synergy (Combat Matters)",
-        "Loran of the Third Path - Synergy (Artifacts Matter)"
+        "Toski, Bearer of Secrets - Synergy (Combat Matters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Repeats Venture into the Dungeon steps to layer incremental room rewards into compounding advantage. Synergies like Artifacts Matter and Aggro reinforce the plan."
@@ -25553,7 +28873,9 @@
         "Serra's Hymn"
       ],
       "synergy_commanders": [
-        "Purphoros, God of the Forge - Synergy (Enchantments Matter)"
+        "Purphoros, God of the Forge - Synergy (Enchantments Matter)",
+        "Danitha Capashen, Paragon - Synergy (Enchantments Matter)",
+        "Yawgmoth, Thran Physician - Synergy (Counters Matter)"
       ],
       "popularity_bucket": "Rare",
       "description": "Accumulates verse counters to unlock scaling payoffs, removal triggers, or delayed value conversions."
@@ -25591,9 +28913,9 @@
         "Avacyn, Angel of Hope - Synergy (Angel Kindred)",
         "Aurelia, the Warleader - Synergy (Angel Kindred)",
         "Gisela, Blade of Goldnight - Synergy (Angel Kindred)",
-        "The Gitrog, Ravenous Ride - Synergy (Mount Kindred)",
-        "Calamity, Galloping Inferno - Synergy (Mount Kindred)",
-        "Zeriam, Golden Wind - Synergy (Griffin Kindred)"
+        "Etali, Primal Storm - Synergy (Elder Kindred)",
+        "Ghalta, Primal Hunger - Synergy (Elder Kindred)",
+        "The Council of Four - Synergy (Knight Token)"
       ],
       "popularity_bucket": "Common",
       "description": "Builds around Vigilance leveraging synergies with Angel Kindred and Mount Kindred."
@@ -25610,6 +28932,27 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Sanar, Innovative First-Year",
+        "Ashaya, Soul of the Wild - Synergy (Elemental Kindred)",
+        "Omnath, Locus of Rage - Synergy (Elemental Kindred)",
+        "Muldrotha, the Gravetide - Synergy (Elemental Kindred)",
+        "Selvala, Heart of the Wilds - Synergy (Blink)"
+      ],
+      "example_cards": [
+        "Bloom Tender",
+        "Prismatic Undercurrents",
+        "Shimmercreep",
+        "Aurora Awakener",
+        "Shinestriker",
+        "Elemental Spectacle",
+        "Sanar, Innovative First-Year",
+        "Prismabasher"
+      ],
+      "synergy_commanders": [
+        "Sheoldred, Whispering One - Synergy (Blink)",
+        "Veyran, Voice of Duality - Synergy (Enter the Battlefield)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Vivid leveraging synergies with Elemental Kindred and Blink."
     },
@@ -25689,8 +29032,8 @@
         "Hardened Scales"
       ],
       "synergy_commanders": [
-        "Ardenn, Intrepid Archaeologist - Synergy (Auras)",
-        "Codsworth, Handy Helper - Synergy (Auras)"
+        "Codsworth, Handy Helper - Synergy (Auras)",
+        "Ardenn, Intrepid Archaeologist - Synergy (Auras)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Stacks auras, equipment, and protection on a single threat to push commander damage with layered resilience. Synergies like Equipment Matters and Auras reinforce the plan."
@@ -25707,6 +29050,23 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Slinn Voda, the Rising Deep - Synergy (Kicker)",
+        "Tourach, Dread Cantor - Synergy (Kicker)",
+        "Josu Vess, Lich Knight - Synergy (Kicker)",
+        "Yawgmoth, Thran Physician - Synergy (+1/+1 Counters)",
+        "Rishkar, Peema Renegade - Synergy (+1/+1 Counters)"
+      ],
+      "example_cards": [
+        "Anavolver",
+        "Necravolver",
+        "Cetavolver",
+        "Degavolver",
+        "Rakavolver"
+      ],
+      "synergy_commanders": [
+        "Etali, Primal Conqueror // Etali, Primal Sickness - Synergy (Counters Matter)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Volver creatures into play with shared payoffs (e.g., Kicker and +1/+1 Counters)."
     },
@@ -25740,7 +29100,10 @@
         "Weathered Sentinels"
       ],
       "synergy_commanders": [
-        "Meloku the Clouded Mirror - Synergy (Illusion Kindred)"
+        "Invisible Woman, Sue Storm - Synergy (Wall Token)",
+        "Invisible Woman - Synergy (Wall Token)",
+        "Super-Skrull - Synergy (Wall Token)",
+        "The Walls of Ba Sing Se - Synergy (Defender)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Focuses on getting a high number of Wall creatures into play with shared payoffs (e.g., Defender and Plant Kindred)."
@@ -25757,6 +29120,30 @@
       ],
       "primary_color": "White",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Invisible Woman, Sue Storm",
+        "Invisible Woman",
+        "Super-Skrull",
+        "The Fantastic Four",
+        "Doctor Spectrum"
+      ],
+      "example_cards": [
+        "Rammas Echor, Ancient Shield",
+        "Teyo, Geometric Tactician",
+        "Rampart Architect",
+        "The Birth of Meletis",
+        "Teyo, the Shieldmage",
+        "Builder's Talent",
+        "Invisible Woman, Sue Storm",
+        "Invisible Woman"
+      ],
+      "synergy_commanders": [
+        "The Walls of Ba Sing Se - Synergy (Wall Kindred)",
+        "Pramikon, Sky Rampart - Synergy (Wall Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)",
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Wall Kindred and Creature Tokens reinforce the plan."
     },
@@ -25790,11 +29177,12 @@
         "Adrix and Nev, Twincasters"
       ],
       "synergy_commanders": [
-        "Renata, Called to the Hunt - Synergy (Demigod Kindred)",
-        "Anikthea, Hand of Erebos - Synergy (Demigod Kindred)",
         "Bayek of Siwa - Synergy (Disguise)",
         "Arno Dorian - Synergy (Disguise)",
-        "Etrata, Deadly Fugitive - Synergy (Cloak)"
+        "Aveline de Grandpré - Synergy (Disguise)",
+        "Vannifar, Evolved Enigma - Synergy (Cloak)",
+        "Etrata, Deadly Fugitive - Synergy (Cloak)",
+        "Toski, Bearer of Secrets - Synergy (Protective Effects)"
       ],
       "popularity_bucket": "Uncommon",
       "description": "Builds around Ward leveraging synergies with Demigod Kindred and Disguise."
@@ -25829,12 +29217,11 @@
         "Rivaz of the Claw"
       ],
       "synergy_commanders": [
-        "Ragavan, Nimble Pilferer - Synergy (Outlaw Kindred)",
-        "Lotho, Corrupt Shirriff - Synergy (Outlaw Kindred)",
-        "Captain Lannery Storm - Synergy (Outlaw Kindred)",
-        "Toski, Bearer of Secrets - Synergy (Squirrel Kindred)",
-        "Chatterfang, Squirrel General - Synergy (Squirrel Kindred)",
-        "Peregrin Took - Synergy (Food Token)"
+        "Beledros Witherbloom - Synergy (Pest Kindred)",
+        "Moseo, Vein's New Dean - Synergy (Pest Kindred)",
+        "Blex, Vexing Pest // Search for Blex - Synergy (Pest Kindred)",
+        "Valentin, Dean of the Vein // Lisette, Dean of the Root - Synergy (Pest Token)",
+        "High Perfect Morcant - Synergy (Blight)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Warlock creatures into play with shared payoffs (e.g., Outlaw Kindred and Squirrel Kindred)."
@@ -25870,7 +29257,7 @@
       ],
       "synergy_commanders": [
         "Codsworth, Handy Helper - Synergy (Robot Kindred)",
-        "K-9, Mark I - Synergy (Robot Kindred)"
+        "Kilo, Apogee Mind - Synergy (Robot Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Warp leveraging synergies with Void and Exile Matters."
@@ -25905,11 +29292,11 @@
         "Oketra's Monument"
       ],
       "synergy_commanders": [
-        "Zurgo Stormrender - Synergy (Mobilize)",
+        "God-Eternal Oketra - Synergy (Warrior Token)",
+        "Zurgo Stormrender - Synergy (Warrior Token)",
+        "Maja, Bretagard Protector - Synergy (Warrior Token)",
         "Zurgo, Thunder's Decree - Synergy (Mobilize)",
-        "Themberchaud - Synergy (Exert)",
-        "Anep, Vizier of Hazoret - Synergy (Exert)",
-        "Khârn the Betrayer - Synergy (Astartes Kindred)"
+        "Marneus Calgar - Synergy (Astartes Token)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Focuses on getting a high number of Warrior creatures into play with shared payoffs (e.g., Mobilize and Exert)."
@@ -25926,6 +29313,29 @@
       ],
       "primary_color": "White",
       "secondary_color": "Green",
+      "example_commanders": [
+        "God-Eternal Oketra",
+        "Zurgo Stormrender",
+        "Maja, Bretagard Protector",
+        "Rhys the Redeemed",
+        "Ajani, Nacatl Pariah // Ajani, Nacatl Avenger"
+      ],
+      "example_cards": [
+        "Voice of Victory",
+        "Oketra's Monument",
+        "Secure the Wastes",
+        "Imperious Perfect",
+        "Elvish Warmaster",
+        "Galadhrim Ambush",
+        "Lys Alana Huntmaster",
+        "Will of the Mardu"
+      ],
+      "synergy_commanders": [
+        "Zurgo, Thunder's Decree - Synergy (Mobilize)",
+        "Marneus Calgar - Synergy (Astartes Token)",
+        "Mortarion, Daemon Primarch - Synergy (Astartes Token)",
+        "Imotekh the Stormlord - Synergy (Necron Token)"
+      ],
       "popularity_bucket": "Uncommon",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Mobilize and Astartes Token reinforce the plan."
     },
@@ -25933,14 +29343,36 @@
       "id": "waterbend",
       "theme": "Waterbend",
       "synergies": [
+        "Waterbending",
         "Bending",
         "Ally Kindred",
         "Cost Reduction",
-        "Warrior Kindred",
-        "Big Mana"
+        "Warrior Kindred"
       ],
       "primary_color": "Blue",
       "secondary_color": "Black",
+      "example_commanders": [
+        "The Unagi of Kyoshi Island",
+        "Aang, Swift Savior // Aang and La, Ocean's Fury",
+        "Katara, Water Tribe's Hope",
+        "Katara, Bending Prodigy",
+        "Yue, the Moon Spirit"
+      ],
+      "example_cards": [
+        "The Unagi of Kyoshi Island",
+        "Spirit Water Revival",
+        "Aang, Swift Savior // Aang and La, Ocean's Fury",
+        "Waterbender Ascension",
+        "Waterbending Lesson",
+        "Katara, Water Tribe's Hope",
+        "Katara, Bending Prodigy",
+        "Waterbender's Restoration"
+      ],
+      "synergy_commanders": [
+        "Toph, Hardheaded Teacher - Synergy (Bending)",
+        "Toph, Earthbending Master - Synergy (Bending)",
+        "Drana, Liberator of Malakir - Synergy (Ally Kindred)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Builds around Waterbend leveraging synergies with Waterbending and Bending."
     },
@@ -25974,11 +29406,11 @@
         "Watery Grasp"
       ],
       "synergy_commanders": [
-        "Appa, Steadfast Guardian - Synergy (Bending)",
-        "Aang, Airbending Master - Synergy (Bending)",
-        "Ghalta, Primal Hunger - Synergy (Cost Reduction)",
-        "Emry, Lurker of the Loch - Synergy (Cost Reduction)",
-        "Braids, Arisen Nightmare - Synergy (Card Draw)"
+        "The Unagi of Kyoshi Island - Synergy (Waterbend)",
+        "Aang, Swift Savior // Aang and La, Ocean's Fury - Synergy (Waterbend)",
+        "Toph, Hardheaded Teacher - Synergy (Bending)",
+        "Toph, Earthbending Master - Synergy (Bending)",
+        "Drana, Liberator of Malakir - Synergy (Ally Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Waterbending leveraging synergies with Bending and Cost Reduction."
@@ -26026,11 +29458,12 @@
         "Spider-Man, Web-Slinger"
       ],
       "synergy_commanders": [
-        "Deadpool, Trading Card - Synergy (Hero Kindred)",
-        "G'raha Tia, Scion Reborn - Synergy (Hero Kindred)",
-        "Iron Man, Titan of Innovation - Synergy (Hero Kindred)",
         "Arasta of the Endless Web - Synergy (Spider Kindred)",
-        "Shelob, Dread Weaver - Synergy (Spider Kindred)"
+        "Gwenom, Remorseless - Synergy (Spider Kindred)",
+        "Iron Spider, Stark Upgrade - Synergy (Spider Kindred)",
+        "Deadpool, Trading Card - Synergy (Hero Kindred)",
+        "Spectacular Spider-Man - Synergy (Hero Kindred)",
+        "Syr Konrad, the Grim - Synergy (Human Kindred)"
       ],
       "popularity_bucket": "Rare",
       "description": "Builds around Web-slinging leveraging synergies with Hero Kindred and Spider Kindred."
@@ -26049,7 +29482,10 @@
       "secondary_color": "Black",
       "example_commanders": [
         "Melek, Izzet Paragon",
-        "Melek, Reforged Researcher"
+        "Melek, Reforged Researcher",
+        "Azusa, Lost but Seeking - Synergy (Toughness Matters)",
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)",
+        "Sheoldred, the Apocalypse - Synergy (Toughness Matters)"
       ],
       "example_cards": [
         "Hydroelectric Specimen // Hydroelectric Laboratory",
@@ -26060,6 +29496,11 @@
         "Nothic",
         "Steamcore Scholar",
         "Turn // Burn"
+      ],
+      "synergy_commanders": [
+        "Lotho, Corrupt Shirriff - Synergy (Spells Matter)",
+        "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Spells Matter)",
+        "Mangara, the Diplomat - Synergy (Spellslinger)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Weird creatures into play with shared payoffs."
@@ -26093,6 +29534,9 @@
         "Avabruck Caretaker // Hollowhenge Huntmaster",
         "Tovolar's Huntmaster // Tovolar's Packleader"
       ],
+      "synergy_commanders": [
+        "Faldorn, Dread Wolf Herald - Synergy (Wolf Token)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Werewolf creatures into play with shared payoffs (e.g., Daybound and Nightbound)."
     },
@@ -26125,8 +29569,9 @@
         "Great Whale"
       ],
       "synergy_commanders": [
-        "Etali, Primal Storm - Synergy (Big Mana)",
-        "Azusa, Lost but Seeking - Synergy (Toughness Matters)"
+        "Aurelia, the Warleader - Synergy (Flying)",
+        "Azusa, Lost but Seeking - Synergy (Toughness Matters)",
+        "Selvala, Heart of the Wilds - Synergy (Toughness Matters)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Whale creatures into play with shared payoffs (e.g., Flying and Big Mana)."
@@ -26162,9 +29607,8 @@
       ],
       "synergy_commanders": [
         "Birgi, God of Storytelling // Harnfel, Horn of Bounty - Synergy (Discard Matters)",
-        "Solphim, Mayhem Dominus - Synergy (Discard Matters)",
         "Yawgmoth, Thran Physician - Synergy (Discard Matters)",
-        "Toski, Bearer of Secrets - Synergy (Card Draw)",
+        "Solphim, Mayhem Dominus - Synergy (Discard Matters)",
         "Lotho, Corrupt Shirriff - Synergy (Spellslinger)"
       ],
       "popularity_bucket": "Very Common",
@@ -26182,8 +29626,28 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Ellivere of the Wild Court - Synergy (Role token)",
+        "Gylwain, Casting Director - Synergy (Role token)",
+        "Syr Armont, the Redeemer - Synergy (Role token)",
+        "Heliod, God of the Sun - Synergy (Enchantment Tokens)",
+        "Go-Shintai of Life's Origin - Synergy (Enchantment Tokens)"
+      ],
+      "example_cards": [
+        "Not Dead After All",
+        "Charming Scoundrel",
+        "Witch's Mark",
+        "Lord Skitter's Blessing",
+        "Twisted Fealty",
+        "Twisted Sewer-Witch",
+        "The Witch's Vanity",
+        "Shatter the Oath"
+      ],
+      "synergy_commanders": [
+        "Sram, Senior Edificer - Synergy (Equipment Matters)"
+      ],
       "popularity_bucket": "Rare",
-      "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Role Token and Enchantment Tokens reinforce the plan."
+      "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Role token and Enchantment Tokens reinforce the plan."
     },
     {
       "id": "will-of-the-planeswalkers",
@@ -26238,6 +29702,9 @@
         "Galadriel, Elven-Queen"
       ],
       "synergy_commanders": [
+        "Braids, Arisen Nightmare - Synergy (Card Draw)",
+        "Loran of the Third Path - Synergy (Card Draw)",
+        "Toski, Bearer of Secrets - Synergy (Card Draw)",
         "Mangara, the Diplomat - Synergy (Spellslinger)"
       ],
       "popularity_bucket": "Rare",
@@ -26299,8 +29766,9 @@
         "Cinderbones"
       ],
       "synergy_commanders": [
+        "Tekuthal, Inquiry Dominus - Synergy (-1/-1 Counters)",
         "Ashaya, Soul of the Wild - Synergy (Elemental Kindred)",
-        "Titania, Protector of Argoth - Synergy (Elemental Kindred)",
+        "Omnath, Locus of Rage - Synergy (Elemental Kindred)",
         "Kutzil, Malamet Exemplar - Synergy (Warrior Kindred)"
       ],
       "popularity_bucket": "Rare",
@@ -26336,12 +29804,12 @@
         "Emry, Lurker of the Loch"
       ],
       "synergy_commanders": [
+        "Kuja, Genome Sorcerer // Trance Kuja, Fate Defied - Synergy (Wizard Token)",
+        "Queen Brahne - Synergy (Wizard Token)",
+        "Commodore Guff - Synergy (Wizard Token)",
         "Meloku the Clouded Mirror - Synergy (Moonfolk Kindred)",
         "Kotori, Pilot Prodigy - Synergy (Moonfolk Kindred)",
-        "Katsumasa, the Animator - Synergy (Moonfolk Kindred)",
-        "Padeem, Consul of Innovation - Synergy (Vedalken Kindred)",
-        "Unctus, Grand Metatect - Synergy (Vedalken Kindred)",
-        "Kitsa, Otterball Elite - Synergy (Otter Kindred)"
+        "Berta, Wise Extrapolator - Synergy (Increment)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Focuses on getting a high number of Wizard creatures into play with shared payoffs (e.g., Moonfolk Kindred and Vedalken Kindred)."
@@ -26356,10 +29824,33 @@
         "Token Creation",
         "Tokens Matter"
       ],
-      "primary_color": "Blue",
-      "secondary_color": "Red",
+      "primary_color": "Red",
+      "secondary_color": "Blue",
+      "example_commanders": [
+        "Kuja, Genome Sorcerer // Trance Kuja, Fate Defied",
+        "Queen Brahne",
+        "Commodore Guff",
+        "Emry, Lurker of the Loch - Synergy (Wizard Kindred)",
+        "Niv-Mizzet, Parun - Synergy (Wizard Kindred)"
+      ],
+      "example_cards": [
+        "Lindblum, Industrial Regency // Mage Siege",
+        "Circle of Power",
+        "Transpose",
+        "Cornered by Black Mages",
+        "Kuja, Genome Sorcerer // Trance Kuja, Fate Defied",
+        "Mysidian Elder",
+        "Queen Brahne",
+        "Docent of Perfection // Final Iteration"
+      ],
+      "synergy_commanders": [
+        "Talrand, Sky Summoner - Synergy (Wizard Kindred)",
+        "Syr Konrad, the Grim - Synergy (Pingers)",
+        "Elas il-Kor, Sadistic Pilgrim - Synergy (Pingers)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
       "popularity_bucket": "Rare",
-      "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Wizard Kindred and Creature Tokens reinforce the plan."
+      "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Wizard Kindred and Pingers reinforce the plan."
     },
     {
       "id": "wolf-kindred",
@@ -26391,11 +29882,11 @@
         "Hollowhenge Overlord"
       ],
       "synergy_commanders": [
+        "Faldorn, Dread Wolf Herald - Synergy (Wolf Token)",
+        "Varis, Silverymoon Ranger - Synergy (Wolf Token)",
+        "Garruk, Cursed Huntsman - Synergy (Wolf Token)",
         "Vincent Valentine // Galian Beast - Synergy (Werewolf Kindred)",
-        "Ulrich of the Krallenhorde // Ulrich, Uncontested Alpha - Synergy (Werewolf Kindred)",
-        "Liberator, Urza's Battlethopter - Synergy (Flash)",
-        "Jin-Gitaxias, Core Augur - Synergy (Flash)",
-        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+        "The Chief Warg - Synergy (Ferocious)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Wolf creatures into play with shared payoffs (e.g., Werewolf Kindred and Flash)."
@@ -26412,6 +29903,28 @@
       ],
       "primary_color": "Green",
       "secondary_color": "Red",
+      "example_commanders": [
+        "Faldorn, Dread Wolf Herald",
+        "Varis, Silverymoon Ranger",
+        "Wildsear, Scouring Maw - Synergy (Wolf Kindred)",
+        "Anara, Wolvid Familiar - Synergy (Wolf Kindred)",
+        "Torgal, A Fine Hound - Synergy (Wolf Kindred)"
+      ],
+      "example_cards": [
+        "Garruk, Cursed Huntsman",
+        "Faldorn, Dread Wolf Herald",
+        "Sword of Body and Mind",
+        "Wolfwillow Haven",
+        "Howling Moon",
+        "Hollowhenge Overlord",
+        "Nightpack Ambusher",
+        "Ranger Class"
+      ],
+      "synergy_commanders": [
+        "Vincent Valentine // Galian Beast - Synergy (Werewolf Kindred)",
+        "Tovolar, Dire Overlord // Tovolar, the Midnight Scourge - Synergy (Werewolf Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
       "popularity_bucket": "Niche",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Wolf Kindred and Werewolf Kindred reinforce the plan."
     },
@@ -26426,7 +29939,8 @@
       "example_commanders": [
         "Ragavan, Nimble Pilferer - Synergy (Little Fellas)",
         "Azusa, Lost but Seeking - Synergy (Little Fellas)",
-        "Toski, Bearer of Secrets - Synergy (Little Fellas)"
+        "Toski, Bearer of Secrets - Synergy (Little Fellas)",
+        "Loran of the Third Path - Synergy (Little Fellas)"
       ],
       "example_cards": [
         "Hivespine Wolverine",
@@ -26457,8 +29971,8 @@
         "Sacrifice Matters",
         "Aristocrats",
         "Creature Tokens",
-        "Token Creation",
-        "Tokens Matter"
+        "Blink",
+        "Enter the Battlefield"
       ],
       "primary_color": "Black",
       "secondary_color": "Blue",
@@ -26480,8 +29994,8 @@
         "Simic Ragworm"
       ],
       "synergy_commanders": [
-        "Ojer Taq, Deepest Foundation // Temple of Civilization - Synergy (Aristocrats)",
-        "Ragavan, Nimble Pilferer - Synergy (Little Fellas)"
+        "Yawgmoth, Thran Physician - Synergy (Aristocrats)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
       ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Worm creatures into play with shared payoffs (e.g., Sacrifice Matters and Aristocrats)."
@@ -26492,6 +30006,15 @@
       "synergies": [],
       "primary_color": "Black",
       "secondary_color": "Green",
+      "example_commanders": [
+        "Lluwen, Imperfect Naturalist"
+      ],
+      "example_cards": [
+        "Creakwood Liege",
+        "Wriggling Grub",
+        "Lluwen, Imperfect Naturalist",
+        "Worm Harvest"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines."
     },
@@ -26540,6 +30063,13 @@
       "synergies": [],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Lord of the Nazgûl"
+      ],
+      "example_cards": [
+        "Lord of the Nazgûl",
+        "In the Darkness Bind Them"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines."
     },
@@ -26573,9 +30103,9 @@
         "Impervious Greatwurm"
       ],
       "synergy_commanders": [
-        "Mondrak, Glory Dominus - Synergy (Phyrexian Kindred)",
-        "Sheoldred, the Apocalypse - Synergy (Phyrexian Kindred)",
-        "Syr Konrad, the Grim - Synergy (Big Mana)"
+        "Baru, Wurmspeaker - Synergy (Wurm Token)",
+        "Garruk, Primal Hunter - Synergy (Wurm Token)",
+        "Mondrak, Glory Dominus - Synergy (Phyrexian Kindred)"
       ],
       "popularity_bucket": "Niche",
       "description": "Focuses on getting a high number of Wurm creatures into play with shared payoffs (e.g., Trample and Big Mana)."
@@ -26592,6 +30122,27 @@
       ],
       "primary_color": "Green",
       "secondary_color": "White",
+      "example_commanders": [
+        "Baru, Wurmspeaker",
+        "Baru, Fist of Krosa",
+        "Grothama, All-Devouring - Synergy (Wurm Kindred)",
+        "Garruk, Primal Hunter - Synergy (Wurm Kindred)",
+        "Adeline, Resplendent Cathar - Synergy (Creature Tokens)"
+      ],
+      "example_cards": [
+        "Wurmcoil Engine",
+        "Garruk, Primal Hunter",
+        "Sandwurm Convergence",
+        "Worldspine Wurm",
+        "Baru, Wurmspeaker",
+        "Wurmcoil Larva",
+        "Wurmquake",
+        "Wurmcalling"
+      ],
+      "synergy_commanders": [
+        "Talrand, Sky Summoner - Synergy (Creature Tokens)",
+        "Ragavan, Nimble Pilferer - Synergy (Token Creation)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Wurm Kindred and Creature Tokens reinforce the plan."
     },
@@ -26599,11 +30150,11 @@
       "id": "x-spells",
       "theme": "X Spells",
       "synergies": [
-        "Firebend",
         "Ravenous",
         "Undaunted",
         "Affinity",
-        "Firebending"
+        "Firebending",
+        "Cost Reduction"
       ],
       "primary_color": "Blue",
       "secondary_color": "Green",
@@ -26625,9 +30176,9 @@
         "Finale of Devastation"
       ],
       "synergy_commanders": [
-        "Urza, Chief Artificer - Synergy (Affinity)",
-        "Nahiri, Forged in Fury - Synergy (Affinity)",
-        "Fire Lord Zuko - Synergy (Firebending)"
+        "Fire Lord Azula - Synergy (Firebending)",
+        "Ozai, the Phoenix King - Synergy (Firebending)",
+        "Zuko, Exiled Prince - Synergy (Firebending)"
       ],
       "popularity_bucket": "Very Common",
       "description": "Builds around X Spells leveraging synergies with Affinity and Ravenous."
@@ -26657,6 +30208,9 @@
         "Karplusan Strider",
         "Shambling Strider"
       ],
+      "synergy_commanders": [
+        "Ghalta, Primal Hunger - Synergy (Big Mana)"
+      ],
       "popularity_bucket": "Rare",
       "description": "Focuses on getting a high number of Yeti creatures into play with shared payoffs."
     },
@@ -26672,8 +30226,25 @@
       ],
       "primary_color": "Red",
       "secondary_color": "White",
+      "example_commanders": [
+        "Ellivere of the Wild Court - Synergy (Role token)",
+        "Gylwain, Casting Director - Synergy (Role token)",
+        "Syr Armont, the Redeemer - Synergy (Role token)",
+        "Heliod, God of the Sun - Synergy (Enchantment Tokens)",
+        "Go-Shintai of Life's Origin - Synergy (Enchantment Tokens)"
+      ],
+      "example_cards": [
+        "Return Triumphant",
+        "Embereth Veteran",
+        "Cut In",
+        "Merry Bards",
+        "Protective Parents"
+      ],
+      "synergy_commanders": [
+        "Deadpool, Trading Card - Synergy (Hero Kindred)"
+      ],
       "popularity_bucket": "Rare",
-      "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Role Token and Enchantment Tokens reinforce the plan."
+      "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Role token and Enchantment Tokens reinforce the plan."
     },
     {
       "id": "zombie-kindred",
@@ -26722,6 +30293,30 @@
       ],
       "primary_color": "Black",
       "secondary_color": "Blue",
+      "example_commanders": [
+        "Jadar, Ghoulcaller of Nephalia",
+        "God-Eternal Oketra",
+        "Ghoulcaller Gisa",
+        "Wilhelt, the Rotcleaver",
+        "Teval, the Balanced Scale"
+      ],
+      "example_cards": [
+        "Field of the Dead",
+        "Liliana, Dreadhorde General",
+        "Waste Not",
+        "Jadar, Ghoulcaller of Nephalia",
+        "Grave Titan",
+        "Dreadhorde Invasion",
+        "Teval's Judgment",
+        "Cryptbreaker"
+      ],
+      "synergy_commanders": [
+        "Freyalise, Llanowar's Fury - Synergy (Druid Token)",
+        "The Sibsig Ceremony - Synergy (Druid Token)",
+        "Saruman, the White Hand - Synergy (Army Token)",
+        "Gothmog, Morgul Lieutenant - Synergy (Army Token)",
+        "Sauron, the Dark Lord - Synergy (Army Kindred)"
+      ],
       "popularity_bucket": "Uncommon",
       "description": "Goes wide with creature tokens then converts mass into damage, draw, drain, or sacrifice engines. Synergies like Druid Token and Army Token reinforce the plan."
     },
@@ -26761,134 +30356,131 @@
   ],
   "frequencies_by_base_color": {
     "white": {
-      "Aggro": 2295,
-      "Combat Matters": 2295,
-      "Creature Tokens": 859,
-      "Nephilim Kindred": 4,
-      "Sand Kindred": 2,
-      "Sand Token": 4,
-      "Token Creation": 1096,
-      "Tokens Matter": 1108,
-      "Burn": 521,
-      "Haste": 76,
-      "Historics Matter": 1363,
-      "Human Kindred": 1874,
-      "Legends Matter": 1363,
-      "Soldier Kindred": 873,
-      "Toughness Matters": 1437,
-      "Vigilance": 460,
-      "Angel Kindred": 287,
-      "Big Mana": 1794,
+      "Aggro": 2309,
+      "Angel Kindred": 290,
+      "Big Mana": 1806,
+      "Combat Matters": 2310,
       "Deathtouch": 31,
-      "Flying": 1063,
-      "Life Matters": 1721,
-      "Lifegain": 1720,
-      "Lifelink": 442,
-      "Phyrexian Kindred": 85,
-      "Topdeck": 322,
-      "+1/+1 Counters": 809,
+      "Flying": 1067,
+      "Historics Matter": 1385,
+      "Legends Matter": 1385,
+      "Life Matters": 1731,
+      "Lifegain": 1730,
+      "Lifelink": 444,
+      "Phyrexian Kindred": 86,
+      "Topdeck": 323,
+      "Vigilance": 462,
+      "+1/+1 Counters": 816,
       "-1/-1 Counters": 69,
-      "Counters Matter": 1160,
+      "Counters Matter": 1168,
       "Horror Kindred": 22,
       "Infect": 54,
       "Midrange": 191,
-      "Planeswalkers": 160,
+      "Planeswalkers": 164,
       "Proliferate": 16,
-      "Superfriends": 160,
-      "Voltron": 1434,
-      "Little Fellas": 2554,
-      "Spells Matter": 1735,
-      "Spellslinger": 1735,
-      "Artifact Tokens": 225,
-      "Artifacts Matter": 1163,
+      "Superfriends": 164,
+      "Voltron": 1444,
+      "Little Fellas": 2568,
+      "Nephilim Kindred": 5,
+      "Spells Matter": 1742,
+      "Spellslinger": 1742,
+      "Artifact Tokens": 226,
+      "Artifacts Matter": 1172,
+      "Burn": 526,
+      "Creature Tokens": 863,
+      "Human Kindred": 1884,
       "Thopter Kindred": 8,
       "Thopter Token": 8,
-      "Toolbox": 153,
-      "Blink": 1134,
-      "Control": 390,
-      "Enter the Battlefield": 1134,
-      "Leave the Battlefield": 1145,
-      "Mill": 706,
-      "Reanimate": 733,
-      "Aristocrats": 286,
-      "Enchantments Matter": 1247,
-      "Sacrifice Matters": 286,
+      "Token Creation": 1104,
+      "Tokens Matter": 1116,
+      "Toolbox": 155,
+      "Blink": 1142,
+      "Control": 391,
+      "Enter the Battlefield": 1142,
+      "Leave the Battlefield": 1153,
+      "Mill": 708,
+      "Reanimate": 736,
+      "Aristocrats": 287,
+      "Enchantments Matter": 1249,
+      "Sacrifice Matters": 287,
       "Spirit Kindred": 340,
       "Spirit Token": 109,
-      "Card Draw": 704,
+      "Card Draw": 714,
       "Mana Rock": 69,
-      "Ramp": 223,
+      "Ramp": 225,
       "Sacrifice to Draw": 76,
-      "Interaction": 1245,
-      "Removal": 525,
-      "Unconditional Draw": 242,
-      "Cleric Kindred": 484,
+      "Interaction": 1250,
+      "Removal": 528,
+      "Unconditional Draw": 246,
+      "Cleric Kindred": 486,
       "Dog Kindred": 47,
       "Graveyard Recursion": 223,
       "Mana Dork": 59,
       "Morph": 27,
-      "Warrior Kindred": 322,
-      "Lands Matter": 489,
+      "Warrior Kindred": 326,
+      "Lands Matter": 491,
       "Graveyard Hate": 71,
-      "Auras": 465,
-      "Clones": 88,
+      "Soldier Kindred": 874,
+      "Auras": 467,
+      "Clones": 89,
       "Demigod Kindred": 4,
       "Menace": 32,
-      "Zombie Kindred": 51,
+      "Zombie Kindred": 52,
       "Dragon Kindred": 85,
+      "Toughness Matters": 1447,
       "Halfling Kindred": 28,
-      "Lifegain Triggers": 57,
+      "Lifegain Triggers": 58,
       "Outlaw Kindred": 104,
       "Rogue Kindred": 55,
-      "Wheels": 133,
+      "Wheels": 135,
       "Reach": 36,
       "Shaman Kindred": 28,
       "Treefolk Kindred": 17,
       "Alt Fetchland": 7,
-      "Cycling": 105,
-      "Discard Matters": 200,
+      "Cycling": 106,
+      "Discard Matters": 201,
       "Landscape Land": 6,
-      "Loot": 135,
-      "Cost Reduction": 141,
-      "Druid Kindred": 36,
-      "X Spells": 206,
+      "Loot": 136,
+      "Cost Reduction": 143,
+      "Druid Kindred": 37,
+      "X Spells": 207,
       "Board Wipes": 178,
       "Trample": 93,
       "Fungus Kindred": 3,
       "Saproling Kindred": 13,
       "Saproling Token": 12,
       "Land Types Matter": 98,
-      "Elephant Kindred": 46,
-      "Stax": 673,
+      "Elephant Kindred": 47,
+      "Stax": 678,
       "Corrupted": 7,
       "Poison Counters": 30,
       "Toxic": 10,
       "Centaur Kindred": 19,
-      "Hexproof": 88,
-      "Indestructible": 227,
+      "Hexproof": 89,
+      "Indestructible": 228,
       "Insect Kindred": 13,
       "Nightmare Kindred": 13,
-      "Protective Effects": 568,
-      "Advisor Kindred": 75,
+      "Protective Effects": 571,
+      "Advisor Kindred": 76,
       "Elf Kindred": 89,
       "Pingers": 101,
       "God Kindred": 34,
       "Bard Kindred": 22,
-      "Conditional Draw": 183,
+      "Conditional Draw": 187,
       "Sagas Matter": 96,
-      "Wizard Kindred": 219,
+      "Wizard Kindred": 222,
       "Kicker": 52,
       "Volver Kindred": 3,
-      "Beast Kindred": 61,
-      "Cat Kindred": 201,
+      "Beast Kindred": 62,
+      "Cat Kindred": 204,
       "Mutate": 9,
       "Fuse": 8,
-      "Citizen Kindred": 69,
+      "Citizen Kindred": 70,
       "Lore Counters": 65,
       "Ore Counters": 77,
       "Djinn Kindred": 12,
       "Rhino Kindred": 25,
-      "First strike": 195,
+      "First strike": 196,
       "Frog Kindred": 3,
       "Landfall": 29,
       "Plant Kindred": 5,
@@ -26896,18 +30488,19 @@
       "Zombie Token": 10,
       "Mite Kindred": 9,
       "Mite Token": 9,
-      "Phyrexian Token": 17,
+      "Phyrexian Token": 18,
       "Scout Kindred": 94,
       "Assassin Kindred": 23,
       "Exile Matters": 180,
       "Memory Counters": 1,
       "Berserker Kindred": 4,
-      "Goblin Kindred": 16,
+      "Goblin Kindred": 17,
+      "Haste": 76,
       "Demon Kindred": 14,
       "Mobilize": 7,
       "Warrior Token": 50,
-      "Orc Kindred": 22,
-      "Draw Triggers": 123,
+      "Orc Kindred": 23,
+      "Draw Triggers": 125,
       "Soldier Token": 158,
       "Knight Kindred": 354,
       "Regenerate": 31,
@@ -26924,9 +30517,8 @@
       "Warlock Kindred": 31,
       "Ally Kindred": 110,
       "Bending": 21,
-      "Firebend": 3,
       "Firebending": 3,
-      "Noble Kindred": 74,
+      "Noble Kindred": 75,
       "Samurai Kindred": 49,
       "Artificer Kindred": 86,
       "Construct Kindred": 26,
@@ -26934,12 +30526,12 @@
       "Gnome Kindred": 15,
       "Human Token": 76,
       "Experience Counters": 8,
-      "Elder Kindred": 20,
+      "Elder Kindred": 21,
       "Giant Kindred": 64,
-      "Politics": 96,
+      "Politics": 97,
       "Enchant": 317,
-      "Goblin Token": 9,
-      "Combat Tricks": 282,
+      "Goblin Token": 10,
+      "Combat Tricks": 283,
       "Scry": 110,
       "Raid": 4,
       "Bounty Counters": 2,
@@ -26947,193 +30539,138 @@
       "Eye Kindred": 10,
       "Living metal": 7,
       "More Than Meets the Eye": 8,
-      "Robot Kindred": 39,
+      "Robot Kindred": 40,
       "Robot Token": 12,
       "Assassin Token": 3,
-      "Monarch": 23,
+      "Monarch": 24,
       "Flashback": 45,
       "Dinosaur Kindred": 53,
       "Mercenary Kindred": 23,
-      "Equipment Matters": 321,
+      "Equipment Matters": 323,
       "Dwarf Kindred": 87,
-      "Elemental Kindred": 88,
-      "Atog Kindred": 4,
-      "Airbend": 13,
-      "Avatar Kindred": 54,
-      "Earthbend": 6,
-      "Waterbend": 5,
-      "Eldrazi Kindred": 8,
-      "Bringer Kindred": 5,
-      "Beast Token": 4,
-      "Bestow": 13,
-      "Manticore Kindred": 1,
-      "Golem Kindred": 23,
       "Hero Kindred": 143,
-      "Spider Kindred": 25,
-      "Citizen Token": 18,
-      "Illusion Kindred": 4,
-      "Dragon Token": 4,
-      "Cantrips": 139,
-      "Food": 44,
-      "Freerunning": 2,
-      "Spell Copy": 30,
-      "Enchantment Tokens": 22,
-      "Shrines Matter": 6,
-      "Bear Kindred": 9,
-      "Mutant Kindred": 32,
-      "Ninja Kindred": 29,
-      "Turtle Kindred": 15,
-      "Charge Counters": 14,
-      "Station": 7,
-      "Battles Matter": 11,
-      "Kavu Kindred": 4,
-      "Kavu Token": 1,
-      "Companion": 5,
-      "Elk Kindred": 11,
-      "Angel Token": 36,
-      "Alien Kindred": 6,
-      "Flash": 157,
-      "Cascade": 9,
-      "Rooms Matter": 12,
-      "Crew": 26,
-      "Exhaust": 1,
-      "Vehicles": 84,
-      "Impulse": 25,
-      "Changeling": 14,
-      "Shapeshifter Kindred": 21,
-      "Age Counters": 21,
-      "Cumulative upkeep": 17,
-      "Power-up": 7,
-      "Spy Kindred": 15,
-      "Hexproof from": 7,
-      "Bear Token": 1,
-      "Converge": 3,
-      "Crystal Counters": 1,
-      "Hydra Kindred": 3,
-      "Protection": 85,
-      "Protection from Quality": 62,
-      "Scarecrow Kindred": 1,
-      "Sliver Kindred": 36,
-      "Sliver Token": 3,
-      "Encore": 6,
-      "Sphinx Kindred": 20,
+      "Spell Copy": 31,
       "Wall Kindred": 52,
       "Wall Token": 11,
-      "Elemental Token": 8,
-      "Devoid": 4,
-      "Phasing": 20,
-      "Myr Kindred": 5,
-      "Myr Token": 4,
-      "Hideaway": 4,
-      "Phoenix Kindred": 2,
-      "Faerie Kindred": 20,
+      "Scientist Kindred": 9,
+      "Elemental Kindred": 88,
+      "Doctor Kindred": 28,
+      "Double": 15,
+      "Faerie Kindred": 21,
       "Faerie Token": 3,
       "Surveil": 29,
-      "Double": 15,
-      "Ward": 65,
+      "Ward": 66,
       "Astartes Kindred": 12,
       "Astartes Token": 4,
+      "Impulse": 25,
       "Rampage": 2,
-      "Loyalty Counters": 22,
+      "Flash": 158,
+      "Loyalty Counters": 23,
       "Counterspells": 55,
+      "Golem Kindred": 23,
       "Lairs Matter": 3,
       "Knight Token": 46,
+      "Sphinx Kindred": 20,
+      "Cascade": 9,
       "Vedalken Kindred": 10,
       "Gates Matter": 50,
       "Hero Token": 13,
       "Throw Wide the Gates": 1,
+      "Shapeshifter Kindred": 21,
       "Clue Token": 44,
       "Inquisitor Kindred": 1,
       "Investigate": 44,
       "Connive": 7,
       "Octopus Kindred": 3,
-      "Bird Kindred": 233,
+      "Shadow": 13,
+      "Soltari Kindred": 11,
+      "Hexproof from": 7,
+      "Bird Kindred": 234,
       "Warp": 9,
       "Finality Counters": 11,
       "Soul Counters": 1,
+      "Avatar Kindred": 54,
       "Venture into the dungeon": 14,
-      "Protection from Color": 116,
+      "Protection": 85,
+      "Protection from Color": 117,
+      "Mutant Kindred": 32,
+      "Ninja Kindred": 29,
       "Rat Kindred": 6,
       "Metathran Kindred": 1,
+      "Protection from Quality": 62,
       "Council's dilemma": 2,
       "Gargoyle Kindred": 19,
       "Affinity": 17,
-      "Scientist Kindred": 9,
-      "Doctor Kindred": 25,
       "Egg Kindred": 2,
       "Egg Token": 1,
       "Rabbit Kindred": 28,
       "Backup": 7,
       "Fox Kindred": 45,
+      "Citizen Token": 18,
       "Raccoon Kindred": 1,
       "Junk Token": 2,
       "Junk Tokens": 3,
+      "Bear Kindred": 9,
       "Populate": 16,
       "Rhino Token": 1,
       "Lizard Kindred": 4,
+      "Beast Token": 4,
+      "Sand Kindred": 2,
+      "Sand Token": 4,
       "Deserts Matter": 14,
       "Landwalk": 14,
-      "Cat Token": 29,
+      "Camel Kindred": 7,
+      "Food": 45,
+      "Food Token": 37,
+      "Horse Kindred": 16,
+      "Mount Kindred": 25,
+      "Wolf Kindred": 8,
+      "Cat Token": 30,
       "Dog Token": 5,
       "Token Modification": 15,
+      "Cantrips": 143,
       "Detective Kindred": 31,
       "Dryad Kindred": 9,
       "Goad": 11,
+      "Elemental Token": 8,
       "Hamster Kindred": 2,
       "Ranger Kindred": 17,
       "Shroud": 26,
       "Discover": 5,
       "Parley": 4,
+      "Enchantment Tokens": 23,
+      "Kavu Kindred": 4,
       "Griffin Kindred": 51,
-      "Food Token": 36,
+      "Dragon Token": 4,
       "Archer Kindred": 34,
       "Start your engines!": 10,
       "Boast": 5,
       "Melee": 6,
       "Monk Kindred": 81,
+      "Earthbend": 5,
+      "Earthbending": 5,
       "Formidable": 1,
-      "Wolf Kindred": 7,
       "Fight": 7,
       "Ally Token": 25,
+      "Phasing": 20,
       "Shield Counters": 16,
+      "Bird Token": 29,
       "Exalted": 22,
-      "Bird Token": 28,
       "Alliance": 9,
       "Yeti Kindred": 1,
       "Plot": 5,
+      "Bestow": 13,
       "Nymph Kindred": 6,
       "Fish Kindred": 4,
       "Spider Token": 2,
       "Hippo Kindred": 2,
       "Hippo Token": 2,
       "Phelddagrif Kindred": 2,
+      "Angel Token": 36,
       "Merfolk Kindred": 28,
       "Grand Summon": 1,
-      "Mouse Kindred": 18,
-      "Fabricate": 5,
-      "Servo Kindred": 13,
-      "Wizard Token": 5,
-      "Energy": 31,
-      "Energy Counters": 29,
-      "Resource Engine": 31,
-      "Efreet Kindred": 3,
-      "Prowess": 18,
-      "Suspend": 23,
-      "Time Counters": 33,
-      "Dinosaur Token": 6,
-      "Chimera Kindred": 4,
-      "Performer Kindred": 7,
-      "Kirin Kindred": 8,
-      "Flurry": 6,
-      "Monk Token": 4,
-      "Convoke": 40,
-      "Bolster": 15,
-      "Defender": 68,
-      "Minotaur Kindred": 10,
-      "Stun Counters": 16,
-      "Gotta Go Fast": 1,
-      "Craft": 6,
       "Prepared": 26,
+      "Devoid": 4,
       "Card Selection": 10,
       "Explore": 9,
       "Archon Kindred": 20,
@@ -27152,7 +30689,10 @@
       "Overload": 3,
       "Ninja Token": 4,
       "Sneak": 11,
+      "Turtle Kindred": 15,
       "Cleric Token": 3,
+      "Crew": 26,
+      "Vehicles": 85,
       "Thrull Kindred": 10,
       "Max speed": 9,
       "Evoke": 9,
@@ -27160,16 +30700,18 @@
       "Mentor": 12,
       "Partner": 28,
       "Partner with": 13,
-      "Pilot Kindred": 28,
+      "Pilot Kindred": 29,
       "Aftermath": 9,
       "Hag Kindred": 3,
       "Kithkin Kindred": 85,
       "Kithkin Token": 16,
       "Wither": 2,
       "Revolt": 8,
+      "Servo Kindred": 13,
       "Servo Token": 9,
       "Afterlife": 8,
       "Pillowfort": 26,
+      "Battles Matter": 11,
       "Equip": 76,
       "Ghostform Counters": 1,
       "Entwine": 7,
@@ -27178,15 +30720,18 @@
       "Life to Draw": 1,
       "Lifeloss": 9,
       "Lifeloss Triggers": 9,
+      "Companion": 5,
       "Will of the council": 4,
       "Darkforce Inversion": 1,
       "Samurai Token": 6,
+      "Sliver Kindred": 36,
       "Persist": 7,
+      "Convoke": 40,
       "Peasant Kindred": 27,
       "Cleave": 3,
-      "Horse Kindred": 15,
       "Nomad Kindred": 21,
       "Threshold": 23,
+      "Changeling": 14,
       "Unearth": 6,
       "Battle Cry": 7,
       "Learn": 5,
@@ -27194,10 +30739,64 @@
       "Skeleton Kindred": 3,
       "Blood Token": 3,
       "Miracle": 7,
+      "Defender": 68,
       "Fate Counters": 1,
       "Constellation": 10,
       "Eerie": 5,
+      "Rooms Matter": 12,
       "Friends Forever": 4,
+      "Mouse Kindred": 18,
+      "Fabricate": 5,
+      "Wizard Token": 5,
+      "Spy Kindred": 15,
+      "Energy": 31,
+      "Energy Counters": 29,
+      "Resource Engine": 31,
+      "Efreet Kindred": 3,
+      "Prowess": 18,
+      "Suspend": 23,
+      "Time Counters": 33,
+      "Dinosaur Token": 6,
+      "Chimera Kindred": 4,
+      "Performer Kindred": 7,
+      "Kirin Kindred": 8,
+      "Charge Counters": 14,
+      "Station": 7,
+      "Flurry": 6,
+      "Monk Token": 4,
+      "Bolster": 15,
+      "Minotaur Kindred": 10,
+      "Stun Counters": 16,
+      "Gotta Go Fast": 1,
+      "Craft": 6,
+      "Alien Kindred": 6,
+      "Atog Kindred": 4,
+      "Airbending": 12,
+      "Waterbending": 5,
+      "Eldrazi Kindred": 8,
+      "Bringer Kindred": 5,
+      "Manticore Kindred": 1,
+      "Spider Kindred": 25,
+      "Illusion Kindred": 5,
+      "Freerunning": 2,
+      "Shrines Matter": 6,
+      "Kavu Token": 1,
+      "Elk Kindred": 11,
+      "Exhaust": 1,
+      "Age Counters": 21,
+      "Cumulative upkeep": 17,
+      "Power-up": 7,
+      "Bear Token": 1,
+      "Converge": 3,
+      "Crystal Counters": 1,
+      "Hydra Kindred": 3,
+      "Scarecrow Kindred": 1,
+      "Sliver Token": 3,
+      "Encore": 6,
+      "Myr Kindred": 5,
+      "Myr Token": 4,
+      "Hideaway": 4,
+      "Phoenix Kindred": 2,
       "Wurm Token": 2,
       "Exert": 14,
       "Compleated": 2,
@@ -27209,7 +30808,6 @@
       "Elf Token": 5,
       "Rabbit Token": 9,
       "Support": 9,
-      "Mount Kindred": 24,
       "Troll Kindred": 3,
       "Forestwalk": 1,
       "Renown": 9,
@@ -27230,11 +30828,11 @@
       "Ouphe Kindred": 1,
       "Mystic Kindred": 5,
       "Forestcycling": 1,
-      "Landcycling": 19,
+      "Landcycling": 20,
       "Plainscycling": 13,
-      "Typecycling": 19,
+      "Typecycling": 20,
       "Pegasus Kindred": 25,
-      "Rebel Kindred": 67,
+      "Rebel Kindred": 68,
       "Survival": 7,
       "Survivor Kindred": 8,
       "Storage Counters": 4,
@@ -27245,7 +30843,7 @@
       "Web-slinging": 6,
       "Pavitr's Sevā": 1,
       "No One Dies!": 1,
-      "Basic landcycling": 6,
+      "Basic landcycling": 7,
       "Mutant Token": 7,
       "Training": 7,
       "Depletion Counters": 4,
@@ -27294,10 +30892,10 @@
       "Valiant": 6,
       "Jenova Cells": 1,
       "The Reunion": 1,
-      "Shadow": 12,
-      "Soltari Kindred": 10,
       "Clown Kindred": 3,
       "Retrace": 2,
+      "Airbend": 12,
+      "Waterbend": 4,
       "Detain": 9,
       "Feather Counters": 3,
       "Embalm": 8,
@@ -27324,7 +30922,7 @@
       "Palliation Counters": 1,
       "Starfish Kindred": 1,
       "Forecast": 8,
-      "Homunculus Kindred": 3,
+      "Homunculus Kindred": 4,
       "Dream Counters": 2,
       "Vanishing": 7,
       "Ascend": 7,
@@ -27399,7 +30997,6 @@
       "Assist": 4,
       "Unity Counters": 1,
       "Licid Kindred": 2,
-      "Camel Kindred": 6,
       "Lhurgoyf Kindred": 1,
       "Devour": 1,
       "Goat Kindred": 8,
@@ -27448,6 +31045,8 @@
       "Sculpture Token": 1,
       "Coyote Kindred": 1,
       "Dwarf Token": 3,
+      "Germ Kindred": 2,
+      "Germ Token": 2,
       "Praetor Kindred": 3,
       "Squad": 6,
       "Epic": 1,
@@ -27505,8 +31104,6 @@
       "Golden Rule": 1,
       "Unbreakable Skin": 1,
       "Reprieve Counters": 1,
-      "Germ Kindred": 1,
-      "Germ Token": 1,
       "Living weapon": 1,
       "Cohort": 4,
       "Legal Justice": 1,
@@ -27572,69 +31169,69 @@
       "Ice Counters": 1
     },
     "blue": {
-      "Aggro": 1740,
-      "Card Draw": 1753,
-      "Combat Matters": 1740,
-      "Discard Matters": 519,
-      "Draw Triggers": 345,
-      "Little Fellas": 2323,
-      "Nephilim Kindred": 4,
-      "Wheels": 394,
-      "Big Mana": 2130,
+      "Aggro": 1747,
+      "Card Draw": 1763,
+      "Combat Matters": 1750,
+      "Discard Matters": 521,
+      "Draw Triggers": 346,
+      "Little Fellas": 2335,
+      "Nephilim Kindred": 5,
+      "Wheels": 395,
+      "Big Mana": 2143,
       "Cascade": 19,
       "Exile Matters": 254,
-      "Historics Matter": 1286,
-      "Legends Matter": 1286,
+      "Historics Matter": 1310,
+      "Legends Matter": 1310,
       "Ogre Kindred": 9,
-      "Topdeck": 685,
-      "Trample": 93,
-      "Wizard Kindred": 847,
+      "Topdeck": 687,
+      "Trample": 95,
+      "Wizard Kindred": 852,
       "Angel Kindred": 30,
       "Deathtouch": 35,
-      "Flying": 1257,
-      "Life Matters": 307,
-      "Lifegain": 306,
+      "Flying": 1261,
+      "Life Matters": 309,
+      "Lifegain": 308,
       "Lifelink": 67,
       "Phyrexian Kindred": 71,
-      "Vigilance": 173,
-      "+1/+1 Counters": 557,
+      "Vigilance": 176,
+      "+1/+1 Counters": 558,
       "-1/-1 Counters": 71,
-      "Counters Matter": 967,
-      "Horror Kindred": 80,
+      "Counters Matter": 971,
+      "Horror Kindred": 81,
       "Infect": 50,
       "Midrange": 107,
-      "Planeswalkers": 163,
+      "Planeswalkers": 167,
       "Proliferate": 37,
-      "Superfriends": 163,
-      "Voltron": 1014,
-      "Spells Matter": 2528,
-      "Spellslinger": 2528,
-      "Artifact Tokens": 227,
-      "Artifacts Matter": 1112,
-      "Burn": 338,
-      "Creature Tokens": 448,
-      "Human Kindred": 1117,
+      "Superfriends": 167,
+      "Voltron": 1016,
+      "Spells Matter": 2533,
+      "Spellslinger": 2533,
+      "Artifact Tokens": 229,
+      "Artifacts Matter": 1120,
+      "Burn": 340,
+      "Creature Tokens": 450,
+      "Human Kindred": 1120,
       "Thopter Kindred": 28,
       "Thopter Token": 30,
-      "Token Creation": 740,
-      "Tokens Matter": 744,
-      "Toolbox": 128,
-      "Blink": 899,
-      "Control": 903,
-      "Enter the Battlefield": 899,
-      "Leave the Battlefield": 902,
-      "Mill": 970,
-      "Reanimate": 1057,
-      "Loot": 394,
+      "Token Creation": 747,
+      "Tokens Matter": 751,
+      "Toolbox": 131,
+      "Blink": 903,
+      "Control": 906,
+      "Enter the Battlefield": 903,
+      "Leave the Battlefield": 906,
+      "Mill": 974,
+      "Reanimate": 1062,
+      "Loot": 396,
       "Morph": 50,
-      "Toughness Matters": 1544,
+      "Toughness Matters": 1553,
       "Kicker": 65,
       "Regenerate": 12,
       "Volver Kindred": 3,
-      "Lands Matter": 576,
+      "Lands Matter": 578,
       "Shaman Kindred": 44,
       "Turtle Kindred": 46,
-      "Enchantments Matter": 961,
+      "Enchantments Matter": 962,
       "Graveyard Recursion": 260,
       "Lore Counters": 53,
       "Ore Counters": 60,
@@ -27645,56 +31242,60 @@
       "Nightmare Kindred": 27,
       "Gorgon Kindred": 3,
       "Board Wipes": 85,
-      "Conditional Draw": 409,
-      "Interaction": 1078,
-      "Ramp": 308,
-      "Counterspells": 428,
-      "Flash": 259,
-      "Removal": 325,
+      "Conditional Draw": 413,
+      "Interaction": 1080,
+      "Ramp": 313,
+      "Counterspells": 429,
+      "Flash": 261,
+      "Removal": 326,
       "Snake Kindred": 45,
-      "Stax": 1218,
-      "Surveil": 95,
+      "Stax": 1222,
+      "Surveil": 96,
       "Menace": 33,
-      "Ooze Kindred": 10,
-      "Outlaw Kindred": 380,
-      "Protective Effects": 365,
-      "Rogue Kindred": 255,
-      "Ward": 115,
-      "Clue Token": 69,
+      "Ooze Kindred": 11,
+      "Outlaw Kindred": 381,
+      "Protective Effects": 368,
+      "Rogue Kindred": 256,
+      "Ward": 116,
+      "Clue Token": 70,
       "Gates Matter": 75,
       "Investigate": 69,
-      "Sacrifice to Draw": 136,
+      "Sacrifice to Draw": 138,
       "Alt Fetchland": 6,
-      "Cycling": 112,
+      "Cycling": 113,
       "Landscape Land": 6,
       "Fungus Kindred": 2,
       "Frog Kindred": 43,
-      "Noble Kindred": 68,
+      "Noble Kindred": 70,
       "Aetherborn Kindred": 2,
-      "Cost Reduction": 242,
+      "Cost Reduction": 245,
       "Theft": 165,
-      "X Spells": 342,
+      "X Spells": 344,
       "Ranger Kindred": 7,
-      "Aristocrats": 190,
-      "Sacrifice Matters": 180,
-      "Scientist Kindred": 50,
+      "Aristocrats": 192,
+      "Sacrifice Matters": 182,
+      "Scientist Kindred": 51,
       "Treasure": 45,
       "Treasure Token": 45,
+      "Crab Kindred": 45,
+      "Druid Kindred": 40,
+      "Landfall": 36,
+      "Starfish Kindred": 4,
       "Dinosaur Kindred": 18,
       "Hexproof": 115,
-      "Indestructible": 35,
+      "Indestructible": 36,
       "Mutant Kindred": 78,
       "God Kindred": 31,
-      "Unconditional Draw": 652,
+      "Unconditional Draw": 654,
       "Dragon Kindred": 119,
       "Renew": 4,
-      "Zombie Kindred": 153,
+      "Zombie Kindred": 154,
       "Warrior Kindred": 108,
       "Impulse": 41,
       "Bard Kindred": 15,
       "Elf Kindred": 67,
-      "Faerie Kindred": 127,
-      "Clones": 239,
+      "Faerie Kindred": 128,
+      "Clones": 240,
       "Avatar Kindred": 51,
       "Rat Kindred": 17,
       "Spell Copy": 144,
@@ -27706,146 +31307,89 @@
       "Zombie Token": 38,
       "Leviathan Kindred": 30,
       "Mana Rock": 77,
-      "Druid Kindred": 39,
-      "Mana Dork": 121,
+      "Mana Dork": 123,
       "Druid Token": 3,
       "Delve": 11,
       "Ninja Kindred": 45,
       "Pingers": 90,
-      "Spirit Kindred": 208,
+      "Spirit Kindred": 209,
       "Rad Counters": 7,
       "Graveyard Hate": 82,
-      "Insect Kindred": 25,
+      "Insect Kindred": 26,
       "Lhurgoyf Kindred": 2,
-      "Shapeshifter Kindred": 91,
+      "Shapeshifter Kindred": 92,
       "Pirate Kindred": 94,
       "Populate": 2,
       "Land Types Matter": 71,
       "Hydra Kindred": 6,
       "Hydra Token": 1,
       "Dryad Kindred": 2,
-      "Atog Kindred": 5,
-      "Airbend": 3,
-      "Ally Kindred": 47,
-      "Bending": 28,
-      "Earthbend": 3,
-      "Firebend": 5,
-      "Firebending": 5,
-      "Landfall": 35,
-      "Transform": 123,
-      "Waterbend": 23,
-      "Eldrazi Kindred": 51,
-      "Experience Counters": 5,
-      "Bringer Kindred": 5,
-      "Beast Token": 4,
-      "Construct Kindred": 27,
-      "Auras": 416,
-      "Bestow": 9,
-      "Equipment Matters": 128,
-      "First strike": 30,
-      "Manticore Kindred": 1,
-      "Golem Kindred": 16,
-      "Haste": 55,
-      "Hero Kindred": 95,
-      "Spider Kindred": 15,
-      "Citizen Kindred": 24,
-      "Citizen Token": 1,
-      "Illusion Kindred": 113,
-      "Dragon Token": 9,
-      "Knight Kindred": 52,
-      "Soldier Kindred": 162,
-      "Cantrips": 270,
-      "Food": 13,
-      "Assassin Kindred": 30,
-      "Freerunning": 4,
-      "Enchant": 356,
-      "Enchantment Tokens": 16,
-      "Shrines Matter": 6,
-      "Bear Kindred": 5,
-      "Spirit Token": 22,
-      "Charge Counters": 17,
-      "Robot Kindred": 56,
-      "Robot Token": 10,
-      "Station": 7,
-      "Battles Matter": 11,
-      "Cat Kindred": 29,
-      "Kavu Kindred": 4,
-      "Kavu Token": 1,
-      "Companion": 5,
-      "Elk Kindred": 8,
-      "Angel Token": 6,
+      "Human Token": 13,
       "Scry": 192,
-      "Alien Kindred": 17,
-      "Combat Tricks": 184,
-      "Saproling Kindred": 3,
-      "Saproling Token": 3,
-      "Rooms Matter": 19,
-      "Warlock Kindred": 29,
-      "Crew": 36,
-      "Exhaust": 13,
-      "Vehicles": 68,
-      "Politics": 77,
-      "Changeling": 15,
-      "Warrior Token": 8,
-      "Age Counters": 37,
-      "Cumulative upkeep": 26,
-      "Power-up": 9,
-      "Spy Kindred": 3,
-      "Hexproof from": 5,
-      "Bear Token": 2,
-      "Converge": 7,
-      "Crystal Counters": 1,
-      "Protection": 30,
-      "Protection from Quality": 16,
-      "Scarecrow Kindred": 2,
-      "Sliver Kindred": 29,
-      "Sliver Token": 2,
-      "Encore": 6,
-      "Sphinx Kindred": 82,
+      "Soldier Kindred": 162,
+      "Soldier Token": 21,
+      "Hero Kindred": 95,
       "Wall Kindred": 48,
       "Wall Token": 5,
-      "Cleric Kindred": 46,
-      "Eminence": 3,
-      "Elemental Token": 19,
-      "Devoid": 44,
-      "Phasing": 44,
-      "Myr Kindred": 6,
-      "Myr Token": 3,
-      "Hideaway": 4,
-      "Phoenix Kindred": 1,
-      "Faerie Token": 19,
+      "Politics": 80,
+      "Reach": 28,
+      "Haste": 55,
+      "Doctor Kindred": 25,
       "Double": 12,
+      "Faerie Token": 19,
+      "Warlock Kindred": 29,
+      "Equipment Matters": 128,
+      "Knight Kindred": 52,
+      "Construct Kindred": 30,
       "Astartes Kindred": 6,
       "Astartes Token": 3,
-      "Elder Kindred": 20,
+      "Warrior Token": 8,
+      "Elder Kindred": 21,
       "Rampage": 2,
+      "Combat Tricks": 184,
       "Loyalty Counters": 17,
+      "Golem Kindred": 16,
       "Lairs Matter": 3,
       "Knight Token": 7,
+      "Sphinx Kindred": 82,
       "Vampire Token": 1,
+      "Auras": 417,
       "Vedalken Kindred": 75,
+      "Cat Kindred": 30,
       "Hero Token": 8,
       "Throw Wide the Gates": 1,
       "Inquisitor Kindred": 2,
       "Samurai Kindred": 3,
       "Connive": 31,
       "Octopus Kindred": 55,
+      "Cleric Kindred": 47,
+      "Shadow": 11,
+      "Soltari Kindred": 1,
       "Double strike": 10,
-      "Bird Kindred": 230,
+      "Hexproof from": 5,
+      "Bird Kindred": 231,
       "Warp": 11,
       "Finality Counters": 5,
       "Soul Counters": 1,
+      "Spirit Token": 22,
+      "Citizen Kindred": 24,
       "Giant Kindred": 27,
       "Lifegain Triggers": 5,
-      "Advisor Kindred": 64,
+      "Advisor Kindred": 65,
+      "Assassin Kindred": 30,
       "Assassin Token": 2,
       "Venture into the dungeon": 9,
+      "Eminence": 3,
+      "First strike": 30,
       "Convert": 5,
       "Eye Kindred": 7,
       "More Than Meets the Eye": 5,
-      "Protection from Color": 30,
+      "Robot Kindred": 56,
+      "Protection": 31,
+      "Protection from Color": 31,
       "Metathran Kindred": 8,
-      "Artificer Kindred": 109,
+      "Protection from Quality": 16,
+      "Artificer Kindred": 111,
       "Council's dilemma": 3,
       "Gargoyle Kindred": 9,
       "Affinity": 26,
@@ -27856,15 +31400,25 @@
       "Friends Forever": 3,
       "Dalek Kindred": 1,
       "Dalek Token": 2,
+      "Alien Kindred": 17,
+      "Vehicles": 68,
+      "Enchant": 357,
       "Collection Counters": 1,
+      "Bending": 28,
+      "Firebending": 5,
       "Unearth": 9,
       "Corruption Counters": 1,
+      "Dragon Token": 9,
       "Goblin Kindred": 19,
       "Wraith Kindred": 2,
       "Wraith Token": 2,
+      "Transform": 123,
+      "Illusion Kindred": 113,
       "Goad": 21,
       "Devil Kindred": 1,
       "Devil Token": 1,
+      "Ally Kindred": 47,
+      "Age Counters": 37,
       "Cage Counters": 1,
       "Dethrone": 4,
       "Goblin Formula": 1,
@@ -27879,25 +31433,25 @@
       "Landwalk": 50,
       "Swampwalk": 2,
       "Archer Kindred": 10,
+      "Clown Kindred": 1,
+      "Enchantment Tokens": 16,
       "Equip": 31,
       "Equipment": 35,
       "Snail Kindred": 1,
       "Snail Token": 1,
       "Tiefling Kindred": 4,
-      "Human Token": 13,
-      "Soldier Token": 21,
-      "Reach": 28,
-      "Doctor Kindred": 25,
       "Elephant Kindred": 6,
+      "Bear Token": 2,
       "Cyclops Kindred": 4,
-      "Homunculus Kindred": 26,
+      "Homunculus Kindred": 27,
       "Enrage": 1,
-      "Merfolk Kindred": 301,
+      "Merfolk Kindred": 302,
       "Fight": 6,
       "Scout Kindred": 59,
       "Gremlin Kindred": 1,
       "Gremlin Token": 2,
       "Raid": 11,
+      "Exhaust": 13,
       "Tyranid Kindred": 14,
       "Elephant Token": 3,
       "Harmonize": 5,
@@ -27905,14 +31459,18 @@
       "Energy Counters": 39,
       "Resource Engine": 42,
       "Monkey Kindred": 3,
-      "Bird Token": 26,
+      "Bird Token": 27,
       "Ferocious": 4,
       "Storm": 12,
       "Defender": 90,
       "Snake Token": 2,
+      "Peasant Kindred": 6,
       "Ally Token": 4,
+      "Earthbend": 2,
       "Shroud": 48,
+      "Food": 13,
       "Food Token": 9,
+      "Phasing": 44,
       "Shield Counters": 11,
       "Discover": 5,
       "Exalted": 12,
@@ -27921,8 +31479,9 @@
       "Cat Token": 3,
       "Mercenary Kindred": 4,
       "Plot": 14,
+      "Bestow": 9,
       "Nymph Kindred": 5,
-      "Detective Kindred": 48,
+      "Detective Kindred": 49,
       "Fish Kindred": 54,
       "Fox Kindred": 8,
       "Rabbit Kindred": 4,
@@ -27931,14 +31490,19 @@
       "Hippo Kindred": 4,
       "Hippo Token": 2,
       "Phelddagrif Kindred": 2,
-      "Monk Kindred": 45,
-      "Token Modification": 9,
+      "Monk Kindred": 46,
+      "Token Modification": 10,
+      "Angel Token": 6,
+      "Saproling Kindred": 3,
+      "Saproling Token": 3,
       "Grand Summon": 1,
+      "Freerunning": 4,
       "Rogue Token": 6,
-      "Basic landcycling": 8,
-      "Landcycling": 19,
-      "Typecycling": 21,
+      "Basic landcycling": 9,
+      "Landcycling": 20,
+      "Typecycling": 22,
       "Nightmare Token": 1,
+      "Cantrips": 271,
       "Djinn Kindred": 53,
       "Islandwalk": 25,
       "Alien Token": 1,
@@ -27949,12 +31513,14 @@
       "Transmute": 9,
       "Aftermath": 9,
       "Flashback": 50,
+      "Robot Token": 10,
       "Living metal": 4,
       "Ascend": 9,
       "Evoke": 9,
       "Incarnation Kindred": 7,
       "Employee Kindred": 4,
       "Open an Attraction": 5,
+      "Sliver Kindred": 29,
       "Jump": 8,
       "Jump-start": 8,
       "Inspired": 7,
@@ -27965,24 +31531,33 @@
       "Hit Counters": 1,
       "Disguise": 8,
       "Ninjutsu": 18,
+      "Devoid": 44,
       "Drone Kindred": 29,
+      "Eldrazi Kindred": 51,
       "Ingest": 5,
       "Eerie": 9,
+      "Rooms Matter": 19,
       "Monarch": 12,
       "Persist": 5,
+      "Companion": 5,
       "Kraken Kindred": 35,
+      "Waterbend": 22,
+      "Waterbending": 22,
+      "Crew": 36,
       "Fear": 4,
+      "Battles Matter": 11,
       "Islandcycling": 11,
       "Swampcycling": 1,
       "Leech Kindred": 3,
       "Ninja Token": 2,
-      "Stun Counters": 70,
+      "Stun Counters": 72,
       "Drone Token": 4,
       "Suspend": 32,
       "Time Counters": 42,
       "Skeleton Kindred": 8,
       "Azra Kindred": 1,
       "Disappear": 1,
+      "Cumulative upkeep": 26,
       "Wizard Token": 7,
       "Lord of the Nazgûl": 1,
       "Multiple Copies": 3,
@@ -27990,9 +31565,11 @@
       "Clash": 8,
       "Conspire": 4,
       "Collect evidence": 8,
+      "Changeling": 15,
       "Wither": 1,
       "Prepared": 26,
       "Minion Kindred": 3,
+      "Atog Kindred": 5,
       "Homunculus Token": 2,
       "Shark Kindred": 17,
       "Depletion Counters": 4,
@@ -28004,6 +31581,7 @@
       "Forestwalk": 2,
       "Deserts Matter": 8,
       "Mind Swap": 1,
+      "Spider Kindred": 15,
       "Find New Host": 1,
       "Demon Token": 2,
       "Page Counters": 2,
@@ -28016,7 +31594,7 @@
       "Slug Token": 1,
       "Entwine": 6,
       "Partner with": 15,
-      "Whale Kindred": 20,
+      "Whale Kindred": 21,
       "Wolf Kindred": 3,
       "Processor Kindred": 5,
       "Life to Draw": 1,
@@ -28031,21 +31609,47 @@
       "Dwarf Kindred": 5,
       "Fabricate": 1,
       "Servo Kindred": 4,
+      "Spy Kindred": 3,
       "Efreet Kindred": 10,
       "Prowess": 47,
       "Dinosaur Token": 1,
       "Chimera Kindred": 11,
       "Performer Kindred": 7,
       "Kirin Kindred": 2,
+      "Charge Counters": 17,
+      "Station": 7,
       "Flurry": 4,
       "Monk Token": 3,
       "Convoke": 20,
+      "Kavu Kindred": 4,
       "Bolster": 1,
       "Minotaur Kindred": 5,
       "Gotta Go Fast": 1,
       "Craft": 7,
       "Gnome Kindred": 5,
       "Graveyard Matters": 7,
+      "Airbending": 3,
+      "Earthbending": 2,
+      "Experience Counters": 5,
+      "Bringer Kindred": 5,
+      "Beast Token": 4,
+      "Manticore Kindred": 1,
+      "Citizen Token": 1,
+      "Shrines Matter": 6,
+      "Bear Kindred": 5,
+      "Kavu Token": 1,
+      "Elk Kindred": 8,
+      "Power-up": 9,
+      "Converge": 7,
+      "Crystal Counters": 1,
+      "Scarecrow Kindred": 2,
+      "Sliver Token": 2,
+      "Encore": 6,
+      "Elemental Token": 19,
+      "Myr Kindred": 6,
+      "Myr Token": 3,
+      "Hideaway": 4,
+      "Phoenix Kindred": 1,
       "Treefolk Kindred": 1,
       "Adapt": 10,
       "All Things Are Possible": 1,
@@ -28069,7 +31673,7 @@
       "Spawn Token": 7,
       "Evolve": 11,
       "Otter Kindred": 24,
-      "Manifest": 18,
+      "Manifest": 19,
       "Constellation": 7,
       "Wolf Token": 1,
       "Fish Token": 10,
@@ -28080,7 +31684,6 @@
       "Will of the council": 4,
       "Gargoyle Token": 2,
       "Tyranid Token": 2,
-      "Crab Kindred": 44,
       "Ouphe Kindred": 2,
       "Vivid": 4,
       "Salamander Kindred": 10,
@@ -28108,6 +31711,7 @@
       "Graft": 6,
       "Rebel Kindred": 4,
       "Ravenous": 2,
+      "Tide Counters": 3,
       "Worm Kindred": 3,
       "Retrace": 4,
       "Daybound": 1,
@@ -28152,6 +31756,7 @@
       "From the Future": 1,
       "Reflection Kindred": 3,
       "Time Travel": 4,
+      "Airbend": 2,
       "Unicorn Kindred": 1,
       "Quest Counters": 6,
       "Archon Kindred": 2,
@@ -28168,7 +31773,6 @@
       "Squid Kindred": 8,
       "Sleight Counters": 1,
       "Cid, Timeless Artificer": 1,
-      "Peasant Kindred": 5,
       "Addendum": 5,
       "Gold Token": 2,
       "Skulk": 9,
@@ -28179,10 +31783,9 @@
       "Golem Token": 4,
       "Max speed": 5,
       "Start your engines!": 5,
-      "Merfolk Token": 12,
+      "Merfolk Token": 13,
       "Shard Token": 2,
       "Palliation Counters": 1,
-      "Starfish Kindred": 3,
       "Forecast": 6,
       "Pilot Token": 3,
       "Dream Counters": 2,
@@ -28275,8 +31878,8 @@
       "Licid Kindred": 3,
       "Sneak": 3,
       "Incubation Counters": 1,
-      "Shadow": 9,
       "Trilobite Kindred": 3,
+      "Powerstone Token": 7,
       "Paradigm": 1,
       "Coward Kindred": 1,
       "Vortex Counters": 1,
@@ -28291,7 +31894,6 @@
       "Read Ahead": 2,
       "Hippogriff Kindred": 2,
       "Infection Counters": 1,
-      "Powerstone Token": 6,
       "Undying": 4,
       "Oyster Kindred": 1,
       "Giant Token": 1,
@@ -28302,7 +31904,6 @@
       "Crab Token": 2,
       "Horsemanship": 7,
       "Caves Matter": 3,
-      "Tide Counters": 2,
       "Camarid Kindred": 1,
       "Camarid Token": 1,
       "Sphinx Token": 1,
@@ -28389,228 +31990,177 @@
       "Coin Counters": 1
     },
     "black": {
-      "Aggro": 2165,
-      "Combat Matters": 2165,
-      "Creature Tokens": 603,
-      "Nephilim Kindred": 4,
-      "Sand Kindred": 1,
-      "Sand Token": 1,
-      "Token Creation": 901,
-      "Tokens Matter": 905,
-      "Burn": 1406,
-      "Haste": 104,
-      "Historics Matter": 1252,
-      "Human Kindred": 982,
-      "Legends Matter": 1252,
-      "Soldier Kindred": 129,
-      "Toughness Matters": 1004,
-      "Vigilance": 62,
-      "Card Draw": 1084,
-      "Discard Matters": 385,
-      "Draw Triggers": 415,
-      "Little Fellas": 2099,
-      "Wheels": 440,
-      "Big Mana": 2024,
+      "Aggro": 2180,
+      "Card Draw": 1095,
+      "Combat Matters": 2182,
+      "Discard Matters": 387,
+      "Draw Triggers": 416,
+      "Little Fellas": 2113,
+      "Nephilim Kindred": 5,
+      "Wheels": 442,
+      "Big Mana": 2035,
       "Cascade": 10,
-      "Exile Matters": 207,
+      "Exile Matters": 208,
+      "Historics Matter": 1275,
+      "Legends Matter": 1275,
       "Ogre Kindred": 53,
-      "Topdeck": 341,
-      "Trample": 148,
-      "Wizard Kindred": 253,
-      "Angel Kindred": 39,
+      "Topdeck": 343,
+      "Trample": 149,
+      "Wizard Kindred": 257,
+      "Angel Kindred": 40,
       "Deathtouch": 247,
-      "Flying": 783,
-      "Life Matters": 1361,
-      "Lifegain": 1357,
-      "Lifelink": 313,
-      "Phyrexian Kindred": 207,
-      "+1/+1 Counters": 710,
+      "Flying": 785,
+      "Life Matters": 1368,
+      "Lifegain": 1364,
+      "Lifelink": 316,
+      "Phyrexian Kindred": 209,
+      "Vigilance": 62,
+      "+1/+1 Counters": 716,
       "-1/-1 Counters": 165,
-      "Counters Matter": 1118,
-      "Horror Kindred": 235,
+      "Counters Matter": 1124,
+      "Horror Kindred": 237,
       "Infect": 77,
       "Midrange": 128,
-      "Planeswalkers": 137,
+      "Planeswalkers": 140,
       "Proliferate": 18,
-      "Superfriends": 137,
-      "Voltron": 1059,
-      "Spells Matter": 1930,
-      "Spellslinger": 1930,
+      "Superfriends": 140,
+      "Voltron": 1067,
+      "Spells Matter": 1935,
+      "Spellslinger": 1935,
       "Artifact Tokens": 256,
-      "Artifacts Matter": 826,
+      "Artifacts Matter": 839,
+      "Burn": 1416,
+      "Creature Tokens": 606,
+      "Human Kindred": 986,
       "Thopter Kindred": 2,
       "Thopter Token": 3,
-      "Toolbox": 127,
-      "Blink": 1175,
-      "Control": 404,
-      "Enter the Battlefield": 1175,
-      "Leave the Battlefield": 1176,
-      "Mill": 1590,
-      "Reanimate": 2010,
-      "Graveyard Recursion": 380,
-      "Knight Kindred": 127,
-      "Blight": 15,
-      "Goblin Kindred": 107,
-      "Outlaw Kindred": 626,
-      "Pingers": 386,
-      "Protective Effects": 258,
-      "Unconditional Draw": 245,
-      "Ward": 61,
-      "Warlock Kindred": 156,
-      "Auras": 286,
-      "Enchantments Matter": 812,
-      "Giant Kindred": 32,
-      "Warrior Kindred": 297,
-      "Aristocrats": 979,
-      "Goad": 19,
-      "God Kindred": 33,
-      "Indestructible": 125,
-      "Sacrifice Matters": 975,
-      "Dragon Kindred": 107,
-      "Dragon Token": 8,
-      "Encore": 8,
-      "Kavu Kindred": 5,
-      "Lizard Kindred": 36,
-      "Wurm Kindred": 12,
-      "Lands Matter": 509,
-      "Egg Counters": 2,
-      "Golem Kindred": 12,
-      "Mana Dork": 87,
+      "Token Creation": 908,
+      "Tokens Matter": 912,
+      "Toolbox": 129,
+      "Blink": 1181,
+      "Control": 405,
+      "Enter the Battlefield": 1181,
+      "Leave the Battlefield": 1182,
+      "Mill": 1597,
+      "Reanimate": 2020,
+      "Aristocrats": 989,
+      "Enchantments Matter": 813,
+      "Sacrifice Matters": 985,
+      "Spirit Kindred": 217,
+      "Spirit Token": 41,
       "Mana Rock": 67,
-      "Ramp": 270,
-      "Lairs Matter": 3,
-      "Land Types Matter": 88,
-      "Combat Tricks": 215,
-      "Interaction": 1023,
-      "Stax": 413,
-      "Lhurgoyf Kindred": 7,
-      "Scout Kindred": 21,
-      "Conditional Draw": 206,
-      "Sacrifice to Draw": 152,
-      "Hero Kindred": 25,
-      "Menace": 250,
-      "Transform": 120,
-      "Fuse": 7,
+      "Ramp": 274,
+      "Sacrifice to Draw": 154,
+      "Interaction": 1027,
+      "Removal": 591,
+      "Unconditional Draw": 249,
+      "Cleric Kindred": 187,
+      "Dog Kindred": 25,
+      "Graveyard Recursion": 380,
+      "Mana Dork": 88,
+      "Morph": 27,
+      "Warrior Kindred": 299,
+      "Lands Matter": 511,
       "Graveyard Hate": 205,
-      "Removal": 589,
-      "Insect Kindred": 116,
-      "X Spells": 221,
-      "Clones": 63,
-      "Hydra Kindred": 5,
-      "Charge Counters": 12,
-      "Station": 6,
-      "Regenerate": 135,
-      "Cost Reduction": 122,
-      "Devil Kindred": 20,
-      "Rogue Kindred": 285,
-      "Exalted": 7,
+      "Soldier Kindred": 129,
+      "Auras": 287,
+      "Clones": 64,
+      "Demigod Kindred": 2,
+      "Menace": 253,
+      "Zombie Kindred": 642,
+      "Dragon Kindred": 107,
+      "Toughness Matters": 1012,
+      "Halfling Kindred": 18,
+      "Lifegain Triggers": 39,
+      "Outlaw Kindred": 628,
+      "Rogue Kindred": 287,
+      "Reach": 25,
       "Shaman Kindred": 115,
-      "Blood Token": 37,
-      "Bloodthirst": 5,
-      "Dinosaur Kindred": 13,
-      "Enrage": 1,
-      "Mutant Kindred": 51,
+      "Treefolk Kindred": 24,
+      "Alt Fetchland": 6,
+      "Cycling": 87,
+      "Landscape Land": 6,
+      "Loot": 173,
+      "Cost Reduction": 122,
+      "Druid Kindred": 40,
+      "X Spells": 221,
+      "Board Wipes": 141,
+      "Fungus Kindred": 24,
       "Saproling Kindred": 18,
       "Saproling Token": 17,
-      "Board Wipes": 141,
-      "Berserker Kindred": 37,
-      "Cycling": 86,
-      "Loot": 172,
-      "Theft": 159,
-      "Enchant": 236,
-      "Noble Kindred": 82,
-      "Cat Kindred": 37,
-      "Cat Token": 2,
-      "Landwalk": 53,
-      "Warrior Token": 35,
-      "Cyclops Kindred": 4,
-      "Raccoon Kindred": 1,
-      "Double": 7,
-      "Rhino Kindred": 5,
-      "Treasure": 87,
-      "Treasure Token": 91,
-      "Cleric Kindred": 186,
-      "Orc Kindred": 58,
-      "Kobold Kindred": 3,
-      "Kobold Token": 2,
-      "Citizen Kindred": 16,
-      "Graveborn Kindred": 2,
-      "Graveborn Token": 2,
-      "Artificer Kindred": 37,
-      "Fungus Kindred": 24,
-      "Avatar Kindred": 52,
-      "Druid Kindred": 39,
-      "Pillowfort": 8,
-      "Politics": 91,
-      "Reach": 25,
-      "Spider Kindred": 24,
-      "Scarecrow Kindred": 8,
-      "Kicker": 62,
-      "Alt Fetchland": 6,
-      "Landscape Land": 6,
-      "Elder Kindred": 27,
-      "Advisor Kindred": 38,
-      "Double strike": 6,
-      "Delirium": 25,
-      "Assassin Kindred": 133,
-      "Egg Token": 1,
-      "Insect Token": 16,
-      "Blitz": 5,
-      "Demon Kindred": 214,
-      "Spirit Kindred": 216,
-      "Spirit Token": 41,
-      "Dog Kindred": 25,
-      "Morph": 27,
-      "Demigod Kindred": 2,
-      "Zombie Kindred": 639,
-      "Halfling Kindred": 18,
-      "Lifegain Triggers": 38,
-      "Treefolk Kindred": 24,
+      "Land Types Matter": 88,
       "Elephant Kindred": 3,
+      "Stax": 415,
       "Corrupted": 9,
       "Poison Counters": 54,
       "Toxic": 12,
       "Centaur Kindred": 5,
       "Hexproof": 37,
+      "Indestructible": 126,
+      "Insect Kindred": 116,
       "Nightmare Kindred": 66,
+      "Protective Effects": 259,
+      "Advisor Kindred": 39,
       "Elf Kindred": 115,
+      "Pingers": 389,
+      "God Kindred": 33,
       "Bard Kindred": 12,
+      "Conditional Draw": 209,
       "Sagas Matter": 59,
+      "Kicker": 63,
       "Volver Kindred": 3,
-      "Beast Kindred": 64,
+      "Beast Kindred": 65,
+      "Cat Kindred": 38,
       "Mutate": 11,
+      "Fuse": 7,
+      "Citizen Kindred": 16,
       "Lore Counters": 53,
       "Ore Counters": 61,
       "Djinn Kindred": 7,
+      "Rhino Kindred": 5,
       "First strike": 62,
       "Frog Kindred": 20,
-      "Landfall": 24,
+      "Landfall": 25,
       "Plant Kindred": 15,
       "Plant Token": 3,
-      "Zombie Token": 132,
+      "Zombie Token": 133,
       "Mite Kindred": 3,
       "Mite Token": 2,
       "Phyrexian Token": 9,
+      "Scout Kindred": 22,
+      "Regenerate": 135,
       "Turtle Kindred": 8,
       "Elemental Kindred": 91,
       "Gorgon Kindred": 27,
       "Counterspells": 31,
       "Flash": 88,
       "Snake Kindred": 45,
-      "Surveil": 94,
-      "Ooze Kindred": 15,
+      "Surveil": 96,
+      "Ooze Kindred": 16,
+      "Ward": 61,
       "Clue Token": 32,
       "Gates Matter": 36,
       "Investigate": 26,
+      "Noble Kindred": 84,
       "Aetherborn Kindred": 19,
+      "Theft": 159,
       "Ranger Kindred": 2,
       "Scientist Kindred": 14,
+      "Treasure": 87,
+      "Treasure Token": 91,
+      "Crab Kindred": 4,
+      "Starfish Kindred": 3,
+      "Dinosaur Kindred": 13,
+      "Mutant Kindred": 51,
       "Renew": 5,
-      "Impulse": 30,
+      "Impulse": 31,
       "Faerie Kindred": 53,
-      "Rat Kindred": 111,
+      "Avatar Kindred": 52,
+      "Rat Kindred": 112,
       "Spell Copy": 32,
+      "Demon Kindred": 216,
       "Blood Counters": 4,
+      "Blood Token": 37,
       "Vampire Kindred": 365,
       "Ape Kindred": 4,
       "Leviathan Kindred": 2,
@@ -28618,29 +32168,46 @@
       "Delve": 15,
       "Ninja Kindred": 52,
       "Rad Counters": 11,
+      "Lhurgoyf Kindred": 7,
       "Shapeshifter Kindred": 32,
       "Pirate Kindred": 48,
       "Populate": 2,
+      "Hydra Kindred": 5,
       "Hydra Token": 2,
       "Dryad Kindred": 6,
+      "Assassin Kindred": 133,
       "Memory Counters": 1,
+      "Berserker Kindred": 37,
+      "Goblin Kindred": 108,
+      "Haste": 104,
       "Mobilize": 7,
+      "Warrior Token": 36,
+      "Orc Kindred": 58,
       "Soldier Token": 14,
-      "Eminence": 4,
+      "Knight Kindred": 127,
+      "Eminence": 5,
       "Vampire Token": 18,
+      "Double strike": 6,
       "Graveyard Matters": 6,
       "Magecraft": 7,
+      "Transform": 120,
+      "Warlock Kindred": 156,
       "Ally Kindred": 34,
       "Bending": 26,
-      "Firebend": 15,
-      "Firebending": 14,
+      "Firebending": 16,
       "Samurai Kindred": 13,
-      "Construct Kindred": 24,
+      "Artificer Kindred": 37,
+      "Construct Kindred": 26,
       "Construct Token": 6,
       "Gnome Kindred": 1,
       "Human Token": 11,
       "Experience Counters": 6,
+      "Elder Kindred": 28,
+      "Giant Kindred": 32,
+      "Politics": 93,
+      "Enchant": 236,
       "Goblin Token": 21,
+      "Combat Tricks": 217,
       "Scry": 52,
       "Raid": 14,
       "Bounty Counters": 5,
@@ -28648,83 +32215,43 @@
       "Eye Kindred": 12,
       "Living metal": 5,
       "More Than Meets the Eye": 6,
-      "Robot Kindred": 25,
+      "Robot Kindred": 26,
       "Robot Token": 10,
       "Assassin Token": 5,
       "Monarch": 12,
       "Flashback": 44,
       "Mercenary Kindred": 61,
-      "Equipment Matters": 130,
+      "Equipment Matters": 132,
       "Dwarf Kindred": 9,
-      "Atog Kindred": 4,
-      "Airbend": 1,
-      "Earthbend": 7,
-      "Waterbend": 6,
-      "Eldrazi Kindred": 41,
-      "Bringer Kindred": 5,
-      "Beast Token": 3,
-      "Bestow": 9,
-      "Manticore Kindred": 2,
-      "Citizen Token": 1,
-      "Illusion Kindred": 6,
-      "Cantrips": 115,
-      "Food": 54,
-      "Freerunning": 8,
-      "Enchantment Tokens": 16,
-      "Shrines Matter": 6,
-      "Bear Kindred": 8,
-      "Battles Matter": 10,
-      "Kavu Token": 1,
-      "Companion": 5,
-      "Elk Kindred": 1,
-      "Angel Token": 5,
-      "Alien Kindred": 13,
-      "Rooms Matter": 12,
-      "Crew": 20,
-      "Exhaust": 4,
-      "Vehicles": 45,
-      "Changeling": 11,
-      "Age Counters": 21,
-      "Cumulative upkeep": 15,
-      "Power-up": 4,
-      "Spy Kindred": 6,
-      "Hexproof from": 7,
-      "Bear Token": 1,
-      "Converge": 4,
-      "Crystal Counters": 1,
-      "Protection": 40,
-      "Protection from Quality": 6,
-      "Sliver Kindred": 29,
-      "Sliver Token": 3,
-      "Sphinx Kindred": 11,
-      "Wall Kindred": 23,
-      "Wall Token": 1,
-      "Elemental Token": 3,
-      "Devoid": 42,
-      "Phasing": 6,
-      "Myr Kindred": 3,
-      "Myr Token": 2,
-      "Hideaway": 3,
-      "Phoenix Kindred": 2,
       "Faerie Token": 7,
+      "Double": 7,
       "Astartes Kindred": 11,
       "Astartes Token": 3,
       "Rampage": 1,
       "Loyalty Counters": 14,
+      "Golem Kindred": 12,
+      "Lairs Matter": 3,
       "Knight Token": 7,
+      "Sphinx Kindred": 11,
       "Vedalken Kindred": 5,
+      "Hero Kindred": 25,
       "Hero Token": 3,
       "Throw Wide the Gates": 1,
       "Inquisitor Kindred": 2,
       "Connive": 28,
       "Octopus Kindred": 8,
+      "Shadow": 18,
+      "Soltari Kindred": 1,
+      "Hexproof from": 7,
       "Bird Kindred": 56,
       "Warp": 16,
       "Finality Counters": 24,
       "Soul Counters": 5,
       "Venture into the dungeon": 9,
+      "Protection": 40,
       "Protection from Color": 40,
       "Metathran Kindred": 2,
+      "Protection from Quality": 6,
       "Council's dilemma": 2,
       "Gargoyle Kindred": 4,
       "Affinity": 8,
@@ -28733,12 +32260,19 @@
       "Friends Forever": 2,
       "Dalek Kindred": 6,
       "Dalek Token": 5,
+      "Alien Kindred": 13,
+      "Vehicles": 45,
       "Collection Counters": 1,
       "Unearth": 27,
       "Corruption Counters": 1,
+      "Dragon Token": 8,
       "Wraith Kindred": 14,
       "Wraith Token": 2,
+      "Illusion Kindred": 7,
+      "Goad": 20,
+      "Devil Kindred": 20,
       "Devil Token": 3,
+      "Age Counters": 21,
       "Cage Counters": 1,
       "Dethrone": 1,
       "Goblin Formula": 1,
@@ -28749,163 +32283,227 @@
       "Orc Token": 12,
       "Specter Kindred": 27,
       "Drake Kindred": 9,
+      "Landwalk": 53,
       "Swampwalk": 29,
       "Archer Kindred": 10,
-      "Equip": 50,
-      "Equipment": 52,
+      "Clown Kindred": 1,
+      "Enchantment Tokens": 17,
+      "Equip": 51,
+      "Equipment": 53,
       "Snail Kindred": 2,
       "Snail Token": 1,
       "Tiefling Kindred": 8,
-      "Descend": 8,
-      "Monstrosity": 5,
-      "Snake Token": 5,
-      "Defender": 34,
-      "Disguise": 10,
-      "Fight": 4,
-      "Boar Kindred": 6,
-      "Pest Kindred": 13,
-      "Pest Token": 14,
-      "Bat Kindred": 48,
-      "Badger Kindred": 1,
-      "Domain": 8,
-      "Troll Kindred": 18,
-      "Drone Kindred": 20,
-      "Eldrazi Token": 9,
-      "Scion Kindred": 6,
-      "Scion Token": 5,
-      "Food Token": 46,
-      "Forage": 3,
-      "Squirrel Kindred": 20,
-      "Squirrel Token": 5,
-      "Forestwalk": 5,
-      "Token Modification": 3,
-      "Wolf Kindred": 19,
-      "Wolf Token": 4,
-      "Ooze Token": 1,
-      "Learn": 5,
-      "Worm Kindred": 10,
-      "Worm Token": 4,
-      "Adapt": 6,
-      "Wombat Kindred": 1,
-      "Skeleton Kindred": 81,
-      "Morbid": 11,
-      "Hag Kindred": 7,
-      "Aftermath": 9,
-      "Cleave": 4,
-      "Scavenge": 7,
-      "Prepared": 28,
-      "Incubate": 12,
-      "Incubator Token": 12,
-      "Monster Role Token": 1,
-      "Role Token": 9,
-      "Deserts Matter": 8,
-      "Dredge": 8,
-      "Convoke": 15,
-      "Partner": 27,
-      "Spider Token": 6,
-      "Collect evidence": 5,
-      "Detective Kindred": 16,
-      "Undergrowth": 7,
-      "Partner - Survivors": 2,
-      "Survivor Kindred": 3,
-      "Crocodile Kindred": 16,
-      "Disappear": 7,
-      "Devour": 4,
-      "Elf Token": 10,
-      "Wither": 11,
-      "Peasant Kindred": 8,
-      "Infusion": 7,
-      "Plot": 6,
-      "Partner with": 12,
-      "Plague Counters": 3,
-      "Escape": 12,
-      "Threshold": 32,
-      "Leech Kindred": 15,
-      "Persist": 9,
-      "Bird Token": 3,
-      "Skeleton Token": 7,
-      "Scorpion Kindred": 11,
-      "Open an Attraction": 9,
-      "Performer Kindred": 3,
-      "Fathomless descent": 4,
-      "Time Counters": 16,
-      "Ferocious": 3,
-      "Mount Kindred": 3,
-      "Saddle": 2,
-      "Gamer Kindred": 1,
-      "Guest Kindred": 6,
-      "Fungus Token": 3,
-      "Spore Counters": 2,
-      "Meld": 3,
-      "Pirate Token": 5,
-      "Retrace": 3,
-      "Rogue Token": 16,
-      "Basic landcycling": 6,
-      "Landcycling": 17,
-      "Typecycling": 17,
+      "Blight": 15,
+      "Encore": 8,
+      "Kavu Kindred": 5,
+      "Lizard Kindred": 37,
+      "Wurm Kindred": 12,
+      "Egg Counters": 2,
+      "Charge Counters": 12,
+      "Station": 6,
+      "Exalted": 7,
+      "Bloodthirst": 5,
+      "Enrage": 1,
+      "Cat Token": 2,
+      "Cyclops Kindred": 4,
+      "Raccoon Kindred": 1,
+      "Kobold Kindred": 3,
+      "Kobold Token": 2,
+      "Graveborn Kindred": 2,
+      "Graveborn Token": 2,
+      "Pillowfort": 8,
+      "Spider Kindred": 24,
+      "Scarecrow Kindred": 8,
+      "Delirium": 25,
+      "Egg Token": 1,
+      "Insect Token": 16,
+      "Blitz": 5,
+      "Sand Kindred": 1,
+      "Sand Token": 1,
+      "Freerunning": 8,
+      "Rogue Token": 17,
+      "Basic landcycling": 7,
+      "Landcycling": 18,
+      "Typecycling": 18,
       "Merfolk Kindred": 17,
       "Nightmare Token": 3,
+      "Cantrips": 117,
       "Islandwalk": 2,
       "Alien Token": 1,
+      "Angel Token": 5,
       "Replacement Draw": 4,
       "Cipher": 8,
       "Horror Token": 9,
       "Harpy Kindred": 12,
       "Transmute": 8,
+      "Aftermath": 9,
+      "Detective Kindred": 16,
       "Ascend": 6,
       "Evoke": 7,
       "Incarnation Kindred": 6,
       "Employee Kindred": 8,
+      "Open an Attraction": 9,
+      "Sliver Kindred": 29,
       "Jump": 2,
       "Jump-start": 1,
       "Inspired": 7,
       "Detective Token": 1,
       "Storage Counters": 4,
+      "Threshold": 32,
       "Cloak": 1,
       "Hit Counters": 3,
+      "Disguise": 10,
       "Ninjutsu": 19,
+      "Devoid": 42,
+      "Drone Kindred": 20,
+      "Eldrazi Kindred": 41,
       "Ingest": 4,
       "Eerie": 5,
+      "Rooms Matter": 12,
+      "Persist": 9,
+      "Companion": 5,
       "Kraken Kindred": 3,
+      "Waterbend": 5,
+      "Waterbending": 6,
+      "Crew": 20,
       "Fear": 37,
+      "Battles Matter": 10,
       "Islandcycling": 1,
       "Swampcycling": 11,
+      "Leech Kindred": 15,
       "Ninja Token": 4,
+      "Phasing": 6,
       "Stun Counters": 4,
       "Drone Token": 1,
       "Suspend": 12,
+      "Time Counters": 16,
+      "Skeleton Kindred": 81,
       "Azra Kindred": 8,
+      "Disappear": 7,
+      "Cumulative upkeep": 15,
       "Wizard Token": 5,
       "Lord of the Nazgûl": 1,
       "Multiple Copies": 5,
+      "Crocodile Kindred": 16,
       "Clash": 6,
       "Conspire": 3,
+      "Collect evidence": 5,
+      "Changeling": 11,
+      "Defender": 34,
+      "Wither": 11,
+      "Prepared": 28,
       "Minion Kindred": 43,
+      "Atog Kindred": 4,
       "Homunculus Kindred": 1,
       "Homunculus Token": 1,
       "Shark Kindred": 4,
       "Depletion Counters": 3,
       "Face a dilemma": 1,
       "Siren Kindred": 2,
+      "Partner": 27,
       "Exploit": 14,
+      "Forestwalk": 5,
+      "Deserts Matter": 8,
       "Mind Swap": 1,
       "Find New Host": 1,
       "Demon Token": 19,
       "Page Counters": 1,
       "Photographic Reflexes": 1,
+      "Descend": 8,
       "Body Thief": 2,
       "Takeover Counters": 1,
       "Slime Counters": 1,
       "Slug Kindred": 6,
       "Slug Token": 1,
       "Entwine": 8,
+      "Partner with": 12,
       "Whale Kindred": 1,
+      "Wolf Kindred": 19,
       "Processor Kindred": 3,
       "Life to Draw": 11,
       "Assist": 4,
       "Intimidate": 14,
-      "Rat Token": 20,
+      "Bat Kindred": 48,
+      "Rat Token": 21,
+      "Exhaust": 4,
       "Beholder Kindred": 6,
+      "Card Selection": 11,
+      "Explore": 11,
+      "Archon Kindred": 2,
+      "Coin Counters": 1,
+      "Kor Kindred": 6,
+      "Haunt": 6,
+      "Inkling Kindred": 11,
+      "Inkling Token": 10,
+      "Incubate": 12,
+      "Incubator Token": 12,
+      "Repartee": 7,
+      "Overload": 3,
+      "Sneak": 12,
+      "Cleric Token": 3,
+      "Food": 54,
+      "Thrull Kindred": 31,
+      "Max speed": 10,
+      "Start your engines!": 12,
+      "Mentor": 1,
+      "Bear Kindred": 8,
+      "Pilot Kindred": 6,
+      "Hag Kindred": 7,
+      "Kithkin Kindred": 2,
+      "Kithkin Token": 1,
+      "Revolt": 4,
+      "Servo Kindred": 9,
+      "Servo Token": 4,
+      "Afterlife": 6,
+      "Ghostform Counters": 1,
+      "Token Modification": 3,
+      "Extort": 13,
+      "Bat Token": 9,
+      "Lifeloss": 12,
+      "Lifeloss Triggers": 12,
+      "Will of the council": 3,
+      "Darkforce Inversion": 1,
+      "Samurai Token": 1,
+      "Convoke": 15,
+      "Peasant Kindred": 8,
+      "Cleave": 4,
+      "Horse Kindred": 11,
+      "Nomad Kindred": 1,
+      "Ally Token": 2,
+      "Battle Cry": 2,
+      "Learn": 5,
+      "Griffin Kindred": 1,
+      "Shroud": 3,
+      "Miracle": 3,
+      "Fate Counters": 1,
+      "Fox Kindred": 2,
+      "Constellation": 7,
+      "Food Token": 46,
+      "Airbending": 1,
+      "Earthbending": 7,
+      "Bringer Kindred": 5,
+      "Beast Token": 3,
+      "Bestow": 9,
+      "Manticore Kindred": 2,
+      "Citizen Token": 1,
+      "Earthbend": 6,
+      "Shrines Matter": 6,
+      "Kavu Token": 1,
+      "Elk Kindred": 1,
+      "Power-up": 4,
+      "Spy Kindred": 6,
+      "Bear Token": 1,
+      "Converge": 4,
+      "Crystal Counters": 1,
+      "Sliver Token": 3,
+      "Wall Kindred": 23,
+      "Wall Token": 1,
+      "Elemental Token": 3,
+      "Myr Kindred": 3,
+      "Myr Token": 2,
+      "Hideaway": 3,
+      "Phoenix Kindred": 2,
+      "Scorpion Kindred": 11,
       "Minotaur Kindred": 24,
       "Hellbent": 15,
       "Mercenary Token": 5,
@@ -28914,7 +32512,6 @@
       "Madness": 31,
       "Junk Token": 2,
       "Junk Tokens": 1,
-      "Horse Kindred": 11,
       "Unleash": 9,
       "Oil Counters": 4,
       "Shade Kindred": 33,
@@ -28925,8 +32522,8 @@
       "Heal": 15,
       "Manifest": 8,
       "Manifest dread": 3,
-      "Max speed": 10,
-      "Start your engines!": 12,
+      "Partner - Survivors": 2,
+      "Survivor Kindred": 3,
       "Rebound": 4,
       "Intel Counters": 1,
       "Spectacle": 8,
@@ -28938,60 +32535,70 @@
       "Imp Token": 1,
       "Powerstone Token": 6,
       "Dash": 8,
+      "Escape": 12,
       "Flare Star": 1,
+      "Performer Kindred": 3,
+      "Meld": 3,
       "Storm": 5,
       "Casualty": 7,
       "Hellion Kindred": 1,
       "Barbarian Kindred": 5,
       "Mystic Kindred": 1,
-      "Thrull Kindred": 31,
+      "Troll Kindred": 19,
       "Minotaur Token": 1,
-      "Pilot Kindred": 6,
       "Chaos Control": 1,
       "Ouphe Kindred": 2,
       "Sonic Blast": 1,
+      "Skeleton Token": 7,
       "Berserker Token": 4,
       "Weasel Kindred": 1,
       "Myriad": 3,
       "Bloody Mary": 1,
       "Typhoid Mary": 1,
       "Undying": 9,
-      "Card Selection": 11,
-      "Explore": 11,
-      "Archon Kindred": 2,
-      "Coin Counters": 1,
-      "Kor Kindred": 6,
-      "Haunt": 6,
-      "Inkling Kindred": 11,
-      "Inkling Token": 10,
-      "Repartee": 7,
-      "Overload": 3,
-      "Sneak": 12,
-      "Cleric Token": 3,
-      "Mentor": 1,
-      "Kithkin Kindred": 2,
-      "Kithkin Token": 1,
-      "Revolt": 4,
-      "Servo Kindred": 9,
-      "Servo Token": 4,
-      "Afterlife": 6,
-      "Ghostform Counters": 1,
-      "Extort": 13,
-      "Bat Token": 9,
-      "Lifeloss": 12,
-      "Lifeloss Triggers": 12,
-      "Will of the council": 3,
-      "Darkforce Inversion": 1,
-      "Samurai Token": 1,
-      "Nomad Kindred": 1,
-      "Ally Token": 2,
-      "Battle Cry": 2,
-      "Griffin Kindred": 1,
-      "Shroud": 3,
-      "Miracle": 3,
-      "Fate Counters": 1,
-      "Fox Kindred": 2,
-      "Constellation": 7,
+      "Monstrosity": 5,
+      "Snake Token": 5,
+      "Fight": 4,
+      "Boar Kindred": 6,
+      "Pest Kindred": 13,
+      "Pest Token": 14,
+      "Badger Kindred": 1,
+      "Domain": 8,
+      "Eldrazi Token": 9,
+      "Scion Kindred": 6,
+      "Scion Token": 5,
+      "Forage": 3,
+      "Squirrel Kindred": 20,
+      "Squirrel Token": 5,
+      "Wolf Token": 4,
+      "Ooze Token": 1,
+      "Worm Kindred": 11,
+      "Worm Token": 4,
+      "Adapt": 6,
+      "Wombat Kindred": 1,
+      "Morbid": 11,
+      "Scavenge": 7,
+      "Monster Role Token": 1,
+      "Role Token": 9,
+      "Dredge": 8,
+      "Spider Token": 6,
+      "Undergrowth": 7,
+      "Devour": 4,
+      "Elf Token": 10,
+      "Infusion": 7,
+      "Plot": 6,
+      "Plague Counters": 3,
+      "Bird Token": 3,
+      "Fathomless descent": 4,
+      "Ferocious": 3,
+      "Mount Kindred": 3,
+      "Saddle": 2,
+      "Gamer Kindred": 1,
+      "Guest Kindred": 6,
+      "Fungus Token": 3,
+      "Spore Counters": 2,
+      "Pirate Token": 5,
+      "Retrace": 3,
       "Roll to Visit Your Attractions": 2,
       "Harpy Token": 1,
       "Emerge": 3,
@@ -29041,7 +32648,6 @@
       "Choose a background": 6,
       "Flanking": 4,
       "Horsemanship": 7,
-      "Crab Kindred": 3,
       "Cases Matter": 2,
       "Solved": 2,
       "Fish Kindred": 4,
@@ -29067,7 +32673,6 @@
       "Spell mastery": 4,
       "Offspring": 4,
       "Dauthi Kindred": 11,
-      "Shadow": 15,
       "Jackal Kindred": 5,
       "Void Counters": 2,
       "Plot Counters": 1,
@@ -29081,7 +32686,7 @@
       "Infection Counters": 2,
       "Outlast": 2,
       "Soulbond": 1,
-      "Skunk Kindred": 1,
+      "Skunk Kindred": 2,
       "Cohort": 3,
       "Ice Counters": 1,
       "Beaver Kindred": 1,
@@ -29160,7 +32765,6 @@
       "Will of the Planeswalkers": 1,
       "Offering": 1,
       "Carrier Kindred": 5,
-      "Starfish Kindred": 2,
       "Giant Token": 1,
       "Rat Colony": 1,
       "Death Sickle": 1,
@@ -29197,194 +32801,129 @@
       "Petrification Counters": 1
     },
     "red": {
-      "Aggro": 2483,
-      "Combat Matters": 2483,
-      "Creature Tokens": 550,
-      "Nephilim Kindred": 4,
-      "Sand Kindred": 2,
-      "Sand Token": 3,
-      "Token Creation": 919,
-      "Tokens Matter": 924,
-      "Burn": 2219,
-      "Haste": 533,
-      "Historics Matter": 1333,
-      "Human Kindred": 1155,
-      "Legends Matter": 1333,
-      "Soldier Kindred": 218,
-      "Toughness Matters": 908,
-      "Vigilance": 98,
-      "Card Draw": 757,
-      "Discard Matters": 496,
+      "Aggro": 2492,
+      "Card Draw": 762,
+      "Combat Matters": 2498,
+      "Discard Matters": 500,
       "Draw Triggers": 143,
-      "Little Fellas": 1974,
+      "Little Fellas": 1983,
+      "Nephilim Kindred": 5,
       "Wheels": 150,
-      "Big Mana": 2130,
+      "Big Mana": 2141,
       "Cascade": 28,
-      "Exile Matters": 369,
+      "Exile Matters": 375,
+      "Historics Matter": 1354,
+      "Legends Matter": 1354,
       "Ogre Kindred": 94,
-      "Topdeck": 287,
-      "Trample": 364,
-      "Wizard Kindred": 239,
-      "Artifact Tokens": 326,
-      "Artifacts Matter": 1216,
-      "Life Matters": 334,
-      "Lifegain": 333,
+      "Topdeck": 288,
+      "Trample": 368,
+      "Wizard Kindred": 242,
+      "Artifact Tokens": 328,
+      "Artifacts Matter": 1222,
+      "Burn": 2227,
+      "Creature Tokens": 553,
+      "Human Kindred": 1162,
+      "Life Matters": 338,
+      "Lifegain": 337,
       "Thopter Kindred": 15,
       "Thopter Token": 16,
-      "Toolbox": 142,
-      "Blink": 747,
-      "Control": 299,
-      "Enter the Battlefield": 747,
-      "Leave the Battlefield": 748,
-      "Mill": 653,
-      "Reanimate": 745,
-      "Graveyard Recursion": 261,
-      "Knight Kindred": 103,
-      "-1/-1 Counters": 67,
-      "Blight": 11,
-      "Counters Matter": 895,
-      "Goblin Kindred": 494,
-      "Outlaw Kindred": 305,
-      "Pingers": 490,
-      "Protective Effects": 175,
-      "Unconditional Draw": 241,
-      "Ward": 51,
-      "Warlock Kindred": 37,
-      "Auras": 248,
-      "Enchantments Matter": 797,
-      "Giant Kindred": 127,
-      "Voltron": 971,
-      "Warrior Kindred": 588,
-      "+1/+1 Counters": 572,
-      "Aristocrats": 363,
-      "Goad": 50,
-      "God Kindred": 39,
-      "Indestructible": 73,
-      "Sacrifice Matters": 357,
-      "Dragon Kindred": 301,
-      "Dragon Token": 43,
-      "Flying": 536,
-      "Encore": 7,
-      "Kavu Kindred": 44,
-      "Lizard Kindred": 120,
-      "Wurm Kindred": 14,
-      "Lands Matter": 593,
-      "Egg Counters": 2,
-      "Golem Kindred": 20,
-      "Mana Dork": 166,
-      "Mana Rock": 77,
-      "Ramp": 446,
-      "Lairs Matter": 3,
-      "Land Types Matter": 86,
-      "Combat Tricks": 215,
-      "Interaction": 782,
-      "Spells Matter": 2254,
-      "Spellslinger": 2254,
-      "Stax": 527,
-      "Lhurgoyf Kindred": 4,
-      "Scout Kindred": 42,
-      "Conditional Draw": 178,
-      "Sacrifice to Draw": 86,
-      "Hero Kindred": 109,
-      "Menace": 152,
-      "Transform": 128,
-      "Fuse": 9,
-      "Graveyard Hate": 34,
-      "Removal": 312,
-      "Insect Kindred": 32,
-      "X Spells": 339,
-      "Clones": 92,
-      "Hydra Kindred": 11,
-      "Charge Counters": 24,
-      "Station": 7,
-      "Regenerate": 22,
-      "Cost Reduction": 153,
-      "Devil Kindred": 62,
-      "Midrange": 61,
-      "Rogue Kindred": 146,
-      "Exalted": 2,
-      "Shaman Kindred": 256,
-      "Blood Token": 47,
-      "Bloodthirst": 12,
-      "Dinosaur Kindred": 92,
-      "Enrage": 10,
-      "Mutant Kindred": 56,
-      "Saproling Kindred": 9,
-      "Saproling Token": 8,
-      "Board Wipes": 215,
-      "Berserker Kindred": 124,
-      "Cycling": 97,
-      "Loot": 195,
-      "Theft": 181,
-      "Enchant": 183,
-      "Noble Kindred": 63,
-      "Cat Kindred": 61,
-      "Cat Token": 7,
-      "Landwalk": 35,
-      "Planeswalkers": 139,
-      "Superfriends": 139,
-      "Warrior Token": 24,
-      "Cyclops Kindred": 33,
-      "Raccoon Kindred": 16,
-      "Double": 60,
-      "Rhino Kindred": 7,
-      "Treasure": 189,
-      "Treasure Token": 189,
-      "Cleric Kindred": 41,
-      "Orc Kindred": 86,
-      "Kobold Kindred": 15,
-      "Kobold Token": 4,
-      "Citizen Kindred": 30,
-      "Graveborn Kindred": 2,
-      "Graveborn Token": 2,
-      "Artificer Kindred": 99,
-      "Fungus Kindred": 3,
-      "Avatar Kindred": 45,
-      "Druid Kindred": 27,
-      "Pillowfort": 5,
-      "Politics": 94,
-      "Reach": 87,
-      "Spider Kindred": 22,
-      "Scarecrow Kindred": 4,
-      "Kicker": 63,
-      "Alt Fetchland": 6,
-      "Landscape Land": 6,
-      "Elder Kindred": 21,
-      "Advisor Kindred": 18,
-      "Double strike": 63,
-      "Delirium": 16,
-      "Assassin Kindred": 41,
-      "Egg Token": 4,
-      "Insect Token": 3,
-      "Blitz": 9,
-      "Demon Kindred": 54,
+      "Token Creation": 927,
+      "Tokens Matter": 932,
+      "Toolbox": 143,
+      "Blink": 751,
+      "Control": 300,
+      "Enter the Battlefield": 751,
+      "Leave the Battlefield": 752,
+      "Mill": 655,
+      "Reanimate": 749,
       "First strike": 174,
+      "Warrior Kindred": 590,
+      "Enchantments Matter": 799,
+      "Assassin Kindred": 41,
+      "Counters Matter": 897,
       "Memory Counters": 1,
-      "Angel Kindred": 29,
-      "Lifelink": 59,
+      "Outlaw Kindred": 307,
+      "Berserker Kindred": 125,
+      "Goblin Kindred": 496,
+      "Haste": 533,
+      "Angel Kindred": 30,
+      "Flying": 538,
+      "Kicker": 63,
+      "Lifelink": 60,
+      "Toughness Matters": 914,
+      "Demon Kindred": 55,
       "Mobilize": 7,
-      "Soldier Token": 31,
+      "Warrior Token": 24,
+      "Orc Kindred": 86,
+      "Pingers": 492,
+      "Stax": 528,
+      "Aristocrats": 365,
+      "Sacrifice Matters": 359,
+      "Conditional Draw": 181,
+      "Soldier Kindred": 220,
+      "Soldier Token": 32,
+      "+1/+1 Counters": 574,
+      "Knight Kindred": 103,
+      "Midrange": 61,
+      "Voltron": 975,
+      "Spells Matter": 2260,
+      "Spellslinger": 2260,
+      "Regenerate": 22,
       "Volver Kindred": 3,
+      "Indestructible": 74,
+      "Interaction": 784,
+      "Planeswalkers": 142,
+      "Protective Effects": 177,
+      "Superfriends": 142,
+      "Theft": 182,
+      "Treasure": 190,
+      "Treasure Token": 190,
       "Eminence": 3,
       "Vampire Kindred": 97,
       "Vampire Token": 2,
+      "Double strike": 63,
       "Graveyard Matters": 7,
+      "Graveyard Recursion": 261,
       "Magecraft": 10,
+      "Transform": 128,
+      "Warlock Kindred": 37,
       "Ally Kindred": 60,
       "Bending": 35,
-      "Firebend": 28,
-      "Firebending": 20,
+      "Firebending": 29,
+      "Mana Dork": 167,
+      "Noble Kindred": 65,
+      "Ramp": 450,
+      "X Spells": 340,
+      "Removal": 313,
       "Samurai Kindred": 26,
+      "Artificer Kindred": 99,
       "Construct Kindred": 28,
       "Construct Token": 7,
       "Gnome Kindred": 6,
       "Human Token": 16,
+      "Cleric Kindred": 41,
+      "Dragon Kindred": 302,
+      "Vigilance": 99,
       "Experience Counters": 8,
       "Dog Kindred": 44,
-      "Goblin Token": 76,
+      "Elder Kindred": 22,
+      "Giant Kindred": 127,
+      "Menace": 153,
+      "Cost Reduction": 153,
+      "Politics": 94,
+      "Rogue Kindred": 148,
+      "Auras": 250,
+      "Enchant": 184,
+      "Goblin Token": 77,
+      "Mana Rock": 77,
+      "Sacrifice to Draw": 87,
+      "Combat Tricks": 217,
+      "Scout Kindred": 44,
       "Scry": 68,
+      "Lands Matter": 596,
       "Deathtouch": 23,
       "Raid": 24,
+      "Shaman Kindred": 256,
       "Bounty Counters": 1,
       "Convert": 7,
       "Eye Kindred": 7,
@@ -29392,101 +32931,77 @@
       "More Than Meets the Eye": 7,
       "Robot Kindred": 44,
       "Robot Token": 13,
-      "Spirit Kindred": 125,
+      "Board Wipes": 215,
+      "Spirit Kindred": 126,
+      "Clones": 93,
       "Morph": 28,
       "Assassin Token": 4,
-      "Monarch": 13,
+      "Monarch": 14,
+      "Cycling": 98,
+      "Loot": 196,
+      "Land Types Matter": 87,
+      "Alt Fetchland": 6,
+      "Landscape Land": 6,
       "Flashback": 74,
+      "Cat Kindred": 62,
+      "Dinosaur Kindred": 92,
       "Mutate": 8,
       "Nightmare Kindred": 13,
       "Mercenary Kindred": 40,
-      "Equipment Matters": 229,
+      "Equipment Matters": 230,
       "Lore Counters": 60,
       "Ore Counters": 68,
       "Sagas Matter": 74,
       "Dwarf Kindred": 112,
-      "Elemental Kindred": 328,
-      "Atog Kindred": 5,
-      "Airbend": 1,
-      "Earthbend": 8,
-      "Landfall": 46,
-      "Waterbend": 1,
-      "Eldrazi Kindred": 31,
-      "Bringer Kindred": 5,
-      "Beast Kindred": 138,
-      "Beast Token": 6,
-      "Bestow": 7,
-      "Manticore Kindred": 11,
-      "Citizen Token": 9,
-      "Illusion Kindred": 4,
-      "Phyrexian Kindred": 63,
-      "Cantrips": 119,
-      "Food": 10,
-      "Freerunning": 3,
+      "Hero Kindred": 109,
       "Spell Copy": 137,
-      "Enchantment Tokens": 14,
-      "Shrines Matter": 6,
-      "Bear Kindred": 3,
-      "Spirit Token": 23,
-      "Ninja Kindred": 14,
-      "Turtle Kindred": 18,
-      "Battles Matter": 10,
-      "Kavu Token": 1,
-      "Companion": 4,
-      "Elk Kindred": 3,
-      "Angel Token": 2,
-      "Alien Kindred": 11,
-      "Flash": 49,
-      "Rooms Matter": 9,
-      "Crew": 26,
-      "Exhaust": 15,
-      "Vehicles": 71,
-      "Impulse": 212,
-      "Changeling": 9,
-      "Shapeshifter Kindred": 17,
-      "Age Counters": 19,
-      "Cumulative upkeep": 13,
-      "Power-up": 13,
-      "Spy Kindred": 3,
-      "Hexproof": 16,
-      "Hexproof from": 4,
-      "Bear Token": 2,
-      "Converge": 5,
-      "Crystal Counters": 1,
-      "Protection": 26,
-      "Protection from Quality": 8,
-      "Sliver Kindred": 36,
-      "Sliver Token": 2,
-      "Sphinx Kindred": 2,
       "Wall Kindred": 38,
       "Wall Token": 5,
-      "Bard Kindred": 38,
-      "Elemental Token": 50,
-      "Devoid": 33,
-      "Phasing": 4,
-      "Myr Kindred": 4,
-      "Myr Token": 2,
-      "Hideaway": 2,
-      "Phoenix Kindred": 36,
+      "Reach": 88,
+      "Scientist Kindred": 14,
+      "Unconditional Draw": 242,
+      "Elemental Kindred": 329,
+      "Landfall": 47,
+      "Doctor Kindred": 13,
+      "Double": 60,
       "Astartes Kindred": 8,
       "Pirate Kindred": 74,
       "Finality Counters": 5,
       "Cyberman Kindred": 2,
       "Serpent Kindred": 3,
+      "Fuse": 9,
       "Friends Forever": 4,
+      "Golem Kindred": 20,
+      "Lairs Matter": 3,
       "Dalek Kindred": 2,
       "Dalek Token": 3,
       "Loyalty Counters": 12,
-      "Scientist Kindred": 14,
+      "Alien Kindred": 11,
       "Connive": 2,
-      "Zombie Kindred": 57,
+      "Vehicles": 73,
+      "Zombie Kindred": 58,
+      "Ward": 51,
       "Collection Counters": 1,
+      "Flash": 50,
+      "Impulse": 215,
+      "Mutant Kindred": 56,
       "Unearth": 17,
       "Corruption Counters": 1,
+      "Protection": 27,
+      "Protection from Quality": 8,
+      "Dragon Token": 43,
+      "Spirit Token": 23,
+      "Graveyard Hate": 34,
       "Wraith Kindred": 2,
       "Wraith Token": 1,
       "Horror Kindred": 32,
+      "God Kindred": 39,
+      "Illusion Kindred": 4,
+      "Goad": 52,
+      "Devil Kindred": 62,
       "Devil Token": 12,
+      "Citizen Kindred": 31,
+      "Age Counters": 19,
       "Cage Counters": 1,
       "Dethrone": 6,
       "Frog Kindred": 3,
@@ -29496,11 +33011,15 @@
       "Amass": 28,
       "Army Kindred": 27,
       "Army Token": 24,
+      "Avatar Kindred": 45,
       "Orc Token": 10,
       "Specter Kindred": 2,
       "Drake Kindred": 13,
+      "Landwalk": 35,
       "Swampwalk": 2,
       "Archer Kindred": 29,
+      "Clown Kindred": 7,
+      "Enchantment Tokens": 14,
       "Gates Matter": 29,
       "Investigate": 18,
       "Equip": 72,
@@ -29510,15 +33029,20 @@
       "Snail Kindred": 1,
       "Snail Token": 1,
       "Tiefling Kindred": 7,
-      "Doctor Kindred": 13,
       "Protection from Color": 24,
-      "Elephant Kindred": 8,
+      "Elephant Kindred": 9,
+      "Bear Token": 2,
+      "Cyclops Kindred": 33,
       "Homunculus Kindred": 1,
+      "Enrage": 10,
       "Merfolk Kindred": 9,
       "Fight": 43,
-      "Gremlin Kindred": 14,
-      "Gremlin Token": 6,
+      "Gremlin Kindred": 15,
+      "Gremlin Token": 7,
+      "Beast Kindred": 140,
+      "Hexproof": 16,
       "Ranger Kindred": 12,
+      "Exhaust": 15,
       "Tyranid Kindred": 12,
       "Elephant Token": 3,
       "Harmonize": 5,
@@ -29530,180 +33054,185 @@
       "Bird Kindred": 29,
       "Bird Token": 6,
       "Ferocious": 7,
+      "Bard Kindred": 38,
       "Storm": 19,
       "Defender": 43,
+      "Druid Kindred": 27,
       "Leviathan Kindred": 1,
       "Snake Kindred": 5,
       "Snake Token": 1,
+      "Peasant Kindred": 9,
       "Egg Kindred": 6,
+      "Egg Token": 4,
       "Rabbit Kindred": 3,
       "Backup": 8,
       "Fox Kindred": 3,
+      "Citizen Token": 9,
+      "Raccoon Kindred": 16,
       "Junk Token": 9,
       "Junk Tokens": 9,
+      "Bear Kindred": 3,
       "Populate": 4,
+      "Rhino Kindred": 7,
       "Rhino Token": 1,
+      "Lizard Kindred": 121,
+      "Beast Token": 6,
+      "Sand Kindred": 2,
+      "Sand Token": 3,
       "Deserts Matter": 14,
+      "Camel Kindred": 1,
+      "Food": 11,
+      "Food Token": 8,
+      "Horse Kindred": 12,
+      "Mount Kindred": 11,
+      "Wolf Kindred": 31,
+      "Cat Token": 7,
       "Dog Token": 3,
       "Token Modification": 4,
+      "Cantrips": 119,
       "Detective Kindred": 16,
       "Dryad Kindred": 1,
       "Plant Kindred": 8,
       "Treefolk Kindred": 4,
+      "Elemental Token": 50,
       "Halfling Kindred": 3,
       "Hamster Kindred": 2,
       "Shroud": 5,
-      "Discover": 13,
+      "Discover": 14,
+      "Advisor Kindred": 18,
       "Parley": 2,
+      "Kavu Kindred": 44,
       "Griffin Kindred": 2,
-      "Food Token": 7,
+      "Saproling Kindred": 9,
+      "Saproling Token": 8,
       "Start your engines!": 11,
       "Boast": 8,
       "Melee": 6,
       "Monk Kindred": 42,
+      "Earthbend": 7,
+      "Earthbending": 8,
       "Formidable": 6,
-      "Wolf Kindred": 30,
       "Plant Token": 2,
-      "Scorpion Kindred": 3,
-      "Minotaur Kindred": 98,
-      "Hellbent": 11,
-      "Disguise": 12,
-      "Mercenary Token": 6,
-      "Azra Kindred": 3,
-      "Clue Token": 19,
-      "Knight Token": 7,
-      "Skeleton Kindred": 7,
-      "Imp Kindred": 7,
-      "Bloodstain Counters": 1,
-      "Madness": 20,
-      "Demon Token": 3,
-      "Horse Kindred": 11,
-      "Unleash": 10,
-      "Minion Kindred": 3,
-      "Oil Counters": 17,
-      "Phyrexian Token": 11,
-      "Shade Kindred": 1,
-      "Aftermath": 11,
-      "Rust Counters": 1,
-      "Germ Kindred": 1,
-      "Germ Token": 1,
-      "Living weapon": 1,
-      "Heal": 5,
-      "Manifest": 6,
-      "Manifest dread": 3,
+      "-1/-1 Counters": 67,
+      "Blight": 11,
+      "Encore": 7,
+      "Wurm Kindred": 14,
+      "Egg Counters": 2,
+      "Lhurgoyf Kindred": 4,
+      "Insect Kindred": 32,
+      "Hydra Kindred": 11,
+      "Charge Counters": 24,
+      "Station": 7,
+      "Exalted": 2,
+      "Blood Token": 47,
+      "Bloodthirst": 12,
+      "Kobold Kindred": 15,
+      "Kobold Token": 4,
+      "Graveborn Kindred": 2,
+      "Graveborn Token": 2,
+      "Fungus Kindred": 3,
+      "Pillowfort": 5,
+      "Spider Kindred": 22,
+      "Scarecrow Kindred": 4,
+      "Delirium": 16,
+      "Insect Token": 3,
+      "Blitz": 9,
+      "Fungus Token": 2,
       "Partner - Survivors": 3,
       "Survivor Kindred": 5,
-      "Max speed": 8,
-      "Rebound": 7,
-      "Intel Counters": 1,
-      "Drone Kindred": 15,
-      "Surveil": 14,
-      "Basic landcycling": 7,
-      "Landcycling": 20,
-      "Typecycling": 21,
-      "Spectacle": 6,
-      "Dreadnought Kindred": 1,
-      "Echo": 25,
-      "Mountaincycling": 13,
-      "Swampcycling": 1,
-      "Affinity": 13,
-      "Suspect": 11,
-      "Void": 4,
-      "Warp": 15,
-      "Imp Token": 1,
-      "Powerstone Token": 9,
-      "Beholder Kindred": 2,
-      "Dash": 14,
-      "Escape": 10,
-      "Flare Star": 1,
-      "Wizard Token": 7,
-      "Wither": 12,
-      "Depletion Counters": 3,
-      "Fear": 3,
-      "Performer Kindred": 10,
-      "Meld": 2,
-      "Storage Counters": 4,
-      "Employee Kindred": 5,
-      "Persist": 4,
-      "Casualty": 4,
-      "Hellion Kindred": 22,
-      "Barbarian Kindred": 40,
-      "Threshold": 13,
-      "Mystic Kindred": 1,
-      "Thrull Kindred": 1,
-      "Blood Counters": 1,
-      "Faerie Kindred": 8,
-      "Troll Kindred": 7,
-      "Minotaur Token": 2,
-      "Pilot Kindred": 22,
-      "Chaos Control": 1,
-      "Infect": 13,
-      "Ouphe Kindred": 1,
-      "Sonic Blast": 1,
-      "Partner": 26,
-      "Partner with": 12,
-      "Skeleton Token": 2,
-      "Prepared": 26,
-      "Stun Counters": 5,
-      "Berserker Token": 5,
-      "Weasel Kindred": 1,
-      "Myriad": 7,
-      "Rat Token": 8,
-      "Conspire": 3,
-      "Bloody Mary": 1,
-      "Typhoid Mary": 1,
-      "Undying": 7,
-      "Fungus Token": 2,
+      "Power-up": 13,
       "Alien Token": 2,
       "No Mercy": 1,
       "Mole Kindred": 1,
+      "Powerstone Token": 9,
       "Wolf Token": 6,
       "Daybound": 17,
       "Nightbound": 17,
       "Rebel Kindred": 28,
       "Rebel Token": 9,
       "Modular": 6,
+      "Hellion Kindred": 22,
+      "Escape": 10,
+      "Wither": 12,
       "Centaur Kindred": 7,
       "Boar Kindred": 22,
       "Werewolf Kindred": 43,
+      "Oil Counters": 17,
+      "Phyrexian Kindred": 63,
+      "Surveil": 14,
+      "Minotaur Kindred": 99,
+      "Clue Token": 19,
+      "Performer Kindred": 10,
+      "Cumulative upkeep": 13,
       "Ooze Kindred": 5,
       "Domain": 9,
       "Tribute": 5,
+      "Faerie Kindred": 8,
+      "Sliver Kindred": 36,
       "Riot": 10,
+      "Storage Counters": 4,
       "Satyr Kindred": 18,
+      "Changeling": 9,
+      "Shapeshifter Kindred": 17,
       "Bloodrush": 9,
+      "Conspire": 3,
       "Giant Token": 2,
+      "Troll Kindred": 7,
       "Troll Token": 2,
       "Devour": 10,
       "Juggernaut Kindred": 2,
+      "Aftermath": 11,
       "Badger Kindred": 3,
       "Intimidate": 6,
+      "Battles Matter": 10,
       "Jackal Kindred": 16,
       "Ape Kindred": 11,
+      "Turtle Kindred": 18,
       "Top of the Food Chain": 1,
+      "Atog Kindred": 5,
       "Legendary landwalk": 1,
       "Compleated": 2,
+      "Infect": 13,
+      "Phyrexian Token": 11,
       "Rampage": 5,
       "Ravenous": 3,
       "Noggle Kindred": 5,
+      "Partner": 26,
+      "Partner with": 12,
       "Fetch Counters": 1,
       "Dinosaur Token": 12,
       "Monstrosity": 8,
       "Lizard Token": 2,
+      "Ninja Kindred": 14,
       "Cosmo Memory": 1,
+      "Pilot Kindred": 23,
       "Satyr Token": 5,
+      "Disguise": 12,
       "Basilisk Kindred": 1,
+      "Crew": 27,
+      "Manticore Kindred": 11,
       "Sensational Save": 1,
       "Web-slinging": 1,
+      "Persist": 4,
       "Yeti Kindred": 10,
       "Boar Token": 1,
       "Gnoll Kindred": 2,
       "Pack tactics": 5,
       "Guest Kindred": 4,
-      "Peasant Kindred": 8,
+      "Depletion Counters": 3,
+      "Devoid": 33,
+      "Eldrazi Kindred": 31,
+      "Basic landcycling": 8,
+      "Landcycling": 21,
+      "Typecycling": 22,
       "Forestcycling": 1,
+      "Mountaincycling": 13,
       "Evoke": 8,
       "Incarnation Kindred": 7,
+      "Barbarian Kindred": 41,
+      "Heal": 5,
+      "Prepared": 26,
+      "Drone Kindred": 15,
       "Eldrazi Token": 9,
       "Spawn Kindred": 8,
       "Spawn Token": 9,
@@ -29711,6 +33240,8 @@
       "Fabricate": 1,
       "Proliferate": 4,
       "Servo Kindred": 4,
+      "Wizard Token": 7,
+      "Spy Kindred": 3,
       "Efreet Kindred": 19,
       "Djinn Kindred": 22,
       "Prowess": 44,
@@ -29722,10 +33253,86 @@
       "Monk Token": 4,
       "Convoke": 11,
       "Bolster": 1,
+      "Stun Counters": 5,
+      "Angel Token": 2,
       "Ally Token": 9,
       "Gotta Go Fast": 1,
+      "Phasing": 4,
       "Craft": 5,
       "Lifegain Triggers": 2,
+      "Knight Token": 7,
+      "Airbending": 1,
+      "Waterbending": 1,
+      "Bringer Kindred": 5,
+      "Bestow": 7,
+      "Freerunning": 3,
+      "Shrines Matter": 6,
+      "Kavu Token": 1,
+      "Companion": 4,
+      "Elk Kindred": 3,
+      "Rooms Matter": 9,
+      "Hexproof from": 4,
+      "Converge": 5,
+      "Crystal Counters": 1,
+      "Sliver Token": 2,
+      "Sphinx Kindred": 2,
+      "Myr Kindred": 4,
+      "Myr Token": 2,
+      "Hideaway": 2,
+      "Phoenix Kindred": 36,
+      "Scorpion Kindred": 3,
+      "Hellbent": 11,
+      "Mercenary Token": 6,
+      "Azra Kindred": 3,
+      "Skeleton Kindred": 7,
+      "Imp Kindred": 7,
+      "Bloodstain Counters": 1,
+      "Madness": 20,
+      "Demon Token": 3,
+      "Unleash": 10,
+      "Minion Kindred": 3,
+      "Shade Kindred": 1,
+      "Rust Counters": 1,
+      "Germ Kindred": 1,
+      "Germ Token": 1,
+      "Living weapon": 1,
+      "Manifest": 6,
+      "Manifest dread": 3,
+      "Max speed": 8,
+      "Rebound": 7,
+      "Intel Counters": 1,
+      "Spectacle": 6,
+      "Dreadnought Kindred": 1,
+      "Echo": 25,
+      "Swampcycling": 1,
+      "Affinity": 13,
+      "Suspect": 11,
+      "Void": 4,
+      "Warp": 15,
+      "Imp Token": 1,
+      "Beholder Kindred": 2,
+      "Dash": 14,
+      "Flare Star": 1,
+      "Fear": 3,
+      "Meld": 2,
+      "Employee Kindred": 5,
+      "Casualty": 4,
+      "Threshold": 13,
+      "Mystic Kindred": 1,
+      "Thrull Kindred": 1,
+      "Blood Counters": 1,
+      "Minotaur Token": 2,
+      "Chaos Control": 1,
+      "Ouphe Kindred": 1,
+      "Sonic Blast": 1,
+      "Skeleton Token": 2,
+      "Berserker Token": 5,
+      "Weasel Kindred": 1,
+      "Myriad": 7,
+      "Rat Token": 8,
+      "Bloody Mary": 1,
+      "Typhoid Mary": 1,
+      "Undying": 7,
       "Otter Kindred": 16,
       "Cleave": 2,
       "Partner - Father & Son": 2,
@@ -29800,7 +33407,6 @@
       "Card Selection": 3,
       "Explore": 2,
       "Metalcraft": 7,
-      "Mount Kindred": 10,
       "Rally": 5,
       "Kor Token": 1,
       "Mutant Token": 2,
@@ -29812,7 +33418,6 @@
       "The Reunion": 1,
       "Shadow": 1,
       "Soltari Kindred": 1,
-      "Clown Kindred": 6,
       "Learn": 5,
       "Renown": 5,
       "Rad Counters": 2,
@@ -29836,6 +33441,7 @@
       "Nomad Kindred": 6,
       "Enlist": 4,
       "+1/+0 Counters": 4,
+      "Protection from Creature Type": 1,
       "Horsemanship": 6,
       "Entwine": 6,
       "Gargoyle Kindred": 2,
@@ -30004,206 +33610,143 @@
       "Ninjutsu": 1
     },
     "green": {
-      "Aggro": 2574,
-      "Combat Matters": 2574,
-      "Creature Tokens": 732,
-      "Nephilim Kindred": 4,
-      "Sand Kindred": 4,
-      "Sand Token": 3,
-      "Token Creation": 1039,
-      "Tokens Matter": 1042,
-      "Burn": 458,
-      "Haste": 107,
-      "Historics Matter": 1177,
-      "Human Kindred": 828,
-      "Legends Matter": 1177,
-      "Soldier Kindred": 118,
-      "Toughness Matters": 1106,
-      "Vigilance": 205,
-      "Card Draw": 714,
-      "Discard Matters": 164,
+      "Aggro": 2587,
+      "Card Draw": 719,
+      "Combat Matters": 2589,
+      "Discard Matters": 166,
       "Draw Triggers": 111,
-      "Little Fellas": 2106,
+      "Little Fellas": 2117,
+      "Nephilim Kindred": 5,
       "Wheels": 117,
-      "Big Mana": 2249,
+      "Big Mana": 2263,
       "Cascade": 18,
-      "Exile Matters": 122,
+      "Exile Matters": 123,
+      "Historics Matter": 1198,
+      "Legends Matter": 1198,
       "Ogre Kindred": 10,
-      "Topdeck": 445,
-      "Trample": 566,
-      "Wizard Kindred": 118,
+      "Topdeck": 446,
+      "Trample": 570,
+      "Wizard Kindred": 120,
       "Angel Kindred": 20,
-      "Deathtouch": 104,
+      "Deathtouch": 106,
       "Flying": 228,
-      "Life Matters": 697,
-      "Lifegain": 697,
+      "Life Matters": 701,
+      "Lifegain": 701,
       "Lifelink": 77,
-      "Phyrexian Kindred": 91,
-      "+1/+1 Counters": 1346,
+      "Phyrexian Kindred": 92,
+      "Vigilance": 208,
+      "+1/+1 Counters": 1354,
       "-1/-1 Counters": 115,
-      "Counters Matter": 1652,
+      "Counters Matter": 1661,
       "Horror Kindred": 47,
       "Infect": 92,
       "Midrange": 178,
-      "Planeswalkers": 152,
+      "Planeswalkers": 155,
       "Proliferate": 34,
-      "Superfriends": 152,
-      "Voltron": 1663,
-      "Spells Matter": 1623,
-      "Spellslinger": 1623,
-      "Control": 268,
-      "Graveyard Recursion": 262,
-      "Knight Kindred": 61,
-      "Mill": 897,
-      "Reanimate": 926,
-      "Blight": 2,
-      "Goblin Kindred": 35,
-      "Outlaw Kindred": 107,
-      "Pingers": 76,
-      "Protective Effects": 406,
-      "Unconditional Draw": 274,
-      "Ward": 81,
-      "Warlock Kindred": 26,
-      "Auras": 310,
-      "Enchantments Matter": 913,
-      "Giant Kindred": 49,
-      "Warrior Kindred": 447,
-      "Aristocrats": 333,
-      "Goad": 8,
-      "God Kindred": 24,
-      "Indestructible": 131,
-      "Sacrifice Matters": 314,
-      "Blink": 899,
-      "Dragon Kindred": 103,
-      "Dragon Token": 11,
-      "Enter the Battlefield": 899,
-      "Leave the Battlefield": 900,
-      "Encore": 4,
-      "Kavu Kindred": 26,
-      "Lizard Kindred": 61,
-      "Wurm Kindred": 97,
-      "Lands Matter": 1093,
-      "Egg Counters": 2,
-      "Artifacts Matter": 769,
-      "Golem Kindred": 18,
-      "Mana Dork": 320,
-      "Mana Rock": 68,
-      "Ramp": 877,
-      "Lairs Matter": 3,
-      "Land Types Matter": 116,
-      "Combat Tricks": 226,
-      "Interaction": 742,
-      "Toolbox": 190,
-      "Stax": 459,
-      "Lhurgoyf Kindred": 8,
-      "Scout Kindred": 135,
-      "Conditional Draw": 198,
-      "Sacrifice to Draw": 85,
-      "Hero Kindred": 90,
-      "Menace": 38,
-      "Transform": 122,
-      "Fuse": 7,
-      "Graveyard Hate": 48,
-      "Removal": 319,
-      "Insect Kindred": 160,
-      "X Spells": 297,
-      "Clones": 103,
-      "Hydra Kindred": 59,
-      "Charge Counters": 12,
-      "Station": 7,
-      "Regenerate": 106,
-      "Cost Reduction": 134,
-      "Devil Kindred": 2,
-      "Rogue Kindred": 61,
-      "Exalted": 11,
-      "Shaman Kindred": 201,
-      "Blood Token": 20,
-      "Bloodthirst": 11,
-      "Dinosaur Kindred": 126,
-      "Enrage": 14,
-      "Mutant Kindred": 99,
-      "Saproling Kindred": 76,
-      "Saproling Token": 76,
-      "Board Wipes": 83,
-      "Berserker Kindred": 27,
-      "Cycling": 88,
-      "Loot": 103,
-      "Theft": 37,
-      "Enchant": 226,
-      "Noble Kindred": 58,
-      "Cat Kindred": 130,
-      "Cat Token": 12,
-      "Landwalk": 71,
-      "Warrior Token": 49,
-      "Cyclops Kindred": 5,
-      "Raccoon Kindred": 19,
-      "Double": 67,
-      "Rhino Kindred": 54,
-      "Artifact Tokens": 212,
-      "Treasure": 52,
-      "Treasure Token": 51,
-      "Cleric Kindred": 63,
-      "Orc Kindred": 7,
-      "Kobold Kindred": 1,
-      "Kobold Token": 1,
-      "Citizen Kindred": 62,
-      "Graveborn Kindred": 1,
-      "Graveborn Token": 1,
-      "Artificer Kindred": 32,
-      "Fungus Kindred": 60,
-      "Avatar Kindred": 55,
-      "Druid Kindred": 371,
-      "Pillowfort": 7,
-      "Politics": 64,
-      "Reach": 309,
-      "Spider Kindred": 106,
-      "Scarecrow Kindred": 8,
-      "Kicker": 72,
-      "Alt Fetchland": 7,
-      "Landscape Land": 6,
-      "Elder Kindred": 21,
-      "Advisor Kindred": 32,
-      "Double strike": 7,
-      "Delirium": 29,
-      "Assassin Kindred": 16,
-      "Egg Token": 3,
-      "Insect Token": 39,
-      "Blitz": 5,
-      "Demon Kindred": 8,
+      "Superfriends": 155,
+      "Voltron": 1671,
+      "Spells Matter": 1629,
+      "Spellslinger": 1629,
+      "Aristocrats": 337,
+      "Creature Tokens": 735,
+      "Enchantments Matter": 914,
+      "Sacrifice Matters": 318,
       "Spirit Kindred": 139,
       "Spirit Token": 19,
+      "Token Creation": 1049,
+      "Tokens Matter": 1052,
+      "Artifacts Matter": 771,
+      "Mana Rock": 68,
+      "Ramp": 884,
+      "Sacrifice to Draw": 86,
+      "Burn": 462,
+      "Interaction": 744,
+      "Removal": 319,
+      "Toolbox": 191,
+      "Unconditional Draw": 275,
+      "Cleric Kindred": 63,
       "Dog Kindred": 40,
+      "Graveyard Recursion": 262,
+      "Mana Dork": 325,
+      "Mill": 900,
+      "Reanimate": 930,
+      "Human Kindred": 832,
       "Morph": 32,
+      "Warrior Kindred": 450,
+      "Lands Matter": 1099,
+      "Graveyard Hate": 48,
+      "Soldier Kindred": 120,
+      "Auras": 310,
+      "Clones": 103,
       "Demigod Kindred": 3,
-      "Zombie Kindred": 60,
+      "Menace": 38,
+      "Zombie Kindred": 61,
+      "Blink": 903,
+      "Enter the Battlefield": 903,
+      "Leave the Battlefield": 904,
+      "Dragon Kindred": 103,
+      "Toughness Matters": 1112,
       "Halfling Kindred": 22,
       "Lifegain Triggers": 20,
+      "Outlaw Kindred": 108,
+      "Rogue Kindred": 61,
+      "Reach": 311,
+      "Shaman Kindred": 201,
       "Treefolk Kindred": 114,
-      "Elephant Kindred": 59,
+      "Alt Fetchland": 7,
+      "Cycling": 89,
+      "Landscape Land": 6,
+      "Loot": 104,
+      "Cost Reduction": 135,
+      "Druid Kindred": 372,
+      "X Spells": 298,
+      "Board Wipes": 83,
+      "Fungus Kindred": 60,
+      "Saproling Kindred": 76,
+      "Saproling Token": 76,
+      "Land Types Matter": 117,
+      "Elephant Kindred": 60,
+      "Stax": 461,
       "Corrupted": 6,
       "Poison Counters": 47,
       "Toxic": 17,
       "Centaur Kindred": 75,
-      "Hexproof": 127,
+      "Hexproof": 129,
+      "Indestructible": 132,
+      "Insect Kindred": 160,
       "Nightmare Kindred": 12,
+      "Protective Effects": 408,
+      "Advisor Kindred": 32,
       "Elf Kindred": 605,
+      "Pingers": 77,
+      "God Kindred": 24,
       "Bard Kindred": 20,
+      "Conditional Draw": 200,
       "Sagas Matter": 68,
+      "Kicker": 72,
       "Volver Kindred": 3,
-      "Beast Kindred": 347,
+      "Beast Kindred": 352,
+      "Cat Kindred": 131,
       "Mutate": 12,
+      "Control": 269,
+      "Fuse": 7,
+      "Citizen Kindred": 63,
       "Lore Counters": 57,
       "Ore Counters": 86,
       "Djinn Kindred": 4,
+      "Rhino Kindred": 54,
       "First strike": 30,
-      "Frog Kindred": 56,
-      "Landfall": 125,
+      "Frog Kindred": 57,
+      "Landfall": 129,
       "Plant Kindred": 103,
       "Plant Token": 11,
       "Zombie Token": 7,
+      "Artifact Tokens": 214,
       "Mite Kindred": 2,
       "Mite Token": 1,
       "Phyrexian Token": 16,
+      "Scout Kindred": 136,
+      "Regenerate": 106,
       "Turtle Kindred": 38,
       "Elemental Kindred": 235,
       "Gorgon Kindred": 11,
@@ -30211,265 +33754,241 @@
       "Flash": 102,
       "Snake Kindred": 119,
       "Surveil": 31,
-      "Ooze Kindred": 47,
+      "Ooze Kindred": 48,
+      "Ward": 81,
       "Clue Token": 34,
       "Gates Matter": 48,
       "Investigate": 34,
+      "Noble Kindred": 60,
       "Aetherborn Kindred": 1,
+      "Theft": 37,
       "Ranger Kindred": 52,
-      "Scientist Kindred": 16,
+      "Scientist Kindred": 18,
+      "Treasure": 52,
+      "Treasure Token": 51,
+      "Crab Kindred": 8,
+      "Starfish Kindred": 1,
+      "Dinosaur Kindred": 128,
+      "Mutant Kindred": 100,
       "Renew": 5,
       "Impulse": 17,
       "Faerie Kindred": 25,
+      "Avatar Kindred": 56,
       "Rat Kindred": 2,
-      "Spell Copy": 36,
+      "Spell Copy": 37,
+      "Demon Kindred": 8,
       "Blood Counters": 1,
+      "Blood Token": 20,
       "Vampire Kindred": 5,
-      "Ape Kindred": 33,
+      "Ape Kindred": 35,
       "Leviathan Kindred": 9,
       "Druid Token": 4,
       "Delve": 4,
       "Ninja Kindred": 19,
       "Rad Counters": 6,
+      "Lhurgoyf Kindred": 8,
       "Shapeshifter Kindred": 30,
-      "Pirate Kindred": 2,
+      "Pirate Kindred": 3,
       "Populate": 14,
+      "Hydra Kindred": 59,
       "Hydra Token": 3,
-      "Dryad Kindred": 57,
-      "Atog Kindred": 4,
-      "Airbend": 1,
-      "Ally Kindred": 55,
-      "Bending": 34,
-      "Earthbend": 32,
-      "Firebend": 3,
-      "Firebending": 3,
-      "Waterbend": 2,
-      "Eldrazi Kindred": 45,
-      "Experience Counters": 4,
-      "Bringer Kindred": 5,
-      "Beast Token": 46,
-      "Construct Kindred": 12,
-      "Bestow": 11,
-      "Equipment Matters": 110,
-      "Manticore Kindred": 2,
-      "Citizen Token": 14,
-      "Illusion Kindred": 2,
-      "Cantrips": 127,
-      "Food": 107,
-      "Freerunning": 2,
-      "Enchantment Tokens": 15,
-      "Shrines Matter": 6,
-      "Bear Kindred": 68,
-      "Robot Kindred": 11,
-      "Robot Token": 4,
-      "Battles Matter": 10,
-      "Kavu Token": 2,
-      "Companion": 4,
-      "Elk Kindred": 30,
-      "Angel Token": 3,
+      "Dryad Kindred": 58,
+      "Human Token": 18,
       "Scry": 54,
-      "Alien Kindred": 15,
-      "Rooms Matter": 6,
-      "Crew": 15,
-      "Exhaust": 15,
-      "Vehicles": 43,
-      "Changeling": 17,
-      "Age Counters": 26,
-      "Cumulative upkeep": 20,
-      "Power-up": 14,
-      "Spy Kindred": 1,
-      "Hexproof from": 5,
-      "Bear Token": 14,
-      "Converge": 10,
-      "Crystal Counters": 1,
-      "Protection": 42,
-      "Protection from Quality": 15,
-      "Sliver Kindred": 31,
-      "Sliver Token": 3,
-      "Sphinx Kindred": 1,
+      "Soldier Token": 21,
+      "Hero Kindred": 90,
       "Wall Kindred": 28,
       "Wall Token": 5,
-      "Eminence": 2,
-      "Elemental Token": 16,
-      "Devoid": 30,
-      "Phasing": 4,
-      "Myr Kindred": 2,
-      "Myr Token": 1,
-      "Hideaway": 4,
-      "Phoenix Kindred": 1,
-      "Human Token": 18,
-      "Soldier Token": 20,
-      "Doctor Kindred": 13,
+      "Politics": 64,
+      "Haste": 107,
+      "Doctor Kindred": 14,
+      "Double": 68,
+      "Protection": 42,
       "Protection from Color": 33,
+      "Bear Token": 14,
+      "Giant Kindred": 50,
+      "Cyclops Kindred": 5,
       "Homunculus Kindred": 3,
+      "Enrage": 14,
+      "Transform": 122,
       "Merfolk Kindred": 61,
+      "Dragon Token": 11,
       "Fight": 119,
+      "Artificer Kindred": 32,
       "Gremlin Kindred": 1,
       "Gremlin Token": 1,
+      "Ally Kindred": 55,
+      "Bending": 34,
+      "Firebending": 3,
       "Raid": 1,
+      "Double strike": 7,
+      "Exhaust": 15,
       "Tyranid Kindred": 28,
       "Elephant Token": 14,
       "Harmonize": 4,
       "Energy": 24,
       "Energy Counters": 24,
       "Resource Engine": 24,
+      "Vehicles": 43,
       "Monkey Kindred": 8,
-      "Bird Kindred": 43,
-      "Bird Token": 11,
+      "Bird Kindred": 44,
+      "Bird Token": 12,
       "Ferocious": 15,
+      "Orc Kindred": 7,
       "Storm": 6,
+      "Combat Tricks": 228,
       "Defender": 50,
       "Snake Token": 14,
+      "Peasant Kindred": 16,
       "Egg Kindred": 3,
+      "Egg Token": 3,
       "Rabbit Kindred": 20,
       "Backup": 7,
       "Fox Kindred": 5,
+      "Citizen Token": 14,
+      "Raccoon Kindred": 19,
+      "Equipment Matters": 110,
       "Mercenary Kindred": 11,
       "Junk Token": 3,
       "Junk Tokens": 3,
+      "Bear Kindred": 68,
+      "Assassin Kindred": 16,
       "Rhino Token": 10,
+      "Lizard Kindred": 62,
+      "Beast Token": 46,
+      "Sand Kindred": 4,
+      "Sand Token": 3,
+      "Warrior Token": 49,
       "Deserts Matter": 21,
+      "Landwalk": 71,
+      "Camel Kindred": 2,
+      "Food": 109,
+      "Food Token": 100,
+      "Horse Kindred": 11,
+      "Mount Kindred": 21,
+      "Wolf Kindred": 105,
       "Monarch": 11,
+      "Cat Token": 12,
       "Dog Token": 3,
       "Token Modification": 16,
+      "Cantrips": 127,
       "Detective Kindred": 19,
+      "Goad": 8,
+      "Elemental Token": 16,
+      "Knight Kindred": 61,
       "Hamster Kindred": 2,
       "Shroud": 40,
-      "Discover": 8,
+      "Elder Kindred": 22,
+      "Discover": 9,
       "Parley": 6,
+      "Enchantment Tokens": 15,
+      "Kavu Kindred": 26,
       "Griffin Kindred": 2,
-      "Food Token": 98,
+      "Golem Kindred": 18,
+      "Lairs Matter": 3,
       "Archer Kindred": 66,
       "Start your engines!": 3,
       "Boast": 2,
+      "Protection from Quality": 15,
       "Melee": 4,
       "Monk Kindred": 33,
+      "Earthbend": 31,
+      "Earthbending": 31,
+      "Enchant": 226,
       "Convert": 2,
       "Eye Kindred": 2,
       "Formidable": 9,
       "Living metal": 1,
       "More Than Meets the Eye": 2,
-      "Wolf Kindred": 104,
-      "Descend": 5,
-      "Monstrosity": 15,
-      "Disguise": 12,
-      "Boar Kindred": 41,
-      "Pest Kindred": 14,
-      "Pest Token": 14,
-      "Bat Kindred": 1,
-      "Badger Kindred": 12,
-      "Domain": 24,
-      "Troll Kindred": 52,
-      "Drone Kindred": 17,
-      "Eldrazi Token": 26,
-      "Scion Kindred": 9,
-      "Scion Token": 11,
-      "Forage": 6,
-      "Squirrel Kindred": 42,
-      "Squirrel Token": 21,
-      "Forestwalk": 24,
-      "Bounty Counters": 1,
-      "Wolf Token": 41,
-      "Ooze Token": 14,
-      "Learn": 4,
-      "Worm Kindred": 5,
-      "Worm Token": 3,
-      "Adapt": 15,
-      "Wombat Kindred": 2,
-      "Flashback": 51,
-      "Skeleton Kindred": 8,
-      "Morbid": 14,
-      "Hag Kindred": 4,
-      "Aftermath": 10,
-      "Cleave": 2,
-      "Scavenge": 10,
-      "Prepared": 20,
-      "Incubate": 6,
-      "Incubator Token": 6,
-      "Monster Role Token": 5,
-      "Role Token": 9,
-      "Loyalty Counters": 16,
-      "Dredge": 7,
-      "Convoke": 26,
-      "Partner": 28,
-      "Spider Token": 16,
-      "Collect evidence": 8,
-      "Undergrowth": 9,
-      "Partner - Survivors": 2,
-      "Survivor Kindred": 9,
-      "Crocodile Kindred": 19,
-      "Disappear": 5,
-      "Devour": 14,
-      "Elf Token": 36,
-      "Wither": 7,
-      "Peasant Kindred": 15,
-      "Infusion": 6,
-      "Plot": 12,
-      "Partner with": 14,
-      "Plague Counters": 1,
-      "Escape": 7,
-      "Threshold": 26,
-      "Leech Kindred": 3,
-      "Persist": 9,
-      "Skeleton Token": 1,
-      "Scorpion Kindred": 5,
-      "Open an Attraction": 5,
-      "Performer Kindred": 12,
-      "Fathomless descent": 1,
-      "Swampwalk": 11,
-      "Time Counters": 16,
-      "Mount Kindred": 20,
-      "Saddle": 13,
-      "Gamer Kindred": 1,
-      "Guest Kindred": 6,
-      "Fungus Token": 4,
-      "Spore Counters": 16,
-      "Meld": 2,
-      "Assassin Token": 2,
-      "Pirate Token": 1,
-      "Finality Counters": 6,
-      "Magecraft": 7,
-      "Affinity": 7,
-      "Retrace": 5,
+      "Robot Kindred": 11,
+      "Blight": 2,
+      "Goblin Kindred": 36,
+      "Warlock Kindred": 26,
+      "Encore": 4,
+      "Wurm Kindred": 97,
+      "Egg Counters": 2,
+      "Charge Counters": 12,
+      "Station": 7,
+      "Devil Kindred": 2,
+      "Exalted": 11,
+      "Bloodthirst": 11,
+      "Berserker Kindred": 27,
+      "Kobold Kindred": 1,
+      "Kobold Token": 1,
+      "Graveborn Kindred": 1,
+      "Graveborn Token": 1,
+      "Pillowfort": 7,
+      "Spider Kindred": 107,
+      "Scarecrow Kindred": 8,
+      "Delirium": 29,
+      "Insect Token": 39,
+      "Blitz": 5,
       "Ally Token": 3,
+      "Loyalty Counters": 16,
+      "Phasing": 4,
       "Shield Counters": 12,
       "Alliance": 6,
       "Yeti Kindred": 5,
+      "Plot": 12,
+      "Bestow": 11,
       "Nymph Kindred": 6,
       "Fish Kindred": 6,
       "Vedalken Kindred": 6,
+      "Spider Token": 16,
       "Hippo Kindred": 9,
       "Hippo Token": 3,
       "Phelddagrif Kindred": 2,
+      "Angel Token": 3,
       "Grand Summon": 1,
+      "Fungus Token": 4,
+      "Partner - Survivors": 2,
+      "Survivor Kindred": 9,
+      "Power-up": 14,
       "Alien Token": 4,
       "No Mercy": 1,
+      "Flashback": 51,
       "Mole Kindred": 9,
       "Powerstone Token": 4,
+      "Wolf Token": 41,
       "Daybound": 18,
       "Nightbound": 18,
       "Rebel Kindred": 6,
       "Rebel Token": 2,
       "Modular": 1,
       "Hellion Kindred": 4,
+      "Escape": 7,
+      "Wither": 7,
+      "Boar Kindred": 41,
       "Werewolf Kindred": 54,
       "Samurai Kindred": 7,
       "Oil Counters": 10,
-      "Minotaur Kindred": 3,
+      "Minotaur Kindred": 4,
       "Dwarf Kindred": 6,
+      "Performer Kindred": 12,
+      "Age Counters": 26,
+      "Cumulative upkeep": 20,
       "Friends Forever": 2,
+      "Domain": 24,
       "Tribute": 4,
+      "Sliver Kindred": 31,
       "Riot": 7,
       "Storage Counters": 4,
       "Satyr Kindred": 22,
+      "Changeling": 17,
       "Bloodrush": 7,
       "Conspire": 4,
       "Giant Token": 2,
+      "Troll Kindred": 53,
       "Troll Token": 3,
+      "Devour": 14,
       "Juggernaut Kindred": 1,
+      "Aftermath": 10,
+      "Badger Kindred": 13,
       "Intimidate": 3,
+      "Battles Matter": 10,
       "Jackal Kindred": 6,
       "Top of the Food Chain": 1,
+      "Atog Kindred": 4,
       "Legendary landwalk": 2,
       "Compleated": 4,
       "Equip": 31,
@@ -30477,32 +33996,121 @@
       "Rampage": 4,
       "Ravenous": 9,
       "Noggle Kindred": 1,
+      "Partner": 28,
+      "Partner with": 14,
       "Fetch Counters": 1,
       "Dinosaur Token": 9,
+      "Monstrosity": 15,
       "Lizard Token": 1,
+      "Construct Kindred": 12,
       "Cosmo Memory": 1,
       "Pilot Kindred": 6,
       "Satyr Token": 2,
+      "Disguise": 12,
       "Basilisk Kindred": 12,
+      "Crew": 15,
       "Goblin Token": 2,
+      "Finality Counters": 6,
+      "Manticore Kindred": 2,
       "Sensational Save": 1,
       "Web-slinging": 5,
+      "Persist": 9,
       "Boar Token": 5,
+      "Alien Kindred": 15,
       "Gnoll Kindred": 2,
       "Pack tactics": 4,
+      "Guest Kindred": 6,
       "Depletion Counters": 3,
-      "Basic landcycling": 8,
-      "Landcycling": 19,
-      "Typecycling": 19,
+      "Devoid": 30,
+      "Eldrazi Kindred": 45,
+      "Basic landcycling": 9,
+      "Landcycling": 20,
+      "Typecycling": 20,
       "Forestcycling": 11,
       "Mountaincycling": 1,
       "Evoke": 8,
       "Incarnation Kindred": 7,
       "Barbarian Kindred": 6,
       "Heal": 12,
+      "Prepared": 20,
+      "Drone Kindred": 17,
+      "Eldrazi Token": 26,
       "Spawn Kindred": 15,
       "Spawn Token": 13,
+      "Airbending": 1,
+      "Waterbending": 2,
+      "Experience Counters": 4,
+      "Bringer Kindred": 5,
+      "Illusion Kindred": 2,
+      "Freerunning": 2,
+      "Shrines Matter": 6,
+      "Robot Token": 4,
+      "Kavu Token": 2,
+      "Companion": 4,
+      "Elk Kindred": 30,
+      "Rooms Matter": 6,
+      "Spy Kindred": 1,
+      "Hexproof from": 5,
+      "Converge": 10,
+      "Crystal Counters": 1,
+      "Sliver Token": 3,
+      "Sphinx Kindred": 1,
+      "Eminence": 2,
+      "Myr Kindred": 2,
+      "Myr Token": 1,
+      "Hideaway": 4,
+      "Phoenix Kindred": 1,
+      "Wurm Token": 13,
+      "Exert": 10,
+      "Centaur Token": 9,
+      "Archon Kindred": 2,
+      "Outlast": 3,
+      "Convoke": 26,
+      "Affinity": 7,
+      "Elf Token": 36,
+      "Kithkin Kindred": 16,
+      "Kithkin Token": 3,
+      "Rabbit Token": 2,
+      "Constellation": 13,
+      "Support": 9,
+      "Forestwalk": 24,
+      "Renown": 7,
+      "Knight Token": 5,
+      "Myriad": 7,
+      "Hippogriff Kindred": 1,
+      "Saddle": 13,
+      "Coven": 10,
+      "Bolster": 9,
+      "Role Token": 9,
+      "Virtuous Role Token": 1,
+      "Unicorn Kindred": 7,
+      "Halfling Token": 1,
+      "Vampire Token": 1,
+      "Jellyfish Kindred": 2,
+      "Rally": 3,
+      "Monster Role Token": 5,
+      "Threshold": 26,
+      "Umbra armor": 7,
+      "Protection from Creature Type": 3,
+      "Ouphe Kindred": 17,
+      "Mystic Kindred": 3,
+      "Nomad Kindred": 2,
+      "Plainscycling": 1,
+      "Pegasus Kindred": 1,
+      "Revolt": 7,
+      "Survival": 7,
+      "Mercenary Token": 1,
+      "Flanking": 2,
+      "Pavitr's Sevā": 1,
+      "No One Dies!": 1,
+      "Mutant Token": 1,
+      "Training": 4,
+      "Mouse Kindred": 2,
+      "Blitzball Captain": 1,
+      "Hyena Kindred": 3,
+      "Adapt": 15,
       "Serpent Kindred": 7,
+      "Time Counters": 16,
       "All Things Are Possible": 1,
       "In You": 1,
       "Fractal Kindred": 24,
@@ -30523,7 +34131,7 @@
       "Otter Kindred": 1,
       "Prowess": 1,
       "Manifest": 19,
-      "Constellation": 13,
+      "Collect evidence": 8,
       "Fish Token": 2,
       "Octopus Kindred": 7,
       "Octopus Token": 3,
@@ -30534,16 +34142,14 @@
       "Gargoyle Kindred": 2,
       "Gargoyle Token": 2,
       "Tyranid Token": 6,
-      "Crab Kindred": 7,
-      "Ouphe Kindred": 17,
       "Vivid": 8,
       "Salamander Kindred": 5,
       "Salamander Token": 2,
       "Croak Counters": 1,
       "Manifest dread": 13,
       "Chimera Kindred": 5,
-      "Jellyfish Kindred": 2,
-      "Dryad Token": 2,
+      "Magecraft": 7,
+      "Dryad Token": 3,
       "Study Counters": 2,
       "Ronso Rage": 1,
       "Kraken Token": 1,
@@ -30552,54 +34158,57 @@
       "Drake Token": 1,
       "Metathran Kindred": 1,
       "Growth Counters": 5,
+      "Ooze Token": 14,
       "Gift": 5,
       "Elk Token": 1,
       "Everything Counters": 1,
       "Graft": 9,
       "Thopter Kindred": 1,
       "Thopter Token": 1,
+      "Tide Counters": 1,
+      "Crocodile Kindred": 19,
+      "Worm Kindred": 5,
+      "Retrace": 5,
       "Moonfolk Kindred": 1,
       "Shapeshifter Token": 3,
       "Paradox": 3,
       "Cloak": 2,
-      "Wurm Token": 13,
-      "Exert": 10,
-      "Centaur Token": 9,
-      "Archon Kindred": 2,
-      "Outlast": 3,
-      "Kithkin Kindred": 16,
-      "Kithkin Token": 3,
-      "Rabbit Token": 2,
-      "Support": 9,
-      "Renown": 7,
-      "Knight Token": 5,
-      "Myriad": 7,
-      "Hippogriff Kindred": 1,
-      "Coven": 10,
-      "Bolster": 9,
-      "Virtuous Role Token": 1,
-      "Unicorn Kindred": 7,
-      "Halfling Token": 1,
-      "Vampire Token": 1,
-      "Rally": 3,
-      "Umbra armor": 7,
-      "Protection from Creature Type": 3,
-      "Mystic Kindred": 3,
-      "Nomad Kindred": 2,
-      "Plainscycling": 1,
-      "Pegasus Kindred": 1,
-      "Revolt": 7,
-      "Survival": 7,
-      "Mercenary Token": 1,
-      "Flanking": 2,
-      "Pavitr's Sevā": 1,
-      "No One Dies!": 1,
-      "Mutant Token": 1,
-      "Training": 4,
-      "Mouse Kindred": 2,
-      "Blitzball Captain": 1,
-      "Horse Kindred": 10,
-      "Hyena Kindred": 3,
+      "Cleave": 2,
+      "Descend": 5,
+      "Pest Kindred": 14,
+      "Pest Token": 14,
+      "Bat Kindred": 1,
+      "Scion Kindred": 9,
+      "Scion Token": 11,
+      "Forage": 6,
+      "Squirrel Kindred": 43,
+      "Squirrel Token": 21,
+      "Bounty Counters": 1,
+      "Learn": 4,
+      "Worm Token": 3,
+      "Wombat Kindred": 2,
+      "Skeleton Kindred": 8,
+      "Morbid": 14,
+      "Hag Kindred": 4,
+      "Scavenge": 10,
+      "Incubate": 6,
+      "Incubator Token": 6,
+      "Dredge": 7,
+      "Undergrowth": 9,
+      "Disappear": 5,
+      "Infusion": 6,
+      "Plague Counters": 1,
+      "Leech Kindred": 3,
+      "Skeleton Token": 1,
+      "Scorpion Kindred": 5,
+      "Open an Attraction": 5,
+      "Fathomless descent": 1,
+      "Swampwalk": 11,
+      "Gamer Kindred": 1,
+      "Spore Counters": 16,
+      "Meld": 2,
+      "Assassin Token": 2,
+      "Pirate Token": 1,
       "Doctor's Companion": 5,
       "Doctor's companion": 5,
       "Backgrounds Matter": 11,
@@ -30625,7 +34234,7 @@
       "Teamwork": 3,
       "Level Counters": 4,
       "Level Up": 4,
-      "Quest Counters": 5,
+      "Quest Counters": 6,
       "Fade Counters": 5,
       "Fading": 5,
       "Miracle": 2,
@@ -30687,6 +34296,7 @@
       "Overload": 2,
       "Clash": 6,
       "Entwine": 7,
+      "Waterbend": 1,
       "+2/+2 Counters": 1,
       "Squad": 1,
       "Adamant": 3,
@@ -30743,7 +34353,6 @@
       "Chroma": 2,
       "Defense Counters": 1,
       "Ribbon Counters": 1,
-      "Camel Kindred": 1,
       "Fateful Bite": 1,
       "Possum Kindred": 2,
       "Shaman Token": 1,
@@ -30801,12 +34410,12 @@
   "generated_from": "merge (analytics + curated YAML + whitelist)",
   "metadata_info": {
     "mode": "merge",
-    "generated_at": "2026-08-06T08:55:52",
-    "curated_yaml_files": 764,
+    "generated_at": "2026-08-19T08:40:36",
+    "curated_yaml_files": 900,
     "synergy_cap": 5,
     "inference": "pmi",
     "version": "phase-b-merge-v1",
-    "catalog_hash": "63d5f88bb5c748251e503631c435f2a72820fc32e1394b43e6626d1b7e66c41a"
+    "catalog_hash": "1c369899652fbf84f381df47742da3eb95c79fd152713ff2ea007f8016dce6a2"
   },
   "description_fallback_summary": null
 }

--- a/docs/user_guides/build_wizard.md
+++ b/docs/user_guides/build_wizard.md
@@ -259,6 +259,7 @@ Key settings for the build wizard:
 
 - [Theme Browser](theme_browser.md) — explore and evaluate available themes before building
 - [Partner Mechanics](partner_mechanics.md) — two-commander builds and color identity rules
+- [Rulebreaker Commanders](rulebreaker_commanders.md) — commanders that relax one specific deckbuilding rule
 - [Bracket Compliance](bracket_compliance.md) — power level tiers and enforcement modes
 - [Budget Mode](budget_mode.md) — filter the card pool by per-card price ceiling
 - [Multi-Copy Package](multi_copy.md) — build with many copies of a single archetype card

--- a/docs/user_guides/rulebreaker_commanders.md
+++ b/docs/user_guides/rulebreaker_commanders.md
@@ -1,0 +1,65 @@
+# Rulebreaker Commanders
+
+Build with commanders that bend one specific deckbuilding rule, each in its own unique way.
+
+---
+
+## Overview
+
+Some commanders carry the **Rulebreaker** ability word: a printed exception that relaxes one normal Commander deckbuilding rule (usually color identity or deck size) in a narrow, specific way, everything else about deckbuilding still applies as usual. The builder detects these commanders automatically (by name) and applies their exception during card pool filtering, land selection, and (for one commander) deck-size scaling, on the web app, the mobile app, and the Manual Deck Builder alike.
+
+There's no setting to turn this on or off. If you pick one of the commanders below, its exception is applied automatically.
+
+---
+
+## The 8 Rulebreaker Commanders
+
+| Commander | Color Identity | What it relaxes |
+|---|---|---|
+| **Grizzlegom, Hurloon Hero** | R, G | Any land cards, of any color, are legal. |
+| **Maular, the Next Evolution** | G | Creature cards with mana value 7+, of any color identity, plus any basic lands, are legal. |
+| **Seluma, Light of Aysen** | W | Angel cards of any color identity, plus any basic lands, are legal. |
+| **The Everforger** | (colorless) | Artifact Creature and Equipment cards of any color identity, plus any basic lands, are legal. |
+| **The Unluckiest Planeswalker** | R | Aura cards of any color identity, plus any basic lands, are legal. |
+| **Tolabow, Loch Rascal** | U | Instant and Sorcery cards can use one extra color of your choice (optional), plus any basic lands, are legal. |
+| **Valko Indorian** | B | Cards with the Phyrexian creature subtype, of any color identity, plus any basic lands, are legal. |
+| **Whtz, the Bibliophile** | U, W | No maximum deck size (the 100-card minimum still applies). |
+
+Each exception is scoped to exactly what's printed on the card, nothing more. For example, Maular only relaxes color identity for creatures with mana value 7 or greater; a 3-mana off-color creature is still illegal, and Grizzlegom's land relaxation doesn't extend to spells.
+
+---
+
+## Selecting a Rulebreaker Commander
+
+### Web
+Selecting one of the 8 commanders (as a primary commander, or as one half of a Partner/Background pair) shows an informational banner describing its exception in plain language on the commander step.
+
+- **Tolabow**: an optional color picker appears (excluding Tolabow's own color, blue). Leave it unset to build a mono-blue Instant/Sorcery suite as normal, or pick a second color to widen it.
+- **Whtz**: a target deck size field appears, defaulting to 100. Enter any value of 100 or greater; there's no upper limit.
+
+### Mobile
+The same Tolabow color dropdown and Whtz deck-size field appear inline on the commander step of the build wizard once a Rulebreaker commander is selected. Neither field is required to start a build.
+
+### Manual Deck Builder
+Picking a Rulebreaker commander in the Manual Deck Builder applies the same card-pool and land relaxation as a guided/auto build, the Mana Pips/Sources charts reflect the actual off-identity colors present in your deck rather than zeroing them out.
+
+---
+
+## Deck-Size Scaling (Whtz only)
+
+Since Whtz removes the maximum deck size, the ideal counts for lands, ramp, removal, and other categories are scaled up so a 200-card deck isn't stuck running a 100-card deck's worth of lands. The scaling curve grows land percentage smoothly with deck size (not a flat multiplier), so bigger decks get modestly higher land density without becoming land-flooded. This happens automatically. On the web, the Ideal Counts sliders update live as you change the target deck size, and you can still fine-tune any category afterward.
+
+---
+
+## Random / Surprise-Me Builds
+
+Tolabow is excluded from full-random and surprise-me commander pools, since its optional extra-color choice has no one to answer it during a fully automated pick. The other 7 Rulebreaker commanders can still be selected at random.
+
+---
+
+## See Also
+
+- [Build Wizard](build_wizard.md) — Rulebreaker selection in the context of the full build flow
+- [Manual Deck Builder](manual_builder.md) — building a Rulebreaker commander's deck card-by-card
+- [Smart Land Bases](land_bases.md) — how land count/ratio targets are calculated, including Whtz's deck-size scaling
+- [Partner Mechanics](partner_mechanics.md) — pairing a Rulebreaker commander with a Partner or Background


### PR DESCRIPTION
## Summary
Adds 8 new **Rulebreaker Commander** archetypes: commanders whose oracle text relaxes normal deckbuilding rules (color identity and/or deck size) for a specific card type or condition.

- Grizzlegom, Hurloon Hero: any basic land type, regardless of color identity, split evenly across all five basics.
- Maular, the Next Evolution: creatures with mana value 7+ can be any color.
- Seluma, Light of Aysen: Angels can be any color.
- The Everforger: Artifact Creatures and Equipment can be any color.
- The Unluckiest Planeswalker: Auras can be any color.
- Tolabow, Loch Rascal: Instants and Sorceries can be your color identity plus one additional color.
- Valko Indorian: Phyrexian-subtype cards can be any color.
- Whtz, the Bibliophile: no maximum deck size (100-card minimum still applies).

## What's included
- **Card pool & land relaxation logic** (`code/deck_builder/rulebreaker_rules.py`, `builder_constants.py`, `builder_utils.py`, land phase files): per-commander exceptions applied during deckbuilding.
- **Web UI**: commander selection banner, optional extra-color picker, and target-deck-size field wired into the new-deck flow and manual deck builder; role health bar now reflects actual ideal counts for non-default deck sizes.
- **Public API**: `GET /api/v1/commanders/{name}` reports Rulebreaker metadata; `POST /api/v1/builds` accepts `rulebreaker_extra_color`/`rulebreaker_target_deck_size`.
- **Setup/Tagging safety net**: a local, offline check flags any Commander-legal card that looks like it may carry the Rulebreaker mechanic but isn't yet registered (e.g. a newly spoiled/printed card), with a review banner + copy-paste issue body on the Setup/Tagging page. The weekly/manual "Build Similarity Cache" CI workflow auto-files (and dedupes) a GitHub issue for any candidate found.
- **Docs**: new player-facing guide (`docs/user_guides/rulebreaker_commanders.md`), linked from the build wizard guide.
- **Tests**: `test_rulebreaker_commanders.py` (card pool/land exceptions) and `test_rulebreaker_candidate_detection.py` (detection heuristic, issue-body rendering, GitHub lookup, `/status/setup` endpoint).

See `CHANGELOG.md` (Unreleased) for the full user-facing changelog entry.

## Testing
- `pytest -q` (full suite): only known pre-existing failures remain, no new regressions.
- New Rulebreaker test files pass in isolation.
- Fixed a pre-existing relative-import bug in `commanders.py` uncovered while running the full suite (`from ....deck_builder import ...` broke under the `web.app` import path used by one test file); switched to the repo's established absolute-import convention.

## Follow-up
Mobile app support (build wizard color picker / deck size field) is a separate PR in `mtg-deckbuilder-mobile`, gated on this backend release (v5.8.0+).
