### PR TITLE
fix: art tags for double-faced cards, name: search flag phrase/dash handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ _No unreleased changes yet_
 _No unreleased changes yet_
 
 ### Fixed
-_No unreleased changes yet_
+- Tagging: `art_tags_cache.py` wasn't assigning art tags to transform/modal-DFC/reversible-card layouts (e.g. Delver of Secrets // Insectile Aberration), since Scryfall stores those cards' `illustration_id` per face instead of on the card itself; both faces' illustration ids are now collected and their tags merged. Split/adventure/flip cards (e.g. Fire // Ice) were unaffected, since they already share a single top-level illustration id.
+- Web: the card browser and owned library's search box treated an explicit `name:"..."` flag the same as plain typed words, so quoted phrases and dash-for-space (`name:keeper-of-secrets`) were ignored and fell back to an overly broad legacy fuzzy match; `name:`/`n:` now goes through the same phrase/hyphen-aware matching as the other search flags.
 
 ### Removed
 _No unreleased changes yet_

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -8,7 +8,8 @@ _No unreleased changes yet_
 _No unreleased changes yet_
 
 ### Fixed
-_No unreleased changes yet_
+- Tagging: transform/modal-DFC cards (e.g. Delver of Secrets // Insectile Aberration) weren't getting art tags; both faces are now checked.
+- Web: fixed the `name:"..."` search flag ignoring quoted phrases and dashes and returning overly broad results.
 
 ### Removed
 _No unreleased changes yet_

--- a/code/file_setup/art_tags_cache.py
+++ b/code/file_setup/art_tags_cache.py
@@ -12,8 +12,11 @@ Strategy:
 2. Download the Art Tags bulk JSONL (one Tag object per line, each with a
    list of "taggings" -> [{"illustration_id": ..., "weight": ...}, ...])
 3. Build illustration_id -> [tag labels] from it
-4. Build scryfallID -> illustration_id from card_files/raw/scryfall_bulk_data.json
-5. For each card in all_cards.parquet, write scryfallID -> tags into artTags
+4. Build scryfallID -> [illustration_id, ...] from card_files/raw/scryfall_bulk_data.json
+   (usually one id, but transform/modal_dfc/reversible_card layouts store
+   illustration_id per face instead of on the card object, so both faces'
+   ids are collected and their tags merged)
+5. For each card in all_cards.parquet, write scryfallID -> merged tags into artTags
 
 Optional, standalone step -- not part of the default full pipeline (mirrors
 code/file_setup/rulings_cache.py's rollout pattern), since it requires a
@@ -49,9 +52,15 @@ def _get(url: str) -> bytes:
         return r.read()
 
 
-def build_illustration_id_map() -> dict[str, str]:
+def build_illustration_id_map() -> dict[str, list[str]]:
     """
-    Return scryfallID -> illustration_id using the local scryfall_bulk_data.json.
+    Return scryfallID -> [illustration_id, ...] using the local scryfall_bulk_data.json.
+
+    Single-faced cards (and split/adventure/flip layouts, which share one
+    piece of art across both halves) carry `illustration_id` at the top
+    level. Transform/modal_dfc/reversible_card layouts have no top-level
+    illustration_id at all -- each face has its own under `card_faces`, so
+    those must be collected separately or the card gets no art tags.
     Falls back to empty dict if the file is missing.
     """
     if not LOCAL_BULK_DATA_PATH.exists():
@@ -59,11 +68,22 @@ def build_illustration_id_map() -> dict[str, str]:
         return {}
     with open(LOCAL_BULK_DATA_PATH, encoding="utf-8") as f:
         cards = json.load(f)
-    return {
-        card["id"]: card["illustration_id"]
-        for card in cards
-        if "id" in card and card.get("illustration_id")
-    }
+    result: dict[str, list[str]] = {}
+    for card in cards:
+        cid = card.get("id")
+        if not cid:
+            continue
+        illustration_ids: list[str] = []
+        top_level = card.get("illustration_id")
+        if top_level:
+            illustration_ids.append(top_level)
+        for face in card.get("card_faces") or []:
+            face_id = face.get("illustration_id")
+            if face_id and face_id not in illustration_ids:
+                illustration_ids.append(face_id)
+        if illustration_ids:
+            result[cid] = illustration_ids
+    return result
 
 
 def fetch_art_tags_bulk(output_func=None) -> list[dict]:
@@ -153,10 +173,14 @@ def build_art_tags_cache(output_func=None) -> None:
     _log(f"Indexed art tags for {len(illustration_tags):,} illustrations.")
 
     def _lookup(sid) -> list[str]:
-        illustration_id = scryfall_to_illustration.get(sid) if sid else None
-        if not illustration_id:
+        illustration_ids = scryfall_to_illustration.get(sid) if sid else None
+        if not illustration_ids:
             return []
-        return illustration_tags.get(illustration_id, [])
+        merged: dict[str, str] = {}
+        for illustration_id in illustration_ids:
+            for label in illustration_tags.get(illustration_id, []):
+                merged.setdefault(label.lower(), label)
+        return sorted(merged.values())
 
     df["artTags"] = df["scryfallID"].apply(_lookup)
 

--- a/code/tests/test_art_tags_cache.py
+++ b/code/tests/test_art_tags_cache.py
@@ -25,7 +25,31 @@ def test_build_illustration_id_map(tmp_path, monkeypatch):
     monkeypatch.setattr(art_tags_cache, "LOCAL_BULK_DATA_PATH", path)
 
     result = art_tags_cache.build_illustration_id_map()
-    assert result == {"sid-1": "illus-1", "sid-2": "illus-2"}
+    assert result == {"sid-1": ["illus-1"], "sid-2": ["illus-2"]}
+
+
+def test_build_illustration_id_map_multi_faced_card(tmp_path, monkeypatch):
+    bulk = [
+        # transform/modal_dfc: no top-level illustration_id, one per face
+        {"id": "sid-dfc", "card_faces": [
+            {"name": "Front", "illustration_id": "illus-front"},
+            {"name": "Back", "illustration_id": "illus-back"},
+        ]},
+        # split/adventure/flip: single shared top-level illustration_id
+        {"id": "sid-split", "illustration_id": "illus-shared", "card_faces": [
+            {"name": "Front", "illustration_id": "illus-shared"},
+            {"name": "Back"},
+        ]},
+    ]
+    path = tmp_path / "scryfall_bulk_data.json"
+    path.write_text(json.dumps(bulk), encoding="utf-8")
+    monkeypatch.setattr(art_tags_cache, "LOCAL_BULK_DATA_PATH", path)
+
+    result = art_tags_cache.build_illustration_id_map()
+    assert result == {
+        "sid-dfc": ["illus-front", "illus-back"],
+        "sid-split": ["illus-shared"],
+    }
 
 
 def test_build_illustration_id_map_missing_file(tmp_path, monkeypatch):
@@ -54,8 +78,8 @@ def test_build_art_tags_index_dedupes_and_sorts():
 def test_build_art_tags_cache_writes_column(tmp_path, monkeypatch):
     parquet_path = tmp_path / "all_cards.parquet"
     df = pd.DataFrame({
-        "name": ["Card A", "Card B", "Card C"],
-        "scryfallID": ["sid-1", "sid-2", None],
+        "name": ["Card A", "Card B", "Card C", "Card D // Card D Back"],
+        "scryfallID": ["sid-1", "sid-2", None, "sid-dfc"],
     })
     df.to_parquet(parquet_path, index=False)
 
@@ -63,6 +87,10 @@ def test_build_art_tags_cache_writes_column(tmp_path, monkeypatch):
     bulk_path.write_text(json.dumps([
         {"id": "sid-1", "illustration_id": "illus-1"},
         {"id": "sid-2", "illustration_id": "illus-2"},
+        {"id": "sid-dfc", "card_faces": [
+            {"name": "Card D", "illustration_id": "illus-front"},
+            {"name": "Card D Back", "illustration_id": "illus-back"},
+        ]},
     ]), encoding="utf-8")
 
     monkeypatch.setattr(art_tags_cache, "PARQUET_PATH", parquet_path)
@@ -72,6 +100,8 @@ def test_build_art_tags_cache_writes_column(tmp_path, monkeypatch):
         "fetch_art_tags_bulk",
         lambda output_func=None: [
             {"label": "blue glow", "taggings": [{"illustration_id": "illus-1", "weight": "strong"}]},
+            {"label": "axe", "taggings": [{"illustration_id": "illus-front", "weight": "strong"}]},
+            {"label": "snow", "taggings": [{"illustration_id": "illus-back", "weight": "strong"}]},
         ],
     )
 
@@ -81,3 +111,4 @@ def test_build_art_tags_cache_writes_column(tmp_path, monkeypatch):
     assert list(result.loc[result["name"] == "Card A", "artTags"].iloc[0]) == ["blue glow"]
     assert list(result.loc[result["name"] == "Card B", "artTags"].iloc[0]) == []
     assert list(result.loc[result["name"] == "Card C", "artTags"].iloc[0]) == []
+    assert list(result.loc[result["name"] == "Card D // Card D Back", "artTags"].iloc[0]) == ["axe", "snow"]

--- a/code/tests/test_search_hyphen_space_equivalence.py
+++ b/code/tests/test_search_hyphen_space_equivalence.py
@@ -12,6 +12,7 @@ from code.web.services.card_search import (
     apply_name_clauses,
     apply_text_clauses,
     filter_names_fuzzy,
+    has_structured_flags,
     parse_search_query,
 )
 
@@ -20,6 +21,21 @@ def test_name_search_with_dash_matches_spaced_name():
     df = pd.DataFrame({"name": ["Rabbit Battery", "Other Card"]})
     result = apply_name_clauses(df, ["rabbit-battery"], [])
     assert list(result["name"]) == ["Rabbit Battery"]
+
+
+def test_explicit_name_flag_is_structured():
+    # Regression: an explicit name:/n: flag must be routed through the
+    # structured (phrase/hyphen-aware) path, not the card browser's legacy
+    # literal-string fuzzy fallback, or quotes/dashes get ignored.
+    parsed = parse_search_query('name:"keeper of secrets"')
+    assert has_structured_flags(parsed)
+    parsed_dash = parse_search_query("name:keeper-of-secrets")
+    assert has_structured_flags(parsed_dash)
+
+
+def test_bare_word_name_search_is_not_structured():
+    parsed = parse_search_query("keeper of secrets")
+    assert not has_structured_flags(parsed)
 
 
 def test_name_search_with_literal_hyphen_still_matches():

--- a/code/web/services/card_search.py
+++ b/code/web/services/card_search.py
@@ -146,6 +146,7 @@ class ManaCostClause:
 class ParsedSearch:
     name_include: List[str] = field(default_factory=list)
     name_exclude: List[str] = field(default_factory=list)
+    explicit_name_flag: bool = False
     type_include: List[str] = field(default_factory=list)
     type_exclude: List[str] = field(default_factory=list)
     oracle_include: List[str] = field(default_factory=list)
@@ -427,6 +428,7 @@ def _apply_search_flag(parsed: ParsedSearch, canonical: str, op: str, value: str
         return
     if canonical == "name":
         (parsed.name_exclude if negate else parsed.name_include).append(value)
+        parsed.explicit_name_flag = True
     elif canonical == "type":
         (parsed.type_exclude if negate else parsed.type_include).append(value)
     elif canonical == "oracle":
@@ -582,7 +584,9 @@ def has_structured_flags(parsed: ParsedSearch) -> bool:
     """True if `parsed` contains anything beyond bare name words -- callers
     that have their own fuzzy/typo-tolerant name-only search (e.g. the card
     browser) can use this to decide whether to fall back to structured
-    flag-based filtering instead."""
+    flag-based filtering instead. An explicit `name:`/`n:` flag also counts
+    as structured (so quoted phrases and hyphen-for-space both work), even
+    though it only populates `name_include`/`name_exclude` like bare words."""
     return bool(
         parsed.type_include or parsed.type_exclude
         or parsed.oracle_include or parsed.oracle_exclude
@@ -594,4 +598,5 @@ def has_structured_flags(parsed: ParsedSearch) -> bool:
         or parsed.art_tags or parsed.art_tags_exclude
         or parsed.metadata_tags or parsed.metadata_tags_exclude or parsed.is_new is not None
         or parsed.set_include or parsed.set_exclude
+        or parsed.explicit_name_flag
     )


### PR DESCRIPTION
## Fixes

- **Art tags missing for transform/modal-DFC cards**: Scryfall stores \illustration_id\ per face (not on the card object) for these layouts, so \rt_tags_cache.py\ silently skipped them. Now collects illustration ids from both the top-level card and \card_faces\, merging tags across faces. Split/adventure/flip cards were already fine (single shared illustration id).
- **\
ame:\ search flag ignored quotes/dashes**: \has_structured_flags()\ didn't treat an explicit \
ame:\/\
:\ flag as structured, so it fell back to the card browser/owned library's legacy literal-string fuzzy search, which doesn't understand quoted phrases or hyphen-for-space. Fixed by tracking explicit name-flag usage and routing it through the same structured matching as other flags.

## Testing
- \pytest -q code/tests/test_search_hyphen_space_equivalence.py code/tests/test_scryfall_tag_search.py code/tests/test_art_tags_cache.py code/tests/test_api_v1_cards.py\ all pass.
- Rebuilt \ll_cards.parquet\'s \rtTags\ column locally; confirmed Delver of Secrets // Insectile Aberration and Growing Rites of Itlimoc now have tags.