### PR TITLE
feat: set/collector-number search, printings display, and search fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,21 @@ This format follows Keep a Changelog principles and aims for Semantic Versioning
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- Web: new `set:`/`-set:` search flag (matches set name or 3-5 letter code, e.g. `set:"Modern Horizons 3 Commander"` or `set:msc`) works in the card browser, owned library, manual deck builder search, and the public REST API. Also `cn:`/`number:` for narrowing to a specific collector number or range within a set (e.g. `set:msc cn:212` or `set:msc cn>210`); using `cn:`/`number:` without `set:` surfaces a notice instead of silently doing nothing.
+- Web: when a search is scoped by `set:` and/or `cn:`/`number:` and matches a specific printing, the card browser and card detail page display that exact printing's image instead of the card's globally-scored default.
+- Public API: card search responses now include a `resolvedPrintingId` field when a `set:`/`cn:`/`number:` flag pins a result to a specific printing, so clients can display that exact printing's artwork instead of the card's default.
+- Web: when a search is scoped to exactly one `set:`, card tiles and the card detail page show a small "Set Name #123" badge for the currently displayed printing.
+- Public API: card search responses now include a `setBadge` field (`set`/`setName`/`collectorNumber`) when scoped to exactly one `set:`, so mobile clients can show the same badge.
+- Web and Public API: card search results scoped to exactly one `set:` now default to collector-number order instead of alphabetical (mobile app inherits this automatically since it uses the API's default sort).
+- Web: card detail pages now show a collapsible "Printings" section listing every set a card has been printed in; clicking a set chip runs a `set:` search for that printing.
 
 ### Changed
-_No unreleased changes yet_
+- Web: card browser and owned library search autocomplete now only suggests values for `tag:`/`theme:` flags. The old whole-query card-name autocomplete was removed since it fuzzy-matched the entire Scryfall-style query (including flags like `t:creature` or `set:msc cn:212`) against card names, producing constant "No matching cards" noise.
 
 ### Fixed
-_No unreleased changes yet_
+- Web: the printing/foil toggle buttons on the card detail page could visually bleed over the top of the sticky search bar; the tile image container was missing a CSS stacking context, so its child `z-index` values competed with the search bar's instead of staying contained locally.
+- Web: searching with plain text and no flags (e.g. just a card name) threw an error and cleared the search box; the result sort unconditionally read a `set_include` field that stays `None` for flag-less queries.
+- Web: plain-text card name search was punctuation-sensitive for exact matches (e.g. `Alania Divergent Storm` without the comma wouldn't exact-match `Alania, Divergent Storm`) and fell back to an overly broad word-by-word fuzzy match instead; exact matching now ignores punctuation.
 
 ### Removed
 _No unreleased changes yet_

--- a/RELEASE_NOTES_TEMPLATE.md
+++ b/RELEASE_NOTES_TEMPLATE.md
@@ -2,13 +2,18 @@
 
 ## [Unreleased]
 ### Added
-_No unreleased changes yet_
+- Web: cards can now be searched by set (`set:`, e.g. `set:"Modern Horizons 3 Commander"` or `set:msc`) and, within a set, by collector number or range (`cn:`/`number:`, e.g. `set:msc cn:212`). Searches scoped to a specific printing this way now show that printing's exact image instead of the card's usual default, in the web UI and public API alike.
+- Web: searching by a single set now shows a small "Set Name #123" badge on card tiles and the card detail page; this badge is also available in the mobile app now.
+- Web and mobile: searching by a single set now sorts results by collector number by default instead of alphabetically.
+- Web: card detail pages now show a collapsible "Printings" section listing every set a card has been printed in, with clickable chips to search that set.
 
 ### Changed
-_No unreleased changes yet_
+- Web: search autocomplete on the card browser and owned library now only suggests theme tag values, instead of trying (and often failing) to match your whole search against a card name.
 
 ### Fixed
-_No unreleased changes yet_
+- Web: fixed the printing/foil toggle buttons on the card detail page visually overlapping the search bar.
+- Web: fixed a plain-text search (no flags) throwing an error and clearing the search box.
+- Web: fixed plain-text card name search being overly sensitive to punctuation, sometimes returning a broad list of loosely related cards instead of the exact match.
 
 ### Removed
 _No unreleased changes yet_

--- a/code/file_setup/image_cache.py
+++ b/code/file_setup/image_cache.py
@@ -569,6 +569,57 @@ class ImageCache:
         matches = matches.sort_values("released_at", ascending=False, na_position="last")
         return str(matches.iloc[0]["scryfall_id"])
 
+    def get_printing_id_for_set(self, card_name: str, set_code: str) -> Optional[str]:
+        """Return the Scryfall ID of the card's printing within `set_code`.
+
+        Mirrors `get_default_printing_id()`'s tie-break (highest `score`,
+        then most recent `released_at`) but scoped to a single set, so a
+        `set:` search can show that set's own art instead of the card's
+        globally-best printing. Returns `None` if the card has no printing
+        in that set (or the printings index hasn't been built).
+        """
+        df = self._load_printings_df()
+        if df is None:
+            return None
+        matches = df[
+            (df["face_name"].str.lower() == card_name.lower())
+            & (df["set"].str.upper() == set_code.upper())
+        ]
+        if matches.empty:
+            return None
+        matches = matches.sort_values(["score", "released_at"], ascending=[False, False], na_position="last")
+        return str(matches.iloc[0]["scryfall_id"])
+
+    def get_printing_meta(
+        self, card_name: str, *, scryfall_id: Optional[str] = None, set_code: Optional[str] = None
+    ) -> Optional[dict[str, str]]:
+        """Return `{"set", "set_name", "collector_number"}` for one printing.
+
+        Used by the set+collector-number tile/detail badge: looks up the
+        exact printing by `scryfall_id` if given (so the badge matches
+        whatever art is actually displayed); otherwise falls back to the
+        same best-in-set match `get_printing_id_for_set()` uses (highest
+        `score`, then most recent `released_at`). Returns `None` if nothing
+        matches (or the printings index hasn't been built).
+        """
+        df = self._load_printings_df()
+        if df is None:
+            return None
+        matches = df[df["face_name"].str.lower() == card_name.lower()]
+        if scryfall_id:
+            matches = matches[matches["scryfall_id"] == scryfall_id]
+        elif set_code:
+            matches = matches[matches["set"].str.upper() == set_code.upper()]
+            matches = matches.sort_values(["score", "released_at"], ascending=[False, False], na_position="last")
+        if matches.empty:
+            return None
+        row = matches.iloc[0]
+        return {
+            "set": str(row["set"]).upper(),
+            "set_name": str(row["set_name"]),
+            "collector_number": str(row["collector_number"]),
+        }
+
     def get_printing_image_path(
         self, card_name: str, scryfall_id: str, size: str = "normal"
     ) -> Path:

--- a/code/tests/test_api_v1_cards.py
+++ b/code/tests/test_api_v1_cards.py
@@ -77,6 +77,102 @@ def test_list_cards_by_colors(client):
     assert names == {"Counterspell"}
 
 
+def test_list_cards_by_set_code(client):
+    # api_v1/cards.py doesn't call the shared apply_extra_clauses(), so the
+    # set: filter needs its own mirrored block (Roadmap 38, M1).
+    resp = client.get("/api/v1/cards", params={"q": "set:LEA"})
+    data = resp.json()["data"]
+    names = {c["name"] for c in data["cards"]}
+    assert names == {"Sol Ring", "Lightning Bolt", "Counterspell"}
+
+
+def test_list_cards_by_negative_set_code(client):
+    resp = client.get("/api/v1/cards", params={"q": "-set:LEA"})
+    data = resp.json()["data"]
+    names = {c["name"] for c in data["cards"]}
+    assert "Sol Ring" not in names
+    assert "Fire // Ice" in names
+
+
+def test_list_cards_response_includes_notices_key(client):
+    resp = client.get("/api/v1/cards", params={"q": "set:LEA"})
+    data = resp.json()["data"]
+    assert "notices" in data
+    assert data["notices"] == []
+
+
+def test_list_cards_by_collector_number(client, tmp_path, monkeypatch):
+    # api_v1/cards.py doesn't call the shared apply_extra_clauses(), so
+    # cn:/number: needs its own mirrored block too (Roadmap 38, M3).
+    import code.web.services.card_search as card_search
+
+    printings_df = pd.DataFrame(
+        [
+            {"face_name": "Sol Ring", "set": "LEA", "collector_number": "211", "scryfall_id": "sol-211", "score": 5, "released_at": "2024-01-01"},
+            {"face_name": "Sol Ring", "set": "LEA", "collector_number": "212", "scryfall_id": "sol-212", "score": 20, "released_at": "2024-01-01"},
+        ]
+    )
+    printings_df.to_parquet(tmp_path / "card_printings.parquet", engine="pyarrow")
+    monkeypatch.setattr(card_search, "card_files_processed_dir", lambda: str(tmp_path))
+    card_search._PRINTINGS_INDEX_DF = None
+    card_search._PRINTINGS_INDEX_LOADED = False
+
+    resp = client.get("/api/v1/cards", params={"q": "set:LEA cn:212"})
+    data = resp.json()["data"]
+    names = {c["name"] for c in data["cards"]}
+    assert names == {"Sol Ring"}
+
+    resp = client.get("/api/v1/cards", params={"q": "cn:212"})
+    data = resp.json()["data"]
+    assert data["total_count"] == 6  # no set: -- no-op, unfiltered
+    assert any("requires a set:" in n for n in data["notices"])
+
+    card_search._PRINTINGS_INDEX_DF = None
+    card_search._PRINTINGS_INDEX_LOADED = False
+
+
+def test_list_cards_includes_resolved_printing_id_for_set_scoped_search(client):
+    # Mobile/web parity: a set: search resolves each card to its printing in
+    # that set (mirrors card_browser.py's _set_scoped_printings()), surfaced
+    # via a resolvedPrintingId field so the mobile app can request that
+    # printing's artwork instead of the card's global default.
+    import code.web.routes.api_v1.cards as cards_route
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(cards_route._image_cache, "get_printing_id_for_set", lambda name, code: f"{name}-{code}".lower())
+        resp = client.get("/api/v1/cards", params={"q": "set:LEA"})
+    data = resp.json()["data"]
+    sol_ring = next(c for c in data["cards"] if c["name"] == "Sol Ring")
+    assert sol_ring["resolvedPrintingId"] == "sol ring-lea"
+
+    resp = client.get("/api/v1/cards", params={"q": ""})
+    data = resp.json()["data"]
+    assert all(c["resolvedPrintingId"] is None for c in data["cards"])
+
+
+def test_list_cards_includes_set_badge_for_single_set_search(client):
+    # Roadmap 38 M5 API parity: a single set: search also surfaces a
+    # setBadge (set/setName/collectorNumber) per card, mirroring the web
+    # UI's card tile/detail badge, so the mobile app can render the same info.
+    import code.web.routes.api_v1.cards as cards_route
+
+    def _fake_get_printing_meta(name, *, scryfall_id=None, set_code=None):
+        assert set_code == "LEA"
+        return {"set": "LEA", "set_name": "Limited Edition Alpha", "collector_number": "1"}
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(cards_route._image_cache, "get_printing_meta", _fake_get_printing_meta)
+        resp = client.get("/api/v1/cards", params={"q": "set:LEA"})
+    data = resp.json()["data"]
+    sol_ring = next(c for c in data["cards"] if c["name"] == "Sol Ring")
+    assert sol_ring["setBadge"] == {"set": "LEA", "setName": "Limited Edition Alpha", "collectorNumber": "1"}
+
+    # No set: filter, or more than one -- ambiguous/not scoped, no badge.
+    resp = client.get("/api/v1/cards", params={"q": ""})
+    data = resp.json()["data"]
+    assert all(c["setBadge"] is None for c in data["cards"])
+
+
 def test_list_cards_by_tags_and_logic(client):
     resp = client.get("/api/v1/cards", params={"tags": "Removal,Burn"})
     data = resp.json()["data"]

--- a/code/tests/test_card_browser_single_result_redirect.py
+++ b/code/tests/test_card_browser_single_result_redirect.py
@@ -1,0 +1,89 @@
+"""
+Tests for the card browser's single-result auto-redirect: a search that
+narrows to exactly one card skips the results grid and redirects straight
+to that card's detail page, carrying over any `set:`-scoped printing.
+"""
+from __future__ import annotations
+
+import pandas as pd
+from fastapi.testclient import TestClient
+from unittest.mock import MagicMock
+
+from code.web.app import app  # noqa: F401  (import first to avoid a card_browser circular import)
+import code.web.routes.card_browser as card_browser
+
+
+def _fake_card(name: str, **overrides) -> dict:
+    base = {
+        "name": name,
+        "type": "Artifact",
+        "text": "Add one mana of any color.",
+        "manaValue": 1,
+        "power": None,
+        "toughness": None,
+        "edhrecRank": 1,
+        "rarity": "uncommon",
+        "colors": [],
+        "colorIdentity": "C",
+        "scryfallID": "test-scryfall-id",
+        "themeTags": "",
+        "artTags": "",
+        "metadataTags": "",
+        "isNew": False,
+        "price": None,
+        "ck_price": None,
+        "side": None,
+        "printings": "LEA",
+    }
+    base.update(overrides)
+    return base
+
+
+def _client(monkeypatch, df: pd.DataFrame) -> TestClient:
+    loader_mock = MagicMock()
+    loader_mock.load.return_value = df
+    monkeypatch.setattr(card_browser, "get_loader", lambda: loader_mock)
+
+    sim_mock = MagicMock()
+    sim_mock.find_similar.return_value = []
+    monkeypatch.setattr(card_browser, "get_similarity", lambda: sim_mock)
+
+    return TestClient(app)
+
+
+def test_single_exact_name_match_redirects_to_detail_page(monkeypatch):
+    df = pd.DataFrame([_fake_card("Sol Ring"), _fake_card("Lightning Bolt")])
+    with _client(monkeypatch, df) as client:
+        resp = client.get("/cards/", params={"search": "Sol Ring"}, follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/cards/Sol%20Ring"
+
+
+def test_multiple_matches_do_not_redirect(monkeypatch):
+    df = pd.DataFrame([_fake_card("Sol Ring"), _fake_card("Solemn Simulacrum")])
+    with _client(monkeypatch, df) as client:
+        resp = client.get("/cards/", params={"search": "sol"}, follow_redirects=False)
+    assert resp.status_code == 200
+
+
+def test_empty_search_does_not_redirect_even_with_one_card(monkeypatch):
+    df = pd.DataFrame([_fake_card("Sol Ring")])
+    with _client(monkeypatch, df) as client:
+        resp = client.get("/cards/", follow_redirects=False)
+    assert resp.status_code == 200
+
+
+def test_set_scoped_printing_carries_over_after_redirect(monkeypatch):
+    df = pd.DataFrame([_fake_card("Sol Ring", printings="KHM, LEA"), _fake_card("Lightning Bolt")])
+    monkeypatch.setattr(
+        card_browser._image_cache, "get_printing_id_for_set",
+        lambda name, code: "sol-khm-id" if name == "Sol Ring" and code.upper() == "KHM" else None,
+    )
+    with _client(monkeypatch, df) as client:
+        resp = client.get("/cards/", params={"search": "name:sol-ring set:khm"}, follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers["location"] == "/cards/Sol%20Ring"
+
+        detail = client.get(resp.headers["location"])
+        assert detail.status_code == 200
+        assert "sol-khm-id" in detail.text

--- a/code/tests/test_collector_number_search.py
+++ b/code/tests/test_collector_number_search.py
@@ -1,0 +1,127 @@
+"""
+Unit tests for `cn:`/`number:` collector number filtering
+(Roadmap 38, Milestone 3): code/web/services/card_search.py.
+"""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+import code.web.services.card_search as card_search
+from code.web.services.card_search import (
+    apply_extra_clauses,
+    parse_search_query,
+    resolve_collector_number_printings,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_printings_index_cache():
+    card_search._PRINTINGS_INDEX_DF = None
+    card_search._PRINTINGS_INDEX_LOADED = False
+    yield
+    card_search._PRINTINGS_INDEX_DF = None
+    card_search._PRINTINGS_INDEX_LOADED = False
+
+
+@pytest.fixture()
+def printings_index(tmp_path, monkeypatch):
+    """Write a small fixture card_printings.parquet, simulating Modern
+    Horizons 3 Commander's four Sol Ring printings (211-214)."""
+    df = pd.DataFrame(
+        [
+            {"face_name": "Sol Ring", "set": "MSC", "collector_number": "211", "scryfall_id": "sol-211", "score": 10, "released_at": "2024-06-01"},
+            {"face_name": "Sol Ring", "set": "MSC", "collector_number": "212", "scryfall_id": "sol-212", "score": 20, "released_at": "2024-06-01"},
+            {"face_name": "Sol Ring", "set": "MSC", "collector_number": "213", "scryfall_id": "sol-213", "score": 5, "released_at": "2024-06-01"},
+            {"face_name": "Sol Ring", "set": "MSC", "collector_number": "214", "scryfall_id": "sol-214", "score": 15, "released_at": "2024-06-01"},
+            {"face_name": "Lightning Bolt", "set": "MSC", "collector_number": "007", "scryfall_id": "bolt-7", "score": 10, "released_at": "2024-06-01"},
+            {"face_name": "Weird Card", "set": "MSC", "collector_number": "099a", "scryfall_id": "weird-99a", "score": 10, "released_at": "2024-06-01"},
+            {"face_name": "Promo Card", "set": "MSC", "collector_number": "★", "scryfall_id": "promo-star", "score": 10, "released_at": "2024-06-01"},
+        ]
+    )
+    path = tmp_path / "card_printings.parquet"
+    df.to_parquet(path, engine="pyarrow")
+    monkeypatch.setattr(card_search, "card_files_processed_dir", lambda: str(tmp_path))
+    return path
+
+
+def _all_cards_df() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "name": ["Sol Ring", "Lightning Bolt", "Weird Card", "Promo Card"],
+            "printings": ["MSC, LEA", "MSC, LEA", "MSC", "MSC"],
+        }
+    )
+
+
+def test_exact_cn_isolates_one_printing(printings_index):
+    parsed = parse_search_query("set:msc cn:212")
+    df = apply_extra_clauses(_all_cards_df(), parsed)
+    assert list(df["name"]) == ["Sol Ring"]
+
+    overlay = resolve_collector_number_printings(parsed)
+    assert overlay == {"sol ring": "sol-212"}
+
+
+def test_range_cn_matches_all_four_and_picks_best_scored(printings_index):
+    parsed = parse_search_query("set:msc cn>210")
+    df = apply_extra_clauses(_all_cards_df(), parsed)
+    assert list(df["name"]) == ["Sol Ring"]
+
+    # 212 has the highest score (20) among the matched range -- wins the image.
+    overlay = resolve_collector_number_printings(parsed)
+    assert overlay == {"sol ring": "sol-212"}
+
+
+def test_cn_without_set_is_noop_with_notice(printings_index):
+    parsed = parse_search_query("cn:212")
+    df = apply_extra_clauses(_all_cards_df(), parsed)
+    assert len(df) == 4  # unfiltered
+    assert any("requires a set:" in n for n in parsed.notices)
+    assert resolve_collector_number_printings(parsed) == {}
+
+
+def test_leading_zero_normalization(printings_index):
+    parsed = parse_search_query("set:msc cn:7")
+    df = apply_extra_clauses(_all_cards_df(), parsed)
+    assert list(df["name"]) == ["Lightning Bolt"]
+
+
+def test_suffixed_collector_number_exact_match(printings_index):
+    parsed = parse_search_query("set:msc cn:99a")
+    df = apply_extra_clauses(_all_cards_df(), parsed)
+    assert list(df["name"]) == ["Weird Card"]
+
+
+def test_non_numeric_collector_number_excluded_from_range(printings_index):
+    # "★" has no numeric prefix at all -- excluded from range comparisons
+    # rather than erroring or being treated as 0.
+    parsed = parse_search_query("set:msc cn>0")
+    df = apply_extra_clauses(_all_cards_df(), parsed)
+    assert "Promo Card" not in list(df["name"])
+
+
+def test_missing_printings_index_is_noop(tmp_path, monkeypatch):
+    monkeypatch.setattr(card_search, "card_files_processed_dir", lambda: str(tmp_path))  # no parquet written
+    parsed = parse_search_query("set:msc cn:212")
+    df = apply_extra_clauses(_all_cards_df(), parsed)
+    assert len(df) == 4  # falls back to no cn filtering, no crash
+    assert resolve_collector_number_printings(parsed) == {}
+
+
+def test_get_set_collector_number_sort_map(printings_index):
+    from code.web.services.card_search import get_set_collector_number_sort_map
+
+    sort_map = get_set_collector_number_sort_map("MSC")
+    # Sol Ring has 4 printings in MSC; the best-scored one (212) wins.
+    assert sort_map["sol ring"] == 212
+    assert sort_map["lightning bolt"] == 7  # leading zero stripped
+    assert sort_map["weird card"] == 99  # numeric prefix of "099a"
+    assert sort_map["promo card"] == float("inf")  # no numeric prefix ("★")
+
+
+def test_get_set_collector_number_sort_map_unknown_set(printings_index):
+    from code.web.services.card_search import get_set_collector_number_sort_map
+
+    assert get_set_collector_number_sort_map("ZZZ") == {}
+

--- a/code/tests/test_set_scoped_printing_display.py
+++ b/code/tests/test_set_scoped_printing_display.py
@@ -1,0 +1,158 @@
+"""
+Tests for the set-scoped default printing overlay (Roadmap 38, Milestone 2):
+`ImageCache.get_printing_id_for_set()` and card_browser.py's
+`_set_scoped_printings()` / `_apply_set_scoped_printings()`.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from code.file_setup.image_cache import ImageCache
+from code.web.app import app  # noqa: F401  (import first to avoid a card_browser circular import)
+import code.web.routes.card_browser as card_browser
+from code.web.services.card_search import ParsedSearch
+
+
+def _printings_df():
+    return pd.DataFrame(
+        [
+            {
+                "name": "Sol Ring", "face_name": "Sol Ring", "scryfall_id": "sol-khm",
+                "set": "khm", "set_name": "Kaldheim", "collector_number": "1",
+                "released_at": "2021-02-05", "finishes": ["nonfoil"], "score": 15,
+                "image_url_small": "s", "image_url_normal": "n", "is_default": False,
+            },
+            {
+                "name": "Sol Ring", "face_name": "Sol Ring", "scryfall_id": "sol-znr",
+                "set": "znr", "set_name": "Zendikar Rising", "collector_number": "2",
+                "released_at": "2020-09-25", "finishes": ["nonfoil"], "score": 15,
+                "image_url_small": "s", "image_url_normal": "n", "is_default": False,
+            },
+            {
+                "name": "Sol Ring", "face_name": "Sol Ring", "scryfall_id": "sol-lea",
+                "set": "lea", "set_name": "Limited Edition Alpha", "collector_number": "3",
+                "released_at": "1993-08-05", "finishes": ["nonfoil"], "score": 5,
+                "image_url_small": "s", "image_url_normal": "n", "is_default": True,
+            },
+        ]
+    )
+
+
+@pytest.fixture()
+def cache(tmp_path: Path) -> ImageCache:
+    c = ImageCache(base_dir=str(tmp_path / "images"))
+    c.printings_index_path = tmp_path / "card_printings.parquet"
+    _printings_df().to_parquet(c.printings_index_path, index=False)
+    return c
+
+
+def test_get_printing_id_for_set_matches_code(cache: ImageCache):
+    assert cache.get_printing_id_for_set("Sol Ring", "khm") == "sol-khm"
+    assert cache.get_printing_id_for_set("Sol Ring", "KHM") == "sol-khm"  # case-insensitive
+
+
+def test_get_printing_id_for_set_no_match_returns_none(cache: ImageCache):
+    assert cache.get_printing_id_for_set("Sol Ring", "znc") is None
+    assert cache.get_printing_id_for_set("Nonexistent Card", "khm") is None
+
+
+def test_get_printing_id_for_set_missing_index_returns_none(tmp_path: Path):
+    cache = ImageCache(base_dir=str(tmp_path / "images"))
+    cache.printings_index_path = tmp_path / "card_printings.parquet"  # never written
+    assert cache.get_printing_id_for_set("Sol Ring", "khm") is None
+
+
+def test_set_scoped_printings_skips_manual_picks_and_notices_alternates():
+    parsed = ParsedSearch(set_include={"KHM", "ZNR"})
+    cards_list = [{"name": "Sol Ring"}, {"name": "Manually Picked Card"}]
+    base_printings = {"manually picked card": "user-choice-id"}
+
+    def _fake_get_printing_id_for_set(name, code):
+        return {"khm": "sol-khm", "znr": "sol-znr"}.get(code.lower()) if name == "Sol Ring" else None
+
+    with patch.object(card_browser._image_cache, "get_printing_id_for_set", side_effect=_fake_get_printing_id_for_set):
+        overlay = card_browser._set_scoped_printings(cards_list, parsed, base_printings)
+
+    assert overlay == {"sol ring": "sol-khm"}  # sorted set codes -> KHM before ZNR
+    assert "Manually Picked Card" not in "".join(parsed.notices)
+    assert len(parsed.notices) == 1
+    assert "Sol Ring" in parsed.notices[0]
+
+
+# --- Milestone 5: set + collector number badge ------------------------------
+
+def test_get_printing_meta_by_scryfall_id(cache: ImageCache):
+    meta = cache.get_printing_meta("Sol Ring", scryfall_id="sol-znr")
+    assert meta == {"set": "ZNR", "set_name": "Zendikar Rising", "collector_number": "2"}
+
+
+def test_get_printing_meta_by_set_code_falls_back_to_best_score(cache: ImageCache):
+    # khm and znr tie at score=15; khm has the more recent released_at.
+    meta = cache.get_printing_meta("Sol Ring", set_code="khm")
+    assert meta == {"set": "KHM", "set_name": "Kaldheim", "collector_number": "1"}
+
+
+def test_get_printing_meta_no_match_returns_none(cache: ImageCache):
+    assert cache.get_printing_meta("Sol Ring", scryfall_id="not-a-real-id") is None
+    assert cache.get_printing_meta("Nonexistent Card", set_code="khm") is None
+
+
+def test_set_number_badges_only_when_exactly_one_set():
+    cards_list = [{"name": "Sol Ring"}]
+
+    def _fake_get_printing_meta(name, *, scryfall_id=None, set_code=None):
+        assert set_code == "KHM"
+        return {"set": "khm", "set_name": "Kaldheim", "collector_number": "1"}
+
+    with patch.object(card_browser._image_cache, "get_printing_meta", side_effect=_fake_get_printing_meta):
+        # No set: filter -> no badges.
+        assert card_browser._set_number_badges(cards_list, ParsedSearch(), {}) == {}
+        # Multiple set: filters -> ambiguous, no badges.
+        assert card_browser._set_number_badges(cards_list, ParsedSearch(set_include={"KHM", "ZNR"}), {}) == {}
+        # Exactly one set: filter -> badge populated.
+        badges = card_browser._set_number_badges(cards_list, ParsedSearch(set_include={"KHM"}), {})
+        assert badges == {"sol ring": {"set": "khm", "set_name": "Kaldheim", "collector_number": "1"}}
+
+
+def test_set_scoped_printings_no_set_filter_returns_empty():
+    assert card_browser._set_scoped_printings([{"name": "Sol Ring"}], None, {}) == {}
+    assert card_browser._set_scoped_printings([{"name": "Sol Ring"}], ParsedSearch(), {}) == {}
+
+
+def test_apply_set_scoped_printings_session_lifecycle(monkeypatch):
+    session_store: dict = {}
+    monkeypatch.setattr(card_browser, "get_session", lambda sid: session_store)
+
+    parsed_khm = ParsedSearch(set_include={"KHM"})
+    with patch.object(card_browser._image_cache, "get_printing_id_for_set", return_value="sol-khm"):
+        result = card_browser._apply_set_scoped_printings("sid1", [{"name": "Sol Ring"}], parsed_khm, {})
+    assert result == {"sol ring": "sol-khm"}
+    assert session_store["search_set_printings"]["codes"] == ["KHM"]
+
+    # Same set query, next page (pagination) -- accumulates rather than replacing.
+    with patch.object(card_browser._image_cache, "get_printing_id_for_set", return_value="lotus-khm"):
+        result = card_browser._apply_set_scoped_printings("sid1", [{"name": "Black Lotus"}], parsed_khm, {})
+    assert result == {"sol ring": "sol-khm", "black lotus": "lotus-khm"}
+
+    # A different set query replaces the stored overlay outright.
+    parsed_znr = ParsedSearch(set_include={"ZNR"})
+    with patch.object(card_browser._image_cache, "get_printing_id_for_set", return_value="sol-znr"):
+        result = card_browser._apply_set_scoped_printings("sid1", [{"name": "Sol Ring"}], parsed_znr, {})
+    assert result == {"sol ring": "sol-znr"}
+    assert session_store["search_set_printings"]["codes"] == ["ZNR"]
+
+    # A manual pick always wins over the auto overlay.
+    with patch.object(card_browser._image_cache, "get_printing_id_for_set", return_value="sol-znr"):
+        result = card_browser._apply_set_scoped_printings(
+            "sid1", [{"name": "Sol Ring"}], parsed_znr, {"sol ring": "user-choice-id"}
+        )
+    assert result["sol ring"] == "user-choice-id"
+
+    # No set filter clears the stored overlay.
+    result = card_browser._apply_set_scoped_printings("sid1", [{"name": "Sol Ring"}], None, {})
+    assert result == {}
+    assert session_store["search_set_printings"] == {}

--- a/code/tests/test_set_search_flag.py
+++ b/code/tests/test_set_search_flag.py
@@ -1,0 +1,92 @@
+"""
+Unit tests for `set:`/`s:`/`e:`/`edition:` set-name resolution in
+code/web/services/card_search.py (Roadmap 38, Milestone 1).
+"""
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+import code.web.services.card_search as card_search
+from code.web.services.card_search import parse_search_query
+
+
+@pytest.fixture(autouse=True)
+def _reset_set_index_cache():
+    """The set name/code index is cached as module globals for process
+    lifetime -- reset before/after each test so fixtures don't leak."""
+    card_search._SET_NAME_MAP = None
+    card_search._SET_CODES = None
+    card_search._SET_RELEASE_BY_CODE = None
+    yield
+    card_search._SET_NAME_MAP = None
+    card_search._SET_CODES = None
+    card_search._SET_RELEASE_BY_CODE = None
+
+
+@pytest.fixture()
+def printings_index(tmp_path, monkeypatch):
+    """Write a small fixture card_printings.parquet and point card_search at it."""
+    df = pd.DataFrame(
+        {
+            "set": ["khm", "eld", "aaa", "bbb", "ccc"],
+            "set_name": [
+                "Kaldheim",
+                "Throne of Eldraine",
+                "Commander One",
+                "Commander One Two",
+                "Commander Three",
+            ],
+            "released_at": ["2021-02-05", "2019-10-04", "2020-01-01", "2020-01-01", "2020-01-01"],
+        }
+    )
+    path = tmp_path / "card_printings.parquet"
+    df.to_parquet(path, engine="pyarrow")
+    monkeypatch.setattr(card_search, "card_files_processed_dir", lambda: str(tmp_path))
+    return path
+
+
+def test_set_flag_still_resolves_code(printings_index):
+    parsed = parse_search_query("set:khm")
+    assert parsed.set_include == {"KHM"}
+    assert parsed.notices == []
+
+
+def test_set_flag_resolves_full_name(printings_index):
+    parsed = parse_search_query("set:kaldheim")
+    assert parsed.set_include == {"KHM"}
+    assert parsed.notices == []
+
+
+def test_set_flag_resolves_name_with_punctuation(printings_index):
+    parsed = parse_search_query('set:"Throne of Eldraine"')
+    assert parsed.set_include == {"ELD"}
+
+
+def test_set_flag_ambiguous_name_picks_shortest_and_notices(printings_index):
+    parsed = parse_search_query("set:commander")
+    # "Commander One" (13 chars) is the shortest/closest match among the
+    # three candidates containing "commander".
+    assert parsed.set_include == {"AAA"}
+    assert len(parsed.notices) == 1
+    assert "Commander One Two (BBB)" in parsed.notices[0] or "Commander Three (CCC)" in parsed.notices[0]
+
+
+def test_set_flag_unknown_value_falls_back_to_raw_code(printings_index):
+    parsed = parse_search_query("set:zzz999")
+    assert parsed.set_include == {"ZZZ999"}
+    assert parsed.notices == []
+
+
+def test_set_flag_falls_back_when_printings_index_missing(monkeypatch, tmp_path):
+    # No card_printings.parquet exists at this path.
+    monkeypatch.setattr(card_search, "card_files_processed_dir", lambda: str(tmp_path))
+    parsed = parse_search_query("set:kaldheim")
+    assert parsed.set_include == {"KALDHEIM"}
+    assert parsed.notices == []
+
+
+def test_set_exclude_flag_resolves_name(printings_index):
+    parsed = parse_search_query("-set:kaldheim")
+    assert parsed.set_exclude == {"KHM"}
+    assert parsed.set_include == set()

--- a/code/web/routes/api_v1/cards.py
+++ b/code/web/routes/api_v1/cards.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
+import re
 import time
 import uuid
 from pathlib import Path
@@ -29,6 +30,7 @@ from fastapi.encoders import jsonable_encoder
 from code.deck_builder.builder_utils import parse_theme_tags
 from code.services.all_cards_loader import AllCardsLoader
 
+from ..api import _image_cache
 from ...services.card_search import (
     ColorClause,
     ManaCostClause,
@@ -42,6 +44,10 @@ from ...services.card_search import (
     normalize_word_sep as _normalize_word_sep,
     parse_color_cell as _parse_color_cell,
     parse_search_query as _parse_search_query,
+    resolve_collector_number_printings as _resolve_collector_number_printings,
+    get_set_collector_number_sort_map as _get_set_collector_number_sort_map,
+    _collector_number_match_mask,
+    _load_printings_index_df,
 )
 from ...services.card_similarity import CardSimilarity
 from ...services.rulings import get_rulings
@@ -220,7 +226,13 @@ def _json_safe(value: Any) -> Any:
     return value
 
 
-def _serialize_card(row, *, full: bool = False) -> Dict[str, Any]:
+def _serialize_card(
+    row,
+    *,
+    full: bool = False,
+    resolved_printing_id: Optional[str] = None,
+    set_badge: Optional[Dict[str, str]] = None,
+) -> Dict[str, Any]:
     card = row.to_dict()
     data: Dict[str, Any] = {
         "name": card.get("name"),
@@ -233,6 +245,16 @@ def _serialize_card(row, *, full: bool = False) -> Dict[str, Any]:
         "metadataTags": parse_theme_tags(card.get("metadataTags")),
         "edhrecRank": card.get("edhrecRank"),
         "scryfallID": card.get("scryfallID"),
+        # Only set when a `set:`/`cn:`/`number:` search flag pinned this card to a
+        # specific printing (mirrors the web UI's card_image overlay, see
+        # card_browser.py's _set_scoped_printings()/_apply_collector_number_printings()).
+        # Clients should pass this as the `printing` param to the image endpoint
+        # instead of relying on the default-scored printing.
+        "resolvedPrintingId": resolved_printing_id,
+        # Only set when the search is scoped to exactly one `set:` (mirrors
+        # the web UI's card tile/detail "Set Name #123" badge, see
+        # card_browser.py's _set_number_badges()).
+        "setBadge": set_badge,
     }
     if full:
         data.update(
@@ -263,8 +285,11 @@ async def list_cards(
             "t:/type:, o:/oracle:, m:/mana:, mv:/cmc:/manavalue:, pow:/power:, "
             "tou:/toughness: -- each accepts :, =, >, <, >=, <=, or != and may be "
             "negated with a leading -. Also supports tag:/theme: (theme tags), "
-            "art:/atag:/arttag: (Scryfall community illustration tags), and "
-            "metadata:/mtag:/metatag: (internal deck-builder tags). Note: bare "
+            "art:/atag:/arttag: (Scryfall community illustration tags), "
+            "metadata:/mtag:/metatag: (internal deck-builder tags), and "
+            "set:/s:/e:/edition: (a set code like `khm` or a full set name "
+            "like `kaldheim`; ambiguous set names return a `notices` message "
+            "in the response listing alternatives). Note: bare "
             "`id:br` matches anything playable "
             "with a black/red identity (subset, incl. colorless), while `id=br` "
             "matches only exact black/red; bare `color:br` matches cards including "
@@ -365,10 +390,48 @@ async def list_cards(
     if max_cmc is not None and "manaValue" in df.columns:
         df = df[df["manaValue"] <= max_cmc]
 
+    # Set filter (set:/s:/e:/edition: flags in q, accepts a code or a full
+    # set name) -- not exposed as an explicit query param since it's a niche/
+    # advanced search only. This route doesn't call the shared
+    # `apply_extra_clauses()`, so it needs its own mirrored block, same as
+    # the tag/art_tag/metadata_tag blocks above.
+    if parsed.set_include and "printings" in df.columns:
+        for code in parsed.set_include:
+            df = df[df["printings"].astype(str).str.contains(rf"\b{re.escape(code)}\b", na=False, regex=True)]
+    if parsed.set_exclude and "printings" in df.columns:
+        for code in parsed.set_exclude:
+            df = df[~df["printings"].astype(str).str.contains(rf"\b{re.escape(code)}\b", na=False, regex=True)]
+
+    # Collector number (cn:/number: flags in q, requires set:/s: in the same
+    # query -- a collector number alone isn't meaningful) -- not exposed as
+    # an explicit query param, same mirrored-block gotcha as set: above.
+    if parsed.collector_number_clauses:
+        if not parsed.set_include:
+            parsed.notices.append("cn:/number: requires a set: filter and was ignored.")
+        else:
+            printings_df = _load_printings_index_df()
+            if printings_df is not None and not printings_df.empty:
+                subset = printings_df[printings_df["set"].astype(str).str.upper().isin(parsed.set_include)]
+                if subset.empty:
+                    df = df.iloc[0:0]
+                else:
+                    matched_names = set(
+                        subset.loc[_collector_number_match_mask(subset, parsed.collector_number_clauses), "face_name"].astype(str)
+                    )
+                    df = df[df["name"].astype(str).isin(matched_names)]
+
     # Default sort: Name A-Z, matching the HTML card browser's default sort
     # (card_browser.py's "name_asc"), so results aren't left in arbitrary
-    # data-file order.
-    if "name" in df.columns and len(df):
+    # data-file order. A single set: filter instead defaults to collector
+    # number order (mirrors card_browser.py's default-sort override).
+    set_cn_sort_map: Dict[str, float] = {}
+    if len(parsed.set_include) == 1:
+        (only_set_code,) = parsed.set_include
+        set_cn_sort_map = _get_set_collector_number_sort_map(only_set_code)
+    if set_cn_sort_map and len(df):
+        df = df.assign(_cn_sort=df["name"].str.lower().map(set_cn_sort_map).fillna(float("inf")))
+        df = df.sort_values(["_cn_sort", "name"], ascending=[True, True]).drop(columns="_cn_sort")
+    elif "name" in df.columns and len(df):
         sort_key = df["name"].str.replace('"', "", regex=False).str.replace("'", "", regex=False)
         sort_key = sort_key.apply(lambda x: x.replace("_", " ") if isinstance(x, str) and x.startswith("_") else x)
         df = df.assign(_sort_key=sort_key).sort_values("_sort_key", key=lambda col: col.str.lower()).drop(columns="_sort_key")
@@ -377,13 +440,57 @@ async def list_cards(
     start = (page - 1) * page_size
     page_df = df.iloc[start : start + page_size]
 
+    # Resolved-printing overlay for this page's cards (mobile/web parity):
+    # a `set:` filter pins each card to its best-scored printing in that set
+    # (card_browser.py's _set_scoped_printings()); a `cn:`/`number:` clause
+    # then wins over that, either isolating one exact printing or narrowing
+    # the scoring to just the matched range (resolve_collector_number_printings()).
+    printing_overlay: Dict[str, str] = {}
+    if parsed.set_include:
+        set_codes = sorted(parsed.set_include)
+        for _, row in page_df.iterrows():
+            name = row.get("name")
+            if not name or name.lower() in printing_overlay:
+                continue
+            for code in set_codes:
+                scryfall_id = _image_cache.get_printing_id_for_set(name, code)
+                if scryfall_id:
+                    printing_overlay[name.lower()] = scryfall_id
+                    break
+    if parsed.collector_number_clauses:
+        printing_overlay.update(_resolve_collector_number_printings(parsed))
+
+    # Set + collector number badge (mirrors card_browser.py's
+    # _set_number_badges()): only unambiguous when exactly one `set:` is
+    # searched, using each card's resolved printing above so the badge
+    # never contradicts the returned `resolvedPrintingId`/artwork.
+    set_badges: Dict[str, Dict[str, str]] = {}
+    if len(parsed.set_include) == 1:
+        (set_code,) = parsed.set_include
+        for _, row in page_df.iterrows():
+            name = row.get("name")
+            if not name:
+                continue
+            key = name.lower()
+            meta = _image_cache.get_printing_meta(name, scryfall_id=printing_overlay.get(key), set_code=set_code)
+            if meta:
+                set_badges[key] = {"set": meta["set"], "setName": meta["set_name"], "collectorNumber": meta["collector_number"]}
+
     return ok(
         {
-            "cards": [_serialize_card(row) for _, row in page_df.iterrows()],
+            "cards": [
+                _serialize_card(
+                    row,
+                    resolved_printing_id=printing_overlay.get(str(row.get("name") or "").lower()),
+                    set_badge=set_badges.get(str(row.get("name") or "").lower()),
+                )
+                for _, row in page_df.iterrows()
+            ],
             "total_count": total,
             "page": page,
             "page_size": page_size,
             "total_pages": (total + page_size - 1) // page_size if page_size else 0,
+            "notices": parsed.notices,
         },
         _rid(request),
     )

--- a/code/web/routes/card_browser.py
+++ b/code/web/routes/card_browser.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 from fastapi import APIRouter, Request, Query
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, RedirectResponse
 from ..app import templates
 from ..services.tasks import get_session, new_sid
 
@@ -25,12 +25,15 @@ try:
     from code.deck_builder.color_identity_utils import color_identity_badges
     from code.settings import ENABLE_CARD_DETAILS
     from code.web.routes.api_v1.cards import _get_card_faces
+    from code.web.routes.api import _image_cache
     from code.web.services.card_search import (
         apply_extra_clauses,
         apply_name_clauses,
         apply_parsed_search,
         has_structured_flags,
         parse_search_query,
+        resolve_collector_number_printings,
+        get_set_collector_number_sort_map,
     )
 except ImportError:
     from services.all_cards_loader import AllCardsLoader
@@ -38,16 +41,20 @@ except ImportError:
     from deck_builder.color_identity_utils import color_identity_badges
     from settings import ENABLE_CARD_DETAILS
     from web.routes.api_v1.cards import _get_card_faces
+    from web.routes.api import _image_cache
     from web.services.card_search import (
         apply_extra_clauses,
         apply_name_clauses,
         apply_parsed_search,
         has_structured_flags,
         parse_search_query,
+        resolve_collector_number_printings,
+        get_set_collector_number_sort_map,
     )
 
 if TYPE_CHECKING:
     from code.web.services.card_similarity import CardSimilarity
+    from code.web.services.card_search import ParsedSearch
 
 logger = logging.getLogger(__name__)
 
@@ -91,6 +98,148 @@ def _foils_context(request: Request, sid: str | None = None) -> dict[str, bool]:
     """
     sid = sid or request.cookies.get("sid") or new_sid()
     return dict(get_session(sid).get("foils") or {})
+
+
+def _set_scoped_printings(
+    cards_list: list[dict],
+    parsed: "ParsedSearch | None",
+    base_printings: dict[str, str],
+) -> dict[str, str]:
+    """Build a set-scoped printing overlay for the current search's results.
+
+    For each card not already present in `base_printings` (a manual "Choose
+    Printing" pick always wins), tries each code in `parsed.set_include` in
+    sorted order, using the first set that has a match. Cards with a match
+    in more than one searched set get a `parsed.notices` entry noting
+    alternates are available. Returns `{}` unchanged if there's no `set:`
+    filter to scope to.
+    """
+    overlay: dict[str, str] = {}
+    if not parsed or not parsed.set_include:
+        return overlay
+
+    set_codes = sorted(parsed.set_include)
+    alt_available: list[str] = []
+    for card in cards_list:
+        name = card.get("name")
+        if not name:
+            continue
+        key = name.lower()
+        if key in base_printings:
+            continue
+        matched_sets = []
+        for code in set_codes:
+            scryfall_id = _image_cache.get_printing_id_for_set(name, code)
+            if scryfall_id:
+                matched_sets.append((code, scryfall_id))
+        if matched_sets:
+            overlay[key] = matched_sets[0][1]
+            if len(matched_sets) > 1:
+                alt_available.append(name)
+
+    if alt_available:
+        shown = ", ".join(alt_available[:5])
+        parsed.notices.append(
+            f"Showing the searched set's printing for: {shown}. "
+            "Alternate printings are also available in the other searched sets."
+        )
+    return overlay
+
+
+def _apply_set_scoped_printings(
+    sid: str,
+    cards_list: list[dict],
+    parsed: "ParsedSearch | None",
+    printings: dict[str, str],
+) -> dict[str, str]:
+    """Merge a set-scoped printing overlay into `printings` for template rendering.
+
+    Reads/writes `sess["search_set_printings"]` (kept separate from the
+    manual picker's `sess["printings"]`, see `_printings_context`): a fresh
+    `set:` query (different codes than last time) replaces the stored
+    overlay outright; the same `set:` query across HTMX pagination
+    accumulates entries instead of losing earlier pages' overrides. Manual
+    "Choose Printing" picks in `printings` always take precedence.
+    """
+    session = get_session(sid)
+    stored = session.get("search_set_printings") or {}
+    set_codes = sorted(parsed.set_include) if parsed and parsed.set_include else []
+
+    if not set_codes:
+        if stored:
+            session["search_set_printings"] = {}
+        return printings
+
+    if stored.get("codes") != set_codes:
+        stored = {"codes": set_codes, "entries": {}}
+    new_overlay = _set_scoped_printings(cards_list, parsed, printings)
+    stored["entries"].update(new_overlay)
+    session["search_set_printings"] = stored
+    return {**stored["entries"], **printings}
+
+
+def _apply_collector_number_printings(
+    sid: str,
+    parsed: "ParsedSearch | None",
+    printings: dict[str, str],
+) -> dict[str, str]:
+    """Merge a `cn:`/`number:`-pinned printing overlay into `printings`.
+
+    Unlike `_set_scoped_printings()`, this resolves against the *entire*
+    printings index (not just the current page's `cards_list`), so it needs
+    no pagination-accumulation logic -- it's simply recomputed and fully
+    replaces `sess["search_cn_printings"]` on every request (cleared to `{}`
+    once `cn:`/`number:` is dropped from the query, so a stale pin can't
+    outlive the search that produced it). Wins over the plain set-scoped
+    overlay but still loses to a manual "Choose Printing" pick.
+    """
+    session = get_session(sid)
+    overlay = resolve_collector_number_printings(parsed) if parsed else {}
+    session["search_cn_printings"] = overlay
+    return {**printings, **overlay} if overlay else printings
+
+
+def _set_number_badges(
+    cards_list: list[dict],
+    parsed: "ParsedSearch | None",
+    printings: dict[str, str],
+) -> dict[str, dict]:
+    """Build a `{name.lower(): {set, set_name, collector_number}}` badge overlay.
+
+    Only populated when exactly one `set:` code is active (Milestone 5
+    scope) -- a badge can't unambiguously describe more than one searched
+    set. Looks up the printing actually being displayed (the resolved
+    `printings` overlay entry, which already reflects cn:/manual-pick
+    precedence) so the badge always matches the shown art; falls back to
+    the set's own best-scored printing if nothing's been resolved yet.
+    """
+    if not parsed or len(parsed.set_include) != 1:
+        return {}
+    set_code = next(iter(parsed.set_include))
+    badges: dict[str, dict] = {}
+    for card in cards_list:
+        name = card.get("name")
+        if not name:
+            continue
+        key = name.lower()
+        meta = _image_cache.get_printing_meta(name, scryfall_id=printings.get(key), set_code=set_code)
+        if meta:
+            badges[key] = meta
+    return badges
+
+
+def _card_printed_sets(card_name: str) -> list[dict]:
+    """One chip per unique set a card has been printed in, newest first."""
+    printings = _image_cache.get_printings(card_name)
+    if not printings:
+        return []
+    by_code: dict[str, dict] = {}
+    for p in printings:
+        code = str(p.get("set") or "").upper()
+        if not code or code in by_code:
+            continue
+        by_code[code] = {"code": code, "name": str(p.get("set_name") or code), "released_at": str(p.get("released_at") or "")}
+    return sorted(by_code.values(), key=lambda s: s["released_at"], reverse=True)
 
 
 def get_similarity() -> "CardSimilarity":
@@ -206,7 +355,7 @@ def get_theme_index() -> dict[str, set[int]]:
     return _theme_index
 
 
-def _apply_search_query(filtered_df: "pd.DataFrame", search: str) -> "pd.DataFrame":
+def _apply_search_query(filtered_df: "pd.DataFrame", search: str) -> tuple["pd.DataFrame", "ParsedSearch | None"]:
     """Apply the search box. A query containing any Scryfall-style flags
     (t:/o:/c:/id:/m:/mv:/pow:/tou:/loy:/r:/tag:/is:new/set:) is filtered
     structurally via card_search.py; a plain name-only query keeps this
@@ -214,18 +363,24 @@ def _apply_search_query(filtered_df: "pd.DataFrame", search: str) -> "pd.DataFra
     then same-word-count fuzzy, then substring/fuzzy), which is more
     forgiving than a strict substring search for the "just typing a card
     name" common case.
+
+    Returns `(filtered_df, parsed)` -- `parsed` is the `ParsedSearch` used
+    for structured queries (so callers can read `set_include` for the
+    set-scoped printing overlay), or `None` for a plain name search / no
+    search at all.
     """
     if not search:
-        return filtered_df
+        return filtered_df, None
 
     parsed = parse_search_query(search)
     if has_structured_flags(parsed):
         filtered_df = apply_parsed_search(filtered_df, parsed)
         filtered_df = apply_extra_clauses(filtered_df, parsed)
-        return filtered_df
+        return filtered_df, parsed
 
     query_lower = search.lower().strip()
     query_words = set(query_lower.split())
+    query_norm = _normalize_search_text(search)
 
     exact_matches = []
     word_count_matches = []
@@ -237,8 +392,16 @@ def _apply_search_query(filtered_df: "pd.DataFrame", search: str) -> "pd.DataFra
         # For double-faced cards, get the front face name
         front_name = card_lower.split(' // ')[0].strip() if ' // ' in card_lower else card_lower
 
-        # Exact match (full name or front face)
-        if card_lower == query_lower or front_name == query_lower:
+        # Exact match (full name or front face) -- punctuation-insensitive
+        # (commas/apostrophes) so "Alania Divergent Storm" matches "Alania,
+        # Divergent Storm" the same way typing the comma would, instead of
+        # falling through to the much noisier fuzzy/any-word branch below.
+        if (
+            card_lower == query_lower
+            or front_name == query_lower
+            or _normalize_search_text(card_name) == query_norm
+            or _normalize_search_text(front_name) == query_norm
+        ):
             exact_matches.append(idx)
         # Word count match (same number of words + high similarity)
         elif len(query_lower.split()) == len(front_name.split()) and (
@@ -272,8 +435,8 @@ def _apply_search_query(filtered_df: "pd.DataFrame", search: str) -> "pd.DataFra
             if idx not in seen:
                 seen.add(idx)
                 unique_matches.append(idx)
-        return filtered_df.iloc[unique_matches]
-    return filtered_df.iloc[0:0]
+        return filtered_df.iloc[unique_matches], None
+    return filtered_df.iloc[0:0], None
 
 
 @router.get("/", response_class=HTMLResponse)
@@ -296,7 +459,7 @@ async def card_browser_index(
         # Apply filters
         filtered_df = df.copy()
         
-        filtered_df = _apply_search_query(filtered_df, search)
+        filtered_df, parsed = _apply_search_query(filtered_df, search)
         
         # Multi-select theme filtering (AND logic: card must have ALL selected themes)
         if themes:
@@ -337,7 +500,16 @@ async def card_browser_index(
                     filtered_df = filtered_df.iloc[0:0]
 
         # Apply sorting
-        if sort == "name_desc":
+        set_cn_sort_map: dict = {}
+        if sort == "name_asc" and parsed and len(parsed.set_include) == 1:
+            (only_set_code,) = parsed.set_include
+            set_cn_sort_map = get_set_collector_number_sort_map(only_set_code)
+        if set_cn_sort_map:
+            # Single-set search: default to collector-number order instead of alphabetical.
+            filtered_df['_cn_sort'] = filtered_df['name'].str.lower().map(set_cn_sort_map).fillna(float('inf'))
+            filtered_df = filtered_df.sort_values(['_cn_sort', 'name'], ascending=[True, True])
+            filtered_df = filtered_df.drop('_cn_sort', axis=1)
+        elif sort == "name_desc":
             # Name Z-A
             filtered_df['_sort_key'] = filtered_df['name'].str.replace('"', '', regex=False).str.replace("'", '', regex=False)
             filtered_df['_sort_key'] = filtered_df['_sort_key'].apply(
@@ -427,6 +599,26 @@ async def card_browser_index(
         last_card_name = cards_list[-1]['name'] if cards_list else ""
         
         printings, sid, had_cookie = _printings_context(request)
+        manual_printings = printings
+        printings = _apply_set_scoped_printings(sid, cards_list, parsed, printings)
+        printings = _apply_collector_number_printings(sid, parsed, printings)
+        printings = {**printings, **manual_printings}
+        set_badges = _set_number_badges(cards_list, parsed, printings)
+
+        # A search that narrows to exactly one card skips the results grid
+        # entirely and jumps straight to that card's detail page -- any
+        # set:-scoped printing is already carried over via the session
+        # overlay above, which card_detail() also reads.
+        if search and total_filtered == 1 and cards_list:
+            from urllib.parse import quote
+            resp = RedirectResponse(url=f"/cards/{quote(cards_list[0]['name'])}", status_code=302)
+            if not had_cookie:
+                try:
+                    resp.set_cookie("sid", sid, max_age=60 * 60 * 8, httponly=True, samesite="lax")
+                except Exception:
+                    pass
+            return resp
+
         foils = _foils_context(request, sid)
         resp = templates.TemplateResponse(
             "browse/cards/index.html",
@@ -446,6 +638,7 @@ async def card_browser_index(
                 "enable_card_details": ENABLE_CARD_DETAILS,
                 "printings": printings,
                 "foils": foils,
+                "set_badges": set_badges,
             },
         )
         if not had_cookie:
@@ -510,7 +703,7 @@ async def card_browser_grid(
         # Apply filters
         filtered_df = df.copy()
         
-        filtered_df = _apply_search_query(filtered_df, search)
+        filtered_df, parsed = _apply_search_query(filtered_df, search)
         
         # Multi-select theme filtering (AND logic: card must have ALL selected themes)
         if themes:
@@ -551,7 +744,15 @@ async def card_browser_grid(
                     filtered_df = filtered_df.iloc[0:0]
         
         # Apply sorting (same logic as main endpoint)
-        if sort == "name_desc":
+        set_cn_sort_map: dict = {}
+        if sort == "name_asc" and parsed and len(parsed.set_include) == 1:
+            (only_set_code,) = parsed.set_include
+            set_cn_sort_map = get_set_collector_number_sort_map(only_set_code)
+        if set_cn_sort_map:
+            filtered_df['_cn_sort'] = filtered_df['name'].str.lower().map(set_cn_sort_map).fillna(float('inf'))
+            filtered_df = filtered_df.sort_values(['_cn_sort', 'name'], ascending=[True, True])
+            filtered_df = filtered_df.drop('_cn_sort', axis=1)
+        elif sort == "name_desc":
             filtered_df['_sort_key'] = filtered_df['name'].str.replace('"', '', regex=False).str.replace("'", '', regex=False)
             filtered_df['_sort_key'] = filtered_df['_sort_key'].apply(
                 lambda x: x.replace('_', ' ') if x.startswith('_') else x
@@ -635,6 +836,11 @@ async def card_browser_grid(
         last_card_name = cards_list[-1]['name'] if cards_list else ""
         
         printings, sid, had_cookie = _printings_context(request)
+        manual_printings = printings
+        printings = _apply_set_scoped_printings(sid, cards_list, parsed, printings)
+        printings = _apply_collector_number_printings(sid, parsed, printings)
+        printings = {**printings, **manual_printings}
+        set_badges = _set_number_badges(cards_list, parsed, printings)
         foils = _foils_context(request, sid)
         resp = templates.TemplateResponse(
             "browse/cards/_card_grid.html",
@@ -649,6 +855,7 @@ async def card_browser_grid(
                 "enable_card_details": ENABLE_CARD_DETAILS,
                 "printings": printings,
                 "foils": foils,
+                "set_badges": set_badges,
             },
         )
         if not had_cookie:
@@ -817,103 +1024,6 @@ def _fuzzy_card_name_score(query: str, card_name: str) -> float:
     base_result = max(base_score, best_partial, token_avg, substring_bonus)
     return min(1.0, base_result + word_count_bonus)  # Cap at 1.0
 
-
-
-@router.get("/search-autocomplete", response_class=HTMLResponse)
-async def card_search_autocomplete(
-    request: Request,
-    q: str = Query(..., min_length=2, description="Card name search query"),
-    limit: int = Query(10, ge=1, le=50),
-) -> HTMLResponse:
-    """
-    HTMX endpoint for card name autocomplete with fuzzy matching.
-    
-    Similar to commanders theme autocomplete, returns HTML suggestions
-    with keyboard navigation support.
-    """
-    try:
-        loader = get_loader()
-        df = loader.load()
-        
-        # Quick filter: prioritize exact match, then word count match, then fuzzy
-        query_lower = q.lower()
-        query_words = set(query_lower.split())
-        query_word_count = len(query_lower.split())
-        
-        # Fast categorization
-        exact_matches = []
-        word_count_candidates = []
-        fuzzy_candidates = []
-        
-        for card_name in df['name'].unique():
-            card_lower = card_name.lower()
-            
-            # Exact match
-            if card_lower == query_lower:
-                exact_matches.append(card_name)
-            # Same word count with substring/word overlap
-            elif len(card_lower.split()) == query_word_count and (
-                query_lower in card_lower or any(word in card_lower for word in query_words)
-            ):
-                word_count_candidates.append(card_name)
-            # Fuzzy candidate
-            elif query_lower in card_lower or any(word in card_lower for word in query_words):
-                fuzzy_candidates.append(card_name)
-        
-        # Build final scored list
-        scored_cards: list[tuple[float, str, int]] = []  # (score, name, priority)
-        
-        # 1. Exact matches (priority 0 = highest)
-        for card_name in exact_matches[:limit]:  # Take top N exact matches
-            scored_cards.append((1.0, card_name, 0))
-        
-        # 2. Word count matches (priority 1)
-        if len(scored_cards) < limit and word_count_candidates:
-            # Limit word count candidates before fuzzy scoring
-            if len(word_count_candidates) > 200:
-                word_count_candidates.sort(key=lambda n: (not n.lower().startswith(query_lower), len(n), n.lower()))
-                word_count_candidates = word_count_candidates[:200]
-            
-            for card_name in word_count_candidates:
-                score = _fuzzy_card_name_score(q, card_name)
-                if score >= 0.3:
-                    scored_cards.append((score, card_name, 1))
-        
-        # 3. Fuzzy matches (priority 2)
-        if len(scored_cards) < limit and fuzzy_candidates:
-            # Limit fuzzy candidates before scoring
-            if len(fuzzy_candidates) > 200:
-                fuzzy_candidates.sort(key=lambda n: (not n.lower().startswith(query_lower), len(n), n.lower()))
-                fuzzy_candidates = fuzzy_candidates[:200]
-            
-            for card_name in fuzzy_candidates:
-                score = _fuzzy_card_name_score(q, card_name)
-                if score >= 0.3:
-                    scored_cards.append((score, card_name, 2))
-        
-        # Sort by priority first, then score desc, then name asc
-        scored_cards.sort(key=lambda x: (x[2], -x[0], x[1].lower()))
-        
-        # Take top matches
-        top_matches = scored_cards[:limit]
-        
-        # Generate HTML suggestions with ARIA attributes
-        html_parts = []
-        for score, card_name, priority in top_matches:
-            # Escape HTML special characters
-            safe_name = card_name.replace('&', '&amp;').replace('<', '&lt;').replace('>', '&gt;').replace('"', '&quot;')
-            html_parts.append(
-                f'<div class="autocomplete-item" data-value="{safe_name}" role="option">'
-                f'{safe_name}</div>'
-            )
-        
-        html = "\n".join(html_parts) if html_parts else '<div class="autocomplete-empty">No matching cards</div>'
-        
-        return HTMLResponse(content=html)
-        
-    except Exception as e:
-        logger.error(f"Error in card autocomplete: {e}", exc_info=True)
-        return HTMLResponse(content=f'<div class="autocomplete-error">Error: {str(e)}</div>')
 
 
 @router.get("/theme-autocomplete", response_class=HTMLResponse)
@@ -1150,7 +1260,24 @@ async def card_detail(request: Request, card_name: str, ref: str = Query("", des
         back_text = "Back to Owned Library" if _ref == "owned" else "Back to Card Browser"
 
         printings, sid, had_cookie = _printings_context(request)
+        # Carry over a `set:`/`cn:` search's printing overlay (see
+        # _apply_set_scoped_printings / _apply_collector_number_printings) so
+        # following a search result into its detail page still shows that
+        # search's art; manual picks still win.
+        session = get_session(sid)
+        set_overlay = session.get("search_set_printings", {}).get("entries", {})
+        cn_overlay = session.get("search_cn_printings", {})
+        printings = {**set_overlay, **cn_overlay, **printings}
         foils = _foils_context(request, sid)
+
+        # M5 set+cn badge: only when the last search was scoped to exactly
+        # one set: (see _set_number_badges' docstring for why).
+        set_codes = session.get("search_set_printings", {}).get("codes") or []
+        set_badge = None
+        if len(set_codes) == 1:
+            set_badge = _image_cache.get_printing_meta(
+                card_name, scryfall_id=printings.get(card_name.lower()), set_code=set_codes[0]
+            )
 
         # Per-face details (type/text/mana value/power/toughness) for the
         # "Transform" flip button on double-faced/split/flip/meld cards --
@@ -1161,6 +1288,8 @@ async def card_detail(request: Request, card_name: str, ref: str = Query("", des
             faces = _get_card_faces(card_name)
         except Exception:
             faces = []
+
+        card_printed_sets = _card_printed_sets(card_name)
 
         resp = templates.TemplateResponse(
             "browse/cards/detail.html",
@@ -1177,6 +1306,8 @@ async def card_detail(request: Request, card_name: str, ref: str = Query("", des
                 "back_text": back_text,
                 "printings": printings,
                 "foils": foils,
+                "set_badge": set_badge,
+                "card_printed_sets": card_printed_sets,
             }
         )
         if not had_cookie:

--- a/code/web/routes/owned.py
+++ b/code/web/routes/owned.py
@@ -267,25 +267,6 @@ async def owned_remove(request: Request) -> HTMLResponse:
 # Bulk user-tag endpoints removed by request.
 
 
-@router.get("/search-autocomplete", response_class=HTMLResponse)
-async def owned_search_autocomplete(
-    request: Request,
-    q: str = Query(..., min_length=2),
-    limit: int = Query(10, ge=1, le=20),
-) -> HTMLResponse:
-    """Return card name suggestions from the owned library for the search autocomplete."""
-    names, _, _, _ = store.get_enriched(_user_id(request))
-    ql = q.strip().lower()
-    matches = [n for n in names if ql in n.lower()][:limit]
-    if not matches:
-        return HTMLResponse(content='<div class="autocomplete-empty">No matches in owned library</div>')
-    html = "\n".join(
-        f'<div class="autocomplete-item" data-value="{n}" role="option">{n}</div>'
-        for n in matches
-    )
-    return HTMLResponse(content=html)
-
-
 """
 Note: Per request, all user tag add/remove endpoints have been removed.
 """

--- a/code/web/services/card_search.py
+++ b/code/web/services/card_search.py
@@ -25,6 +25,7 @@ match (or exclude, with `-`) the card name.
 """
 from __future__ import annotations
 
+import os
 import re
 import shlex
 from collections import Counter
@@ -35,6 +36,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 import pandas as pd
 
 from code.deck_builder.builder_utils import parse_theme_tags
+from code.path_util import card_files_processed_dir
 
 
 def parse_color_cell(raw: Any) -> set:
@@ -87,6 +89,7 @@ _KEY_ALIASES: Dict[str, str] = {
     "metadata": "metadatatag", "mtag": "metadatatag", "metatag": "metadatatag",
     "is": "is",
     "set": "set", "s": "set", "e": "set", "edition": "set",
+    "cn": "collector_number", "number": "collector_number",
 }
 
 _COLOR_LETTERS = set("WUBRG")
@@ -143,6 +146,18 @@ class ManaCostClause:
 
 
 @dataclass
+class CollectorNumberClause:
+    """A `cn:`/`number:` clause. `:`/`=`/`!=` compare the raw (leading-zero-
+    normalized) string, so suffixed numbers like `123a`/`123*` still work;
+    `>`/`<`/`>=`/`<=` require a numeric prefix (non-numeric values are
+    excluded from the comparison, not errored -- same convention as
+    power/toughness `*`)."""
+    op: str
+    value: str
+    negate: bool = False
+
+
+@dataclass
 class ParsedSearch:
     name_include: List[str] = field(default_factory=list)
     name_exclude: List[str] = field(default_factory=list)
@@ -168,6 +183,8 @@ class ParsedSearch:
     is_new: Optional[bool] = None
     set_include: Set[str] = field(default_factory=set)
     set_exclude: Set[str] = field(default_factory=set)
+    collector_number_clauses: List[CollectorNumberClause] = field(default_factory=list)
+    notices: List[str] = field(default_factory=list)
 
 
 def _parse_color_value(value: str) -> Tuple[Set[str], Optional[int], Optional[str]]:
@@ -423,6 +440,197 @@ def filter_names_fuzzy(names: List[str], include: List[str], exclude: List[str])
     return fuzzy
 
 
+_SET_NAME_MAP: Optional[Dict[str, str]] = None  # normalized set name -> uppercase code
+_SET_CODES: Optional[Set[str]] = None  # every known uppercase code
+_SET_RELEASE_BY_CODE: Optional[Dict[str, str]] = None  # code -> most recent released_at string
+
+
+def _load_set_index() -> Tuple[Dict[str, str], Set[str], Dict[str, str]]:
+    """Lazily build (and cache for the process lifetime) a set-name/code index
+    from `card_files/processed/card_printings.parquet`'s `set`/`set_name`/
+    `released_at` columns, so `set:` can resolve full set names in addition
+    to codes without a new Scryfall bulk-data fetch. Returns empty
+    structures (never raises) if the printings index hasn't been built yet."""
+    global _SET_NAME_MAP, _SET_CODES, _SET_RELEASE_BY_CODE
+    if _SET_NAME_MAP is not None and _SET_CODES is not None and _SET_RELEASE_BY_CODE is not None:
+        return _SET_NAME_MAP, _SET_CODES, _SET_RELEASE_BY_CODE
+
+    name_map: Dict[str, str] = {}
+    codes: Set[str] = set()
+    release_by_code: Dict[str, str] = {}
+    try:
+        path = os.path.join(card_files_processed_dir(), "card_printings.parquet")
+        df = pd.read_parquet(path, columns=["set", "set_name", "released_at"])
+        grouped = df.dropna(subset=["set"]).groupby("set").agg({"set_name": "first", "released_at": "max"})
+        for code, row in grouped.iterrows():
+            code_upper = str(code).strip().upper()
+            if not code_upper:
+                continue
+            codes.add(code_upper)
+            release_by_code[code_upper] = str(row["released_at"] or "")
+            set_name = row["set_name"]
+            if set_name:
+                name_map[normalize_word_sep(str(set_name))] = code_upper
+    except Exception:
+        name_map, codes, release_by_code = {}, set(), {}
+
+    _SET_NAME_MAP, _SET_CODES, _SET_RELEASE_BY_CODE = name_map, codes, release_by_code
+    return name_map, codes, release_by_code
+
+
+def _resolve_set_value(value: str) -> Tuple[str, Optional[str]]:
+    """Resolve a `set:` flag's raw value into a set code, accepting either a
+    real set code (e.g. `khm`) or a full set name (e.g. `kaldheim`), using
+    `card_files/processed/card_printings.parquet` as the name/code index.
+
+    Returns `(code, notice)`: `code` is always populated (falls back to the
+    raw alnum-stripped-uppercase value if nothing resolves, so an unknown or
+    unindexed code still behaves exactly as before); `notice` is a human-
+    readable "Did you mean" message when a name substring matched more than
+    one set, else `None`.
+    """
+    raw_code = re.sub(r"[^A-Za-z0-9]", "", value).upper()
+    name_map, codes, release_by_code = _load_set_index()
+
+    if raw_code and raw_code in codes:
+        return raw_code, None
+
+    normalized = normalize_word_sep(value)
+    if normalized in name_map:
+        return name_map[normalized], None
+
+    candidates = sorted({(name, code) for name, code in name_map.items() if normalized and normalized in name})
+    if candidates:
+        # Stable-sort least-significant-key-first: most recent release wins
+        # ties, then shortest (closest-to-exact) name wins overall.
+        candidates.sort(key=lambda pair: release_by_code.get(pair[1], ""), reverse=True)
+        candidates.sort(key=lambda pair: len(pair[0]))
+        chosen_name, chosen_code = candidates[0]
+        if len(candidates) > 1:
+            alternates = ", ".join(f"{n.title()} ({c})" for n, c in candidates[1:6])
+            notice = (
+                f"'{value}' matched multiple sets -- using '{chosen_name.title()}' ({chosen_code}). "
+                f"Also matched: {alternates}. Use set:CODE to be specific."
+            )
+            return chosen_code, notice
+        return chosen_code, None
+
+    return raw_code, None
+
+
+_PRINTINGS_INDEX_DF: Optional["pd.DataFrame"] = None
+_PRINTINGS_INDEX_LOADED: bool = False
+
+
+def _load_printings_index_df() -> Optional["pd.DataFrame"]:
+    """Lazily load (and cache for the process lifetime)
+    `card_files/processed/card_printings.parquet`'s per-printing rows, used
+    to resolve `cn:`/`number:` clauses (collector number is per-printing,
+    not on the collapsed `all_cards.parquet` row). Returns `None` (never
+    raises) if the printings index hasn't been built yet."""
+    global _PRINTINGS_INDEX_DF, _PRINTINGS_INDEX_LOADED
+    if _PRINTINGS_INDEX_LOADED:
+        return _PRINTINGS_INDEX_DF
+    try:
+        path = os.path.join(card_files_processed_dir(), "card_printings.parquet")
+        _PRINTINGS_INDEX_DF = pd.read_parquet(
+            path, columns=["face_name", "set", "collector_number", "scryfall_id", "score", "released_at"]
+        )
+    except Exception:
+        _PRINTINGS_INDEX_DF = None
+    _PRINTINGS_INDEX_LOADED = True
+    return _PRINTINGS_INDEX_DF
+
+
+def _collector_number_numeric_prefix(value: str) -> Optional[float]:
+    m = re.match(r"^0*(\d+)", str(value).strip())
+    return float(m.group(1)) if m else None
+
+
+def _collector_number_normalized(value: str) -> str:
+    """Strip leading zeros while keeping any suffix, e.g. `007` -> `7`,
+    `007a` -> `7a`, so formatting differences between sets don't break an
+    exact-equality match."""
+    s = str(value).strip()
+    m = re.match(r"^0*(\d+)(.*)$", s)
+    return (m.group(1) + m.group(2)) if m else s
+
+
+def _collector_number_match_mask(subset: "pd.DataFrame", clauses: List[CollectorNumberClause]) -> "pd.Series":
+    """Boolean mask over a `card_printings.parquet` slice (`subset`) marking
+    rows satisfying every clause in `clauses` (ANDed)."""
+    actual_raw = subset["collector_number"].astype(str)
+    actual_norm = actual_raw.apply(_collector_number_normalized)
+    actual_num = actual_raw.apply(_collector_number_numeric_prefix)
+
+    mask = pd.Series(True, index=subset.index)
+    for clause in clauses:
+        if clause.op in (":", "=", "!="):
+            target = _collector_number_normalized(clause.value)
+            matched = (actual_norm != target) if clause.op == "!=" else (actual_norm == target)
+        else:
+            expected = _collector_number_numeric_prefix(clause.value)
+            matched = pd.Series(False, index=subset.index)
+            if expected is not None:
+                valid = actual_num.notna()
+                matched.loc[valid] = _compare_numeric(actual_num[valid], clause.op, expected)
+        if clause.negate:
+            matched = ~matched
+        mask &= matched
+    return mask
+
+
+def resolve_collector_number_printings(parsed: ParsedSearch) -> Dict[str, str]:
+    """For a query combining `set:` with `cn:`/`number:`, resolve each
+    matching card to one specific printing's `scryfall_id` -- an exact-
+    equality clause naturally narrows to a single printing; a range clause
+    (`cn>50`) narrows to the best-scored printing among the matched range
+    (highest `score`, tie-broken by most recent `released_at`, mirroring
+    `ImageCache.get_default_printing_id()`'s convention). Returns
+    `{card-name-lower: scryfall_id}`, empty if `cn:`/`number:` wasn't used,
+    has no `set:` to pair with, or the printings index is unavailable."""
+    if not parsed.collector_number_clauses or not parsed.set_include:
+        return {}
+    printings = _load_printings_index_df()
+    if printings is None or printings.empty:
+        return {}
+    subset = printings[printings["set"].astype(str).str.upper().isin(parsed.set_include)]
+    if subset.empty:
+        return {}
+    matched = subset.loc[_collector_number_match_mask(subset, parsed.collector_number_clauses)]
+    if matched.empty:
+        return {}
+    matched = matched.sort_values(["score", "released_at"], ascending=[False, False], na_position="last")
+    overlay: Dict[str, str] = {}
+    for _, row in matched.iterrows():
+        overlay.setdefault(str(row["face_name"]).lower(), str(row["scryfall_id"]))
+    return overlay
+
+
+def get_set_collector_number_sort_map(set_code: str) -> Dict[str, float]:
+    """Maps each card name (lowercase) with a printing in `set_code` to that
+    printing's collector number (numeric prefix), for ordering a single-set
+    search by collector number instead of alphabetically. When a card has
+    more than one printing in the set, uses the best-scored one (same
+    tie-break as `ImageCache.get_printing_id_for_set()`). Returns `{}` if
+    the printings index is unavailable."""
+    printings = _load_printings_index_df()
+    if printings is None or printings.empty:
+        return {}
+    subset = printings[printings["set"].astype(str).str.upper() == set_code]
+    if subset.empty:
+        return {}
+    subset = subset.sort_values(["score", "released_at"], ascending=[False, False], na_position="last")
+    sort_map: Dict[str, float] = {}
+    for _, row in subset.iterrows():
+        key = str(row["face_name"]).lower()
+        if key in sort_map:
+            continue
+        num = _collector_number_numeric_prefix(row["collector_number"])
+        sort_map[key] = num if num is not None else float("inf")
+    return sort_map
+
+
 def _apply_search_flag(parsed: ParsedSearch, canonical: str, op: str, value: str, *, negate: bool) -> None:
     if not value:
         return
@@ -492,9 +700,13 @@ def _apply_search_flag(parsed: ParsedSearch, canonical: str, op: str, value: str
     elif canonical == "is" and value.lower() == "new":
         parsed.is_new = False if negate else True
     elif canonical == "set":
-        code = re.sub(r"[^A-Za-z0-9]", "", value).upper()
+        code, notice = _resolve_set_value(value)
         if code:
             (parsed.set_exclude if negate else parsed.set_include).add(code)
+        if notice:
+            parsed.notices.append(notice)
+    elif canonical == "collector_number":
+        parsed.collector_number_clauses.append(CollectorNumberClause(op=op, value=value, negate=negate))
 
 
 def parse_search_query(q: str) -> ParsedSearch:
@@ -577,6 +789,20 @@ def apply_extra_clauses(df: "pd.DataFrame", parsed: ParsedSearch) -> "pd.DataFra
     if parsed.set_exclude and "printings" in df.columns:
         for code in parsed.set_exclude:
             df = df[~df["printings"].astype(str).str.contains(rf"\b{re.escape(code)}\b", na=False, regex=True)]
+    if parsed.collector_number_clauses:
+        if not parsed.set_include:
+            parsed.notices.append("cn:/number: requires a set: filter and was ignored.")
+        else:
+            printings = _load_printings_index_df()
+            if printings is not None and not printings.empty:
+                subset = printings[printings["set"].astype(str).str.upper().isin(parsed.set_include)]
+                if subset.empty:
+                    df = df.iloc[0:0]
+                else:
+                    matched_names = set(
+                        subset.loc[_collector_number_match_mask(subset, parsed.collector_number_clauses), "face_name"].astype(str)
+                    )
+                    df = df[df["name"].astype(str).isin(matched_names)]
     return df
 
 
@@ -598,5 +824,6 @@ def has_structured_flags(parsed: ParsedSearch) -> bool:
         or parsed.art_tags or parsed.art_tags_exclude
         or parsed.metadata_tags or parsed.metadata_tags_exclude or parsed.is_new is not None
         or parsed.set_include or parsed.set_exclude
+        or parsed.collector_number_clauses
         or parsed.explicit_name_flag
     )

--- a/code/web/static/styles.css
+++ b/code/web/static/styles.css
@@ -3239,6 +3239,10 @@ img.lqip.loaded {
 
 .card-browser-tile-image {
   position: relative;
+  /* Contains the on-image overlays' z-index (printing/foil row, badges) so
+	   they can't leak past page-level sticky elements (e.g. the search bar,
+	   which shares z-index:5) once a tile scrolls underneath them. */
+  z-index: 0;
   width: 100%;
   aspect-ratio: 488/680;
   overflow: hidden;
@@ -7231,6 +7235,37 @@ footer.site-footer {
   white-space: nowrap;
 }
 
+/* Set + collector number badge (M5) — lower-right, stacks above the
+   New/Reprint badges (see --stacked-1/--stacked-2) when also present. */
+
+.card-set-badge {
+  position: absolute;
+  bottom: 6px;
+  right: 6px;
+  background: rgba(0, 0, 0, .72);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 10px;
+  pointer-events: none;
+  z-index: 4;
+  white-space: nowrap;
+  letter-spacing: .02em;
+}
+
+/* One badge (New or Reprint) already occupies the corner below it */
+
+.card-set-badge--stacked-1 {
+  bottom: 30px;
+}
+
+/* Both New and Reprint occupy the corner below it */
+
+.card-set-badge--stacked-2 {
+  bottom: 54px;
+}
+
 /* "New" badge on card thumbnails — lower-right, teal pill */
 
 .card-new-badge {
@@ -7250,7 +7285,7 @@ footer.site-footer {
   letter-spacing: .03em;
 }
 
-/* When stacked above a New badge, shifts up by badge height (20px) + 4px gap */
+/* Lower-right; stacks above the New badge (--stacked) when both present */
 
 .card-reprint-badge {
   position: absolute;

--- a/code/web/static/tailwind.css
+++ b/code/web/static/tailwind.css
@@ -1045,6 +1045,10 @@ img.lqip.loaded { filter: blur(0); opacity: 1; }
 
 .card-browser-tile-image {
 	position: relative;
+	/* Contains the on-image overlays' z-index (printing/foil row, badges) so
+	   they can't leak past page-level sticky elements (e.g. the search bar,
+	   which shares z-index:5) once a tile scrolls underneath them. */
+	z-index: 0;
 	width: 100%;
 	aspect-ratio: 488/680;
 	overflow: hidden;
@@ -4703,6 +4707,32 @@ footer.site-footer {
   white-space: nowrap;
 }
 
+/* Set + collector number badge (M5) — lower-right, stacks above the
+   New/Reprint badges (see --stacked-1/--stacked-2) when also present. */
+.card-set-badge {
+  position: absolute;
+  bottom: 6px;
+  right: 6px;
+  background: rgba(0, 0, 0, .72);
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 10px;
+  pointer-events: none;
+  z-index: 4;
+  white-space: nowrap;
+  letter-spacing: .02em;
+}
+/* One badge (New or Reprint) already occupies the corner below it */
+.card-set-badge--stacked-1 {
+  bottom: 30px;
+}
+/* Both New and Reprint occupy the corner below it */
+.card-set-badge--stacked-2 {
+  bottom: 54px;
+}
+
 /* "New" badge on card thumbnails — lower-right, teal pill */
 .card-new-badge {
   position: absolute;
@@ -4721,7 +4751,7 @@ footer.site-footer {
   letter-spacing: .03em;
 }
 
-/* When stacked above a New badge, shifts up by badge height (20px) + 4px gap */
+/* Lower-right; stacks above the New badge (--stacked) when both present */
 .card-reprint-badge {
   position: absolute;
   bottom: 6px;

--- a/code/web/templates/base.html
+++ b/code/web/templates/base.html
@@ -34,7 +34,7 @@
     <script>
       window.__telemetryEndpoint = '/telemetry/events';
     </script>
-  <link rel="stylesheet" href="/static/styles.css?v=20260804-3" />
+  <link rel="stylesheet" href="/static/styles.css?v=20260821-5" />
   <link rel="stylesheet" href="/static/shared-components.css?v=20251021-1" />
   <style>
     /* Disable all transitions until page is loaded to prevent sidebar flash */

--- a/code/web/templates/browse/cards/_card_tile.html
+++ b/code/web/templates/browse/cards/_card_tile.html
@@ -2,6 +2,7 @@
 {% from 'partials/_macros.html' import printing_button, foil_toggle_button %}
 {% set sel_printing = (printings.get(card.name.lower(), '') if printings is defined else '') %}
 {% set is_foil = (foils.get(card.name.lower(), False) if foils is defined else False) %}
+{% set set_badge = (set_badges.get(card.name.lower()) if set_badges is defined else None) %}
 {% set card_idx = card.name|slugify %}
 <div class="card-browser-tile card-tile" 
      data-card-name="{{ card.name }}" 
@@ -32,14 +33,18 @@
     {# Price overlay #}
     <div class="card-price-overlay" id="price-overlay-{{ card_idx }}" data-price-for="{{ card.name }}" data-printing-id="{{ sel_printing }}" data-foil="{{ '1' if is_foil else '0' }}" aria-hidden="true"></div>
 
-    {# Reprint badge — lower-right; shifts up when New badge is also present #}
-    {% if card.isReprint %}
-    <div class="card-reprint-badge{% if show_new_badge and card.isNew %} card-reprint-badge--stacked{% endif %}" title="Reprinted Card" aria-hidden="true">Reprint</div>
-    {% endif %}
-
-    {# New card badge — lower-right #}
+    {# New/Reprint/set+cn badges stack in the lower-right, bottom to top #}
+    {% set ns = namespace(below=0) %}
     {% if show_new_badge and card.isNew %}
     <div class="card-new-badge" title="Recently Released" aria-hidden="true">New</div>
+    {% set ns.below = ns.below + 1 %}
+    {% endif %}
+    {% if card.isReprint %}
+    <div class="card-reprint-badge{% if ns.below == 1 %} card-reprint-badge--stacked{% endif %}" title="Reprinted Card" aria-hidden="true">Reprint</div>
+    {% set ns.below = ns.below + 1 %}
+    {% endif %}
+    {% if set_badge %}
+    <div class="card-set-badge{% if ns.below == 1 %} card-set-badge--stacked-1{% elif ns.below == 2 %} card-set-badge--stacked-2{% endif %}" title="{{ set_badge.set_name }}">{{ set_badge.set }} #{{ set_badge.collector_number }}</div>
     {% endif %}
 
     {# Owned indicator #}

--- a/code/web/templates/browse/cards/detail.html
+++ b/code/web/templates/browse/cards/detail.html
@@ -38,6 +38,9 @@
                 {% if show_new_badge and card.isNew %}
                 <div class="card-new-badge" title="Recently Released" aria-hidden="true">New</div>
                 {% endif %}
+                {% if set_badge is defined and set_badge %}
+                <div class="card-set-badge{% if show_new_badge and card.isNew %} card-set-badge--stacked-1{% endif %}">{{ set_badge.set_name }} #{{ set_badge.collector_number }}</div>
+                {% endif %}
                 <div id="price-overlay-{{ card_idx }}" class="card-price-overlay" data-price-for="{{ card.name }}" data-printing-id="{{ sel_printing }}" data-foil="{{ '1' if is_foil else '0' }}" style="display:none" aria-hidden="true"></div>
             </div>
             <div class="card-detail-printing-row">
@@ -145,6 +148,18 @@
             {% if back_face.text %}
             <div class="card-text" style="white-space: pre-line;">{{ back_face.text | replace('\\n', '\n') }}</div>
             {% endif %}
+            {% endif %}
+
+            {# Printed-in sets #}
+            {% if card_printed_sets and card_printed_sets|length > 0 %}
+            <details style="margin-top:1rem;">
+                <summary class="cd-section-heading" style="display:inline-block; cursor:pointer;">Printings ({{ card_printed_sets|length }})</summary>
+                <div class="card-tags">
+                    {% for s in card_printed_sets %}
+                    <a href="/cards?search={{ ('set:' ~ s.code)|urlencode }}" class="card-tag" title="{{ s.code }}">{{ s.name }}</a>
+                    {% endfor %}
+                </div>
+            </details>
             {% endif %}
 
             <!-- Theme Tags -->

--- a/code/web/templates/browse/cards/index.html
+++ b/code/web/templates/browse/cards/index.html
@@ -134,7 +134,7 @@
               aria-expanded="false"
               style="width: 100%;"
             />
-            <div id="search-autocomplete-dropdown" class="autocomplete-dropdown" role="listbox" aria-label="Card name suggestions"></div>
+            <div id="search-autocomplete-dropdown" class="autocomplete-dropdown" role="listbox" aria-label="Theme tag suggestions"></div>
           </div>
           {% if search %}
           <button type="button" onclick="document.getElementById('search-input').value=''; document.getElementById('card-search-form').submit();" class="btn" style="padding:.3rem .75rem;">Clear</button>
@@ -317,7 +317,7 @@ function applyFilter() {
   try {
     TAG_TOKEN_RE = new RegExp('(-)?\\b(tag|theme):(?:"([^"]*)"?|(\\S*))', 'dgi');
   } catch (e) {
-    TAG_TOKEN_RE = null; // `d` (hasIndices) flag unsupported -- degrade to name-only autocomplete
+    TAG_TOKEN_RE = null; // `d` (hasIndices) flag unsupported -- autocomplete stays disabled
   }
 
   // Finds the tag:/theme: flag (if any) whose value the caret is currently
@@ -362,38 +362,27 @@ function applyFilter() {
     const caret = searchInput.selectionStart ?? searchInput.value.length;
     tagToken = detectTagToken(searchInput.value, caret);
 
-    if (tagToken) {
-      const partial = tagToken.partial.trim();
-      if (partial.length < 2) {
-        autocompleteDropdown.innerHTML = '';
-        return;
-      }
-      // Reuse the theme catalog autocomplete for tag:/theme: flag values.
-      fetch(`/cards/theme-autocomplete?q=${encodeURIComponent(partial)}&limit=8`)
-        .then(response => response.text())
-        .then(html => {
-          autocompleteDropdown.innerHTML = html;
-        })
-        .catch(() => {
-          autocompleteDropdown.innerHTML = '';
-        });
-      return;
-    }
-
-    const query = searchInput.value.trim();
-    if (query.length < 2) {
+    if (!tagToken) {
+      // Scryfall-style flags (t:, o:, c:, set:, cn:, etc.) make up most of
+      // this search box's real usage, and a whole-query card-name fuzzy
+      // match against them just produces constant "No matching cards" noise
+      // -- so autocomplete is scoped to tag:/theme: flag values only.
       autocompleteDropdown.innerHTML = '';
       return;
     }
-    
-    // Call the autocomplete endpoint
-    fetch(`/cards/search-autocomplete?q=${encodeURIComponent(query)}`)
+
+    const partial = tagToken.partial.trim();
+    if (partial.length < 2) {
+      autocompleteDropdown.innerHTML = '';
+      return;
+    }
+    // Reuse the theme catalog autocomplete for tag:/theme: flag values.
+    fetch(`/cards/theme-autocomplete?q=${encodeURIComponent(partial)}&limit=8`)
       .then(response => response.text())
       .then(html => {
         autocompleteDropdown.innerHTML = html;
       })
-      .catch(err => {
-        console.error('Autocomplete error:', err);
+      .catch(() => {
         autocompleteDropdown.innerHTML = '';
       });
   };

--- a/code/web/templates/owned/index.html
+++ b/code/web/templates/owned/index.html
@@ -67,7 +67,7 @@
             aria-expanded="false"
             style="width:100%;"
           />
-          <div id="search-autocomplete-dropdown" class="autocomplete-dropdown" role="listbox" aria-label="Card name suggestions"></div>
+          <div id="search-autocomplete-dropdown" class="autocomplete-dropdown" role="listbox" aria-label="Theme tag suggestions"></div>
         </div>
         {% if search %}
         <button type="button" class="btn" onclick="document.getElementById('search-input').value=''; applyFilter();" style="padding:.3rem .75rem;">Clear</button>
@@ -197,7 +197,10 @@ document.addEventListener('keydown', function(e) {
   }
 });
 
-// Search name autocomplete
+// Tag/theme flag-value autocomplete (Scryfall-style flags make up most of
+// this search box's real usage, and a whole-query card-name fuzzy match
+// against them just produces constant "No matches" noise -- so autocomplete
+// is scoped to tag:/theme: flag values only, mirroring the card browser).
 (function() {
   var searchInput = document.getElementById('search-input');
   var dropdown    = document.getElementById('search-autocomplete-dropdown');
@@ -206,11 +209,52 @@ document.addEventListener('keydown', function(e) {
   var selectedIndex = -1;
   var debounceTimer = null;
   var lastEscapeTime = 0;
+  var tagToken = null;
+  var TAG_TOKEN_RE = null;
+  try {
+    TAG_TOKEN_RE = new RegExp('(-)?\\b(tag|theme):(?:"([^"]*)"?|(\\S*))', 'dgi');
+  } catch (e) {
+    TAG_TOKEN_RE = null; // `d` (hasIndices) flag unsupported -- autocomplete stays disabled
+  }
+
+  var detectTagToken = function(value, caret) {
+    if (!TAG_TOKEN_RE) return null;
+    TAG_TOKEN_RE.lastIndex = 0;
+    var m;
+    while ((m = TAG_TOKEN_RE.exec(value)) !== null) {
+      var idx = m.indices;
+      if (!idx) return null;
+      var start = idx[0][0], end = idx[0][1];
+      if (caret < start || caret > end) continue;
+      var quoted = m[3] !== undefined;
+      var span = quoted ? idx[3] : idx[4];
+      if (!span) continue;
+      var valueStart = span[0], valueEnd = span[1];
+      if (caret < valueStart) continue;
+      return { valueStart: valueStart, valueEnd: valueEnd, partial: value.slice(valueStart, Math.min(caret, valueEnd)) };
+    }
+    return null;
+  };
+
+  var applyTagSuggestion = function(value) {
+    if (!tagToken) return false;
+    var full = searchInput.value;
+    var quotedValue = '"' + value + '"';
+    searchInput.value = full.slice(0, tagToken.valueStart) + quotedValue + full.slice(tagToken.valueEnd);
+    var caret = tagToken.valueStart + quotedValue.length;
+    searchInput.setSelectionRange(caret, caret);
+    tagToken = null;
+    searchInput.focus();
+    return true;
+  };
 
   var fetchSuggestions = function() {
-    var q = searchInput.value.trim();
-    if (q.length < 2) { dropdown.innerHTML = ''; return; }
-    fetch('/owned/search-autocomplete?q=' + encodeURIComponent(q))
+    var caret = searchInput.selectionStart != null ? searchInput.selectionStart : searchInput.value.length;
+    tagToken = detectTagToken(searchInput.value, caret);
+    if (!tagToken) { dropdown.innerHTML = ''; return; }
+    var partial = tagToken.partial.trim();
+    if (partial.length < 2) { dropdown.innerHTML = ''; return; }
+    fetch('/cards/theme-autocomplete?q=' + encodeURIComponent(partial) + '&limit=8')
       .then(function(r){ return r.text(); })
       .then(function(html){ dropdown.innerHTML = html; })
       .catch(function(){ dropdown.innerHTML = ''; });
@@ -229,7 +273,7 @@ document.addEventListener('keydown', function(e) {
   var applyItem = function() {
     var items = getItems();
     var item = items[selectedIndex];
-    if (item && item.dataset.value) { searchInput.value = item.dataset.value; dropdown.innerHTML = ''; selectedIndex = -1; applyFilter(); }
+    if (item && item.dataset.value && applyTagSuggestion(item.dataset.value)) { dropdown.innerHTML = ''; selectedIndex = -1; }
   };
 
   new MutationObserver(function() {
@@ -240,7 +284,7 @@ document.addEventListener('keydown', function(e) {
 
   document.body.addEventListener('click', function(e) {
     var item = e.target.closest('.autocomplete-item');
-    if (item && item.dataset.value && dropdown.contains(item)) { e.preventDefault(); searchInput.value = item.dataset.value; dropdown.innerHTML = ''; applyFilter(); }
+    if (item && item.dataset.value && dropdown.contains(item)) { e.preventDefault(); applyTagSuggestion(item.dataset.value); dropdown.innerHTML = ''; }
   });
   document.addEventListener('click', function(e) { if (!e.target.closest('.autocomplete-container')) { dropdown.innerHTML = ''; selectedIndex = -1; } });
 


### PR DESCRIPTION
## Summary
Adds set/collector-number scoped search and a card detail "Printings" section, plus several search bug fixes discovered along the way.

## Added
- `set:`/`-set:` search flag (set name or 3-5 letter code) and `cn:`/`number:` for narrowing to a collector number/range within a set. Works in the card browser, owned library, manual deck builder search, and the public REST API.
- When a search is scoped to a specific printing, the card browser and card detail page show that printing's exact image instead of the card's default.
- Public API: `resolvedPrintingId` and `setBadge` fields on card search responses.
- Card tiles and card detail show a "Set Name #123" badge when scoped to exactly one set.
- Set-scoped results sort by collector number by default.
- Card detail pages show a collapsible "Printings" section listing every set a card has been printed in, with clickable chips that run a `set:` search.

## Changed
- Search autocomplete now only suggests `tag:`/`theme:` values (removed the old whole-query card-name autocomplete).

## Fixed
- Printing/foil toggle buttons on the card detail page bled over the sticky search bar (missing CSS stacking context).
- Plain-text search with no flags threw an error and cleared the search box.
- Plain-text card name search was punctuation-sensitive for exact matches (e.g. missing comma) and fell back to an overly broad fuzzy match instead.

## Testing
- `pytest -q code/tests/test_api_v1_cards.py code/tests/test_card_browser_single_result_redirect.py code/tests/test_collector_number_search.py code/tests/test_set_scoped_printing_display.py code/tests/test_set_search_flag.py code/tests/test_image_cache_default_mode_tiebreak.py` - all pass
- `pytest -q code/tests -k "search or owned or card_browser or printing"` - all pass
- Manual verification in browser (Docker) for badge stacking, z-index fix, printings chips, and search fixes

## Docs
- `CHANGELOG.md` and `RELEASE_NOTES_TEMPLATE.md` Unreleased sections updated
